### PR TITLE
4Point Ellipse implemented and tested

### DIFF
--- a/src/PRo3D.Base/Annotation/Annotation-Model.fs
+++ b/src/PRo3D.Base/Annotation/Annotation-Model.fs
@@ -23,14 +23,15 @@ type Projection =
 | Bookmark = 3
 
 type Geometry = 
-| Point     = 0 
-| Line      = 1 
-| Polyline  = 2 
-| Polygon   = 3 
-| DnS       = 4
-| TT        = 5
-| Ellipse   = 6
-| AxisEllipse = 7
+| Point         = 0 
+| Line          = 1 
+| Polyline      = 2 
+| Polygon       = 3 
+| DnS           = 4
+| TT            = 5
+| Ellipse       = 6
+| AxisEllipse   = 7
+| Axis4PEllipse = 8
 
 type Semantic = 
 | Horizon0 = 0 
@@ -396,7 +397,8 @@ with
 
 type EllipticAnnotationResult = 
     {
-        geographicalEllipse : Ellipse2d
+        geographicalEllipse      : Ellipse2d
+        geographicalEllipseAssym : Option<Ellipse2d>
     }
     with
         static let version = 0
@@ -406,9 +408,21 @@ type EllipticAnnotationResult =
                 let! center             = Json.read "center"     
                 let! major              = Json.read "major"
                 let! minor              = Json.read "minor"
+
+                let! center2            = Json.tryRead "centerAssim"
+                let! major2             = Json.tryRead "majorAssim"
+                let! minor2             = Json.tryRead "minorAssim"
+
+                let assymEllipse = 
+                    match center2, major2, minor2 with
+                    | Some c, Some ma, Some mi -> 
+                        Some(Ellipse2d(V2d.Parse(c), V2d.Parse(ma), V2d.Parse(mi)))
+                    | _ -> 
+                        None
             
                 return {
-                    geographicalEllipse = Ellipse2d(V2d.Parse(center), V2d.Parse(major), V2d.Parse(minor))
+                    geographicalEllipse      = Ellipse2d(V2d.Parse(center), V2d.Parse(major), V2d.Parse(minor))
+                    geographicalEllipseAssym = assymEllipse
                 }
             }
 
@@ -426,6 +440,13 @@ type EllipticAnnotationResult =
                 do! Json.write   "center"   (string x.geographicalEllipse.Center)
                 do! Json.write   "major"    (string x.geographicalEllipse.Axis0)
                 do! Json.write   "minor"    (string x.geographicalEllipse.Axis1)
+                
+                if x.geographicalEllipseAssym.IsSome then
+                    do! Json.write "centerAssim" (string x.geographicalEllipseAssym.Value.Center)
+                    do! Json.write "majorAssim"  (string x.geographicalEllipseAssym.Value.Axis0)
+                    do! Json.write "minorAssim"  (string x.geographicalEllipseAssym.Value.Axis1)
+    
+
             }
     
 

--- a/src/PRo3D.Base/Annotation/AnnotationHelpers.fs
+++ b/src/PRo3D.Base/Annotation/AnnotationHelpers.fs
@@ -169,7 +169,8 @@ module Calculations =
             match (annotation.geometry) with
             | Geometry.Polygon
             | Geometry.Ellipse
-            | Geometry.AxisEllipse ->
+            | Geometry.AxisEllipse
+            | Geometry.Axis4PEllipse ->
                 calculatePolygonArea annotation.points
             | _ -> Double.NaN
 

--- a/src/PRo3D.Base/Annotation/Exporters/GeoJSON.Export.fs
+++ b/src/PRo3D.Base/Annotation/Exporters/GeoJSON.Export.fs
@@ -89,6 +89,8 @@ module GeoJSONExport =
                     }
             
             GeoJsonGeometry.Polygon(coordinates, properties)
+        | Geometry.Axis4PEllipse -> 
+            failwith "4PEllipse export not implemented (maybe look for AxisEllipse)."
         | Geometry.Ellipse -> 
             failwith "ellipse export not implemented (maybe look for AxisEllipse)."
         | _ ->

--- a/src/PRo3D.Core/Drawing/Drawing-App.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-App.fs
@@ -93,13 +93,19 @@ module DrawingApp =
 
             let w = 
                 match w.geometry, sampleSurface with
