### PR TITLE
Fix for intersection issue with legacy data #534

### DIFF
--- a/docs/KdTrees.md
+++ b/docs/KdTrees.md
@@ -48,7 +48,7 @@ KdTrees can be constructed:
 | OPC_JezeroTest1m_nokdtree | No kd Tree | Yes, no picking, prints `WARNING: [KdTrees] Kdtree not available, please build it manually using opc-tool or pro3d.` | Create KdTree using PRo3D or opc-tool ![alt text](images/createKdTree2.png) and reload the hierarchy. | - |
 | OPC_JezeroTest1m_v2021 | OPC created using per patch kd trees | Yes, picking available fast loading, low memory | None | - |
 | OPC_JezeroTest1m | OPC created without per patch kdTrees, but with master kd tree file (mostly late 2023) | Yes loads, but takes lot of memory since kdtree for whole opc is loaded. Also PRo3D reports this line in stdout `WARNING: Found master kdtree - loading incore. THIS NEEDS A LOT OF MEMORY. CONSIDER CREATING PER-PATCH KD TREES..` | Delete `*.aakd` and create new kd trees using PRo3D or opc-tool. Note that PRo3D never deletes the master kdtree file as whis would be cumbersome. Users confronted with this situation currently really need to delete unwanted huge kd tree files. | This beharior could be changed to [ignore the master kd tree](https://github.com/aardvark-platform/OpcViewer/blob/7fdf368e1e59a2c33c0cc7e5ca3e20b8c18a42a0/src/OPCViewer.Base/KdTrees.fs#L212) |
-
+| MSL Sol 1275 (from pro3d.space page) | both, single and master kdtrees, [in september 2025](https://github.com/pro3d-space/PRo3D/issues/534) i added another tweak (see issue & PR) | Yes | Regenerate KdTrees if feasible | [here](https://github.com/pro3d-space/PRo3D/issues/534) |
 
 ## File system behavior
 

--- a/src/PRo3D.Base/KdTrees.fs
+++ b/src/PRo3D.Base/KdTrees.fs
@@ -251,9 +251,11 @@ module KdTrees =
                 Log.line "[KdTrees] missing kd0 paths: %d/%d" missingKd0Paths.Length kd0Paths.Length
 
             match tryFixPatchFileIfNeeded masterKdPath with
-            | Some masterKdPath when not ignoreMasterKdTree && not forceRebuild ->
+            | Some masterKdPath when not ignoreMasterKdTree && not forceRebuild && missingKd0Paths.Length > 0  ->
                 Log.warn "Found master kdtree - loading incore. THIS NEEDS A LOT OF MEMORY. CONSIDER CREATING PER-PATCH KD TREES. see: https://github.com/pro3d-space/PRo3D/blob/9821c8882b024c7ed85c23ee76110c70e249e480/docs/KdTrees.md#create-kdtrees-for-an-opc-hierarchy"
                 let tree = loadKdtree masterKdPath
+                // triangle set will be 0 for kdtrees with purged object sets. In this case i think rebuilding is a better option
+                //let triangleSet = loadTriangles trafo objectSetPath
 
                 let kd =
                     { kdTree = tree
@@ -263,9 +265,6 @@ module KdTrees =
             | _ -> 
                 Log.line "Found master kdtree and patch trees"
                 Log.startTimed "building lazy kdtree cache"
-
-                let num = kd0Paths |> List.ofSeq |> List.length
-
 
                 let kdTrees =
                     kd0Paths
@@ -347,7 +346,7 @@ module KdTrees =
                                   boundingBox = info.GlobalBoundingBox //t.KdIntersectionTree.BoundingBox3d 
                                 }
 
-                            Report.Progress(float i / float num)
+                            Report.Progress(float i / float kd0Paths.Length)
 
                             (lazyTree.boundingBox, (LazyKdTree lazyTree)) |> Some
                         | _ -> 

--- a/src/PRo3D.Base/KdTrees.fs
+++ b/src/PRo3D.Base/KdTrees.fs
@@ -251,6 +251,7 @@ module KdTrees =
                 Log.line "[KdTrees] missing kd0 paths: %d/%d" missingKd0Paths.Length kd0Paths.Length
 
             match tryFixPatchFileIfNeeded masterKdPath with
+            // the idea here is to use the per-patch kdtrees if available (that's the missingKd0Paths check)
             | Some masterKdPath when not ignoreMasterKdTree && not forceRebuild && missingKd0Paths.Length > 0  ->
                 Log.warn "Found master kdtree - loading incore. THIS NEEDS A LOT OF MEMORY. CONSIDER CREATING PER-PATCH KD TREES. see: https://github.com/pro3d-space/PRo3D/blob/9821c8882b024c7ed85c23ee76110c70e249e480/docs/KdTrees.md#create-kdtrees-for-an-opc-hierarchy"
                 let tree = loadKdtree masterKdPath


### PR DESCRIPTION
This one basically disabled master kdtree loading whenever the "sub" kdtrees are available (https://github.com/pro3d-space/PRo3D/issues/534). This adds another fallback case to the rather complex legacy data handling, as noted [here](https://github.com/pro3d-space/PRo3D/commit/ede79821a0a905df1fb6609d80b21c4e4d9d0c27#diff-7d04f3be2bb9b12d2f892a878e7adf10d2e8cfba2e7de5f7c4397da0f4ba6d10L51) in the kdtree docs.