### PR TITLE
More robust process starting for snapshot exe

### DIFF
--- a/PRODUCT_RELEASE_NOTES.md
+++ b/PRODUCT_RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 5.1.0
+- native dependency fix for mac
+
 ## 5.1.0-prerelease3
 - native dependency fix for mac
 

--- a/aardium/package.json
+++ b/aardium/package.json
@@ -1,7 +1,7 @@
 {
   "name": "PRo3D",
   "productName": "PRo3D.Viewer",
-  "version": "5.1.0-prerelease3",
+  "version": "5.1.0",
   "description": "PRo3D, short for Planetary Robotics 3D Viewer, is an interactive 3D visualization tool to allow planetary scientists to work with high-resolution 3D reconstructions of the Martian surface.",
   "license": "AGPL",
   "copyright": "VRVis Zentrum für Virtual Reality und Visualisierung Forschungs-GmbH",

--- a/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarksApp.fs
+++ b/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarksApp.fs
@@ -386,7 +386,7 @@ module SequencedBookmarksApp =
         if System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform
                 (System.Runtime.InteropServices.OSPlatform.Windows) then
                     
-            let exeName = "PRo3D.Snapshots.exe"
+            let exeName = "./PRo3D.Snapshots.exe"
             match File.Exists exeName with
             | true -> 
                 let args = 

--- a/src/PRo3D.SimulatedViews/Snapshots/Snapshot-Utils.fs
+++ b/src/PRo3D.SimulatedViews/Snapshots/Snapshot-Utils.fs
@@ -17,27 +17,34 @@ open System.Threading.Tasks
 
 module SnapshotUtils =
         
-    let runProcess filename args startDir = 
+    let runProcess (processName : string) (args : string) (startDir : Option<string>) = 
+        let fullPath = Path.GetFullPath(processName)
+        Log.line "[Snapshots] Starting process %s with args %s in %A" fullPath args startDir
+        if File.Exists(fullPath) |> not then
+            failwithf "[Snapshots] Could not find process %s" fullPath
         let procStartInfo = 
             ProcessStartInfo(
                 RedirectStandardOutput = false,
                 RedirectStandardError = false,
                 UseShellExecute = true,
-                FileName = filename,
+                FileName = fullPath,
                 Arguments = args
             )
         match startDir with 
-        | Some d -> procStartInfo.WorkingDirectory <- d 
+        | Some d -> 
+            if Directory.Exists(d) |> not then
+                failwithf "[Snapshots] Could not find working directory %s" d
+            procStartInfo.WorkingDirectory <- d 
         | _ -> ()
         let p = new Process(StartInfo = procStartInfo)
         let started = 
             try
                 p.Start()
             with | ex ->
-                ex.Data.Add("filename", filename)
+                ex.Data.Add("filename", processName)
                 reraise()
         if not started then
-            failwithf "[Snapshots] Failed to start process %s" filename
+            failwithf "[Snapshots] Failed to start process %s" processName
         Log.line "[Snapshots] Started %s with pid %i" p.ProcessName p.Id
         p            
 


### PR DESCRIPTION
In the latest release 5.1 the newly introduced zip release could not start the snapshot exe properly. defe71ac69f188d5d82e6b52d9953fc86e7ed3c6 fixes this one.