-                | Geometry.AxisEllipse, Some sampleSurface -> 
+                | Geometry.AxisEllipse, Some sampleSurface
+                | Geometry.Axis4PEllipse, Some sampleSurface -> 
                     match EllipticAnnotations.constructAndSample planet (IndexList.toArray w.points) sampleSurface with
-                    | Some (ellipse, sampledPoints) -> 
+                    | Some (ellipses, sampledPoints) -> 
                         let points = IndexList.ofArray sampledPoints
-                        { w with points = points; ellipticResults = Some { geographicalEllipse = ellipse }}
+                        if ellipses.Length = 1 then 
+                            { w with points = points; ellipticResults = Some { geographicalEllipse = ellipses.[0]; geographicalEllipseAssym = None }}
+                        else if ellipses.Length = 2 then
+                            { w with points = points; ellipticResults = Some { geographicalEllipse = ellipses.[0]; geographicalEllipseAssym = Some(ellipses.[1]) }}
+                        else
+                            w
                     | _ -> 
-                        w
+                        w                
                 | _ -> 
                     w
 
@@ -132,7 +138,7 @@ module DrawingApp =
                 Log.line "working contains %d points" annotation.points.Count
                 
                 // do not generate segments for ellipses as they are sampled when the ellipse is fully constructed (after having the ellipse we know its outline).
-                let allowSegmentGeneration = w.geometry <> Geometry.Ellipse && w.geometry <> Geometry.AxisEllipse
+                let allowSegmentGeneration = w.geometry <> Geometry.Ellipse && w.geometry <> Geometry.AxisEllipse && w.geometry <> Geometry.Axis4PEllipse
 
                 //fetch current drawing segment (projected, polyline or polygon)
                 let result = 
@@ -167,7 +173,7 @@ module DrawingApp =
                                 { annotation with segments = IndexList.add newSegment annotation.segments }, None
                     | Projection.Linear ->
                         annotation, None
-                    | Projection.Sky when w.geometry = Geometry.AxisEllipse -> 
+                    | Projection.Sky when ((w.geometry = Geometry.AxisEllipse) || (w.geometry = Geometry.Axis4PEllipse)) ->
                         annotation, None
                     | _ -> failwith "case does not exist"            
                 result 
@@ -196,6 +202,8 @@ module DrawingApp =
         | Geometry.Ellipse, 3 -> 
             finishAndAppend up north planet (Some samplePoint) view model, None
         | Geometry.AxisEllipse, 3 -> 
+            finishAndAppend up north planet (Some samplePoint) view model, None
+        | Geometry.Axis4PEllipse, 4 ->  
             finishAndAppend up north planet (Some samplePoint) view model, None
         | _ -> 
             model, newSegment 
@@ -451,7 +459,9 @@ module DrawingApp =
             | SetGeometry mode, _, _ ->
                 let projection = 
                     match mode with
-                    | Geometry.AxisEllipse -> Projection.Sky
+                    | Geometry.AxisEllipse
+                    | Geometry.Axis4PEllipse -> 
+                        Projection.Sky
                     // every other tool uses linear as default. TODO: if switching back to default is an UX problem, 
                     // we need to store the user-set projection mode and reset it if needed.
                     | _ -> Projection.Linear

--- a/src/PRo3D.Core/Drawing/Drawing.UI.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.UI.fs
@@ -48,6 +48,7 @@ module UI =
             | Geometry.Polygon      -> "Pick an arbitrary number of points on the surface to create a closed region connecting them. The polygon depends on the projection mode."
             | Geometry.DnS          -> "Pick an arbitrary number of points on the surface to draw a polyline that is used to draw an intersecting plane using least squares computation. The vectors strike (red) and dip (green) represent the directions of least and highest inclination."
             | Geometry.AxisEllipse  -> "Pick two points to create an axis and a radius from there to draw an ellipse"
+            | Geometry.Axis4PEllipse -> "Pick two points to create an axis and two more for a radius in two directions away from this axis"
             | _                     -> ""
 
         let projectionTooltip (i: Projection) : string =

--- a/src/PRo3D.Core/Drawing/EllipseAnnotation.fs
+++ b/src/PRo3D.Core/Drawing/EllipseAnnotation.fs
@@ -4,6 +4,7 @@ open Aardvark.Base
 open PRo3D.Base
 
 module EllipticAnnotations =
+    let sampleNumber = 50    
 
     module Conv = 
         let geographicalToCartesian (v : CooTransformation.SphericalCoo) =
@@ -14,7 +15,19 @@ module EllipticAnnotations =
                 CooTransformation.SphericalCoo.latitude = v.Y
             }
             
-
+    let createProjectedEllipse (projectToSurface : V3d -> Option<V3d>) (planet : Planet) (geographical : CooTransformation.SphericalCoo) (points : V2d[]) =         
+        points 
+        |> Array.choose (fun latLon -> 
+            let position = 
+                // use altitude from first point (arbitrary decision, projection function will put points to surface again)
+               CooTransformation.getXYZFromLatLonAlt (Conv.cartesianToGeographical geographical latLon) planet
+            match projectToSurface position with
+            | None -> 
+                Log.warn "could not reproject ellipse point."
+                None
+            | Some p -> 
+                Some p
+        )
 
     let constructAndSample (planet : Planet) (points : array<V3d>) (projectToSurface : V3d -> Option<V3d>) = 
         let geographicalPoints = 
@@ -25,22 +38,22 @@ module EllipticAnnotations =
             )
 
         match geographicalPoints with
+        | [| (geographical, p0); (_,p1); (_,p2); (_,p3) |] ->
+            let ellipse1 = EllipseConstruction.constructEllipseOrtho2d p0 p1 p2
+            let ellipse2 = EllipseConstruction.constructEllipseOrtho2d p0 p1 p3
+            let sampledEllipse = EllipseConstruction.constructAssimmetricalEllipse2dPoints ellipse1 ellipse2 sampleNumber
+                        
+            let projectedEllipse = createProjectedEllipse projectToSurface planet geographical sampledEllipse
+
+            Some([ ellipse1; ellipse2 ], projectedEllipse)
+                
+
         | [| (geographical, p0); (_,p1); (_,p2) |] -> 
             let ellipse = EllipseConstruction.constructEllipseOrtho2d p0 p1 p2
-            let sampledEllipse = EllipseConstruction.computeEllipsePoints ellipse 50
-            let projectedEllipse = 
-                sampledEllipse 
-                |> Array.choose (fun latLon -> 
-                    let position = 
-                        // use altitude from first point (arbitrary decision, projection function will put points to surface again)
-                       CooTransformation.getXYZFromLatLonAlt (Conv.cartesianToGeographical geographical latLon) planet
-                    match projectToSurface position with
-                    | None -> 
-                        Log.warn "could not reproject ellipse point."
-                        None
-                    | Some p -> 
-                        Some p
-                )
-            Some (ellipse, projectedEllipse)
+            let sampledEllipse = EllipseConstruction.computeEllipsePoints ellipse sampleNumber
+            let projectedEllipse = createProjectedEllipse projectToSurface planet geographical sampledEllipse
+                
+            Some ([ ellipse ], projectedEllipse)
         | _ -> 
             None
+

--- a/src/PRo3D.Core/Drawing/EllipseConstruction.fs
+++ b/src/PRo3D.Core/Drawing/EllipseConstruction.fs
@@ -40,6 +40,30 @@ module EllipseConstruction =
 
         Ellipse2d(center, majorVec, minorVec)
 
+    /// Compute two ellipses for an assymmetrical one and return the calculated points
+    let constructAssimmetricalEllipse2dPoints
+        (ellipse1 : Ellipse2d)
+        (ellipse2 : Ellipse2d) 
+        (samples  : int)
+        : V2d[] =         
+        
+        Array.init (samples + 1) (fun i ->
+            let calcValue = 
+                if i < samples / 2 then 
+                    i
+                else 
+                    samples - i
+            
+            let t = 2.0 * Constant.Pi * (float calcValue / float samples)
+            let c = cos t
+            let s = sin t
+            
+            if i < (samples / 2) then
+                ellipse1.Center + ellipse1.Axis0 * c + ellipse1.Axis1 * s
+            else
+                ellipse2.Center + ellipse2.Axis0 * c + ellipse2.Axis1 * s
+        )
+
 
     /// Compute ellipse points by sampling the returned Ellipse2d.
     let computeEllipsePoints


### PR DESCRIPTION
Additional to the Axis-Elllipse the Axis-4-Point-Ellipse was added. It works similar like the AxisEllipse but creates an assymetrical Ellipse using the distance of the axis from the third clicked point from one side for the first half of the Ellipse and the distance from the axis to the fourth clicked point for the second half.