### PR TITLE
Make surfaces pickable

### DIFF
--- a/src/PRo3D.Base/Annotation/Annotation-Model.g.fs
+++ b/src/PRo3D.Base/Annotation/Annotation-Model.g.fs
@@ -1,4 +1,4 @@
-//d57beed9-6fc2-ac59-849a-0162bb994dd5
+//09b5f4ae-8083-6190-c48b-ea3d9b1f15df
 //f8c5a4a6-357e-5ffe-e148-5d422bdaddc4
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary

--- a/src/PRo3D.Core/PRo3D.Core.fsproj
+++ b/src/PRo3D.Core/PRo3D.Core.fsproj
@@ -51,11 +51,11 @@
     <Compile Include="UI.fs" />
     <Compile Include="ReferenceSystem.fs" />
     <Compile Include="TransformationApp.fs" />
+	<Compile Include="Traverse-Model.fs" />
+	<Compile Include="Traverse-Model.g.fs" />
     <Compile Include="Surface.fs" />
     <Compile Include="GroupsApp.fs" />
     <Compile Include="OrientationCube.fs" />
-    <Compile Include="Traverse-Model.fs" />
-    <Compile Include="Traverse-Model.g.fs" />
     <Compile Include="Surface\Translation.fs" />
     <Compile Include="Surface\Surface-Properties.fs" />
     <Compile Include="Surface\Surface.Files.fs" />

--- a/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.g.fs
+++ b/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.g.fs
@@ -1,5 +1,5 @@
 //9d9091e1-5600-7fb5-3f95-4778d9ab3384
-//6ed7bfe7-4183-c686-5877-7b21ad92d819
+//996e3726-0fe3-63bf-99bd-237b44f77475
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -13,10 +13,10 @@ open PRo3D.Core.SequencedBookmarks
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
     let mutable _path_ = FSharp.Data.Adaptive.cval(value.path)
+    let mutable _name_ = FSharp.Data.Adaptive.cval(value.name)
     let mutable _key_ = FSharp.Data.Adaptive.cval(value.key)
     let mutable _cameraView_ = FSharp.Data.Adaptive.cval(value.cameraView)
     let mutable _filename_ = FSharp.Data.Adaptive.cval(value.filename)
-    let mutable _name_ = FSharp.Data.Adaptive.cval(value.name)
     let _bookmark_ = PRo3D.Core.AdaptiveBookmark(value.bookmark)
     let _metadata_ = FSharp.Data.Adaptive.cval(value.metadata)
     let _frustumParameters_ = FSharp.Data.Adaptive.cval(value.frustumParameters)
@@ -42,10 +42,10 @@ type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
             __value <- value
             __adaptive.MarkOutdated()
             _path_.Value <- value.path
+            _name_.Value <- value.name
             _key_.Value <- value.key
             _cameraView_.Value <- value.cameraView
             _filename_.Value <- value.filename
-            _name_.Value <- value.name
             _bookmark_.Update(value.bookmark)
             _metadata_.Value <- value.metadata
             _frustumParameters_.Value <- value.frustumParameters
@@ -57,10 +57,10 @@ type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
             _observationInfo_.Update(value.observationInfo)
     member __.Current = __adaptive
     member __.path = _path_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
+    member __.name = _name_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
     member __.key = _key_ :> FSharp.Data.Adaptive.aval<System.Guid>
     member __.cameraView = _cameraView_ :> FSharp.Data.Adaptive.aval<Aardvark.Rendering.CameraView>
     member __.filename = _filename_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
-    member __.name = _name_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
     member __.version = __value.version
     member __.bookmark = _bookmark_
     member __.metadata = _metadata_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.option<Microsoft.FSharp.Core.string>>

--- a/src/PRo3D.Core/Surface.fs
+++ b/src/PRo3D.Core/Surface.fs
@@ -15,6 +15,8 @@ open PRo3D.Extensions
 open PRo3D.Core.Surface
 open PRo3DCompability
 open OpcViewer.Base.KdTrees
+open System.IO
+
 
 module SurfaceTransformations = 
     //let computeSolRotation (sol : Sol) (referenceSystem : ReferenceSystem) : Trafo3d =
@@ -188,6 +190,7 @@ module SurfaceIntersection =
 
     let doKdTreeIntersection 
         (m             : SurfaceModel)
+        (traverseM  : option<TraverseModel>)
         (refSys        : ReferenceSystem)
         (observedSystem : SurfaceId -> Option<SpiceReferenceSystem>)
         (observerSystem : Option<ObserverSystem>)
@@ -209,9 +212,67 @@ module SurfaceIntersection =
                 | _ -> None
             )
             
+        let getRimfaxImageModeFromPath (filePath : string) : option<string> =
+            let folders = Path.GetDirectoryName(filePath).Split(Path.DirectorySeparatorChar)
+            if folders.Length >= 1 then
+                Some folders.[folders.Length - 1]
+            else
+                None
+
+        let rimfaxSurfaces =
+            match traverseM with
+            | Some tm -> 
+                tm.rimfaxTraverses
+                |> HashMap.map (fun guid traverse ->
+                    traverse.sols
+                    |> List.map (fun sol -> 
+                        match sol.solMetrics with
+                        | Some (RimfaxM solMetrics) ->
+                            match solMetrics.rimfaxSurfaceProperties with
+                            | Some rimfaxSurfaceProperties ->
+                                let test = 
+                                    rimfaxSurfaceProperties.rimfaxSurfaces.sgSurfaces
+                                    |> HashMap.filter(fun guid surf -> 
+                                        ((getRimfaxImageModeFromPath surf.sgImportPath) = Some rimfaxSurfaceProperties.rimfaxImageMode && rimfaxSurfaceProperties.isVisibleS)
+                                    )
+                                let testL = test |> HashMap.toList |> List.map snd
+                                testL
+                            | None -> List.Empty
+                        | _ -> List.Empty
+                    )
+                    |> List.collect id
+                )
+                |> HashMap.toList
+                |> List.map snd
+                |> List.collect id
+            | None -> List.Empty
+
+        let rimfaxSurfacesFlat = 
+            match traverseM with
+            | Some tm -> 
+                tm.rimfaxTraverses
+                |> HashMap.map (fun guid traverse ->
+                    traverse.sols
+                    |> List.map (fun sol -> 
+                        match sol.solMetrics with
+                        | Some (RimfaxM solMetrics) ->
+                            match solMetrics.rimfaxSurfaceProperties with
+                            | Some rimfaxSurfaceProperties ->
+                                rimfaxSurfaceProperties.rimfaxSurfaces.surfaces.flat
+                            | None -> HashMap.Empty
+                        | _ -> HashMap.Empty
+                    )
+                )
+                |> HashMap.toSeq
+                |> Seq.collect (fun (_, innerList) ->
+                    innerList |> Seq.collect HashMap.toSeq
+                )
+                |> HashMap.ofSeq
+            | None -> HashMap.Empty
+
         let hits = 
-            activeSgSurfaces 
-            |> List.map (fun d -> d.picking, (m.surfaces.flat |> HashMap.find d.surface) |> Leaf.toSurface)                      
+            List.append activeSgSurfaces rimfaxSurfaces
+            |> List.map (fun d -> d.picking, ([m.surfaces.flat; rimfaxSurfacesFlat] |> Seq.collect HashMap.toSeq |> HashMap.ofSeq |> HashMap.find d.surface) |> Leaf.toSurface)                      
             |> List.choose (fun (p ,surf) ->
                 match p with
                 | Picking.NoPicking -> None

--- a/src/PRo3D.Core/Traverse-Model.fs
+++ b/src/PRo3D.Core/Traverse-Model.fs
@@ -41,7 +41,6 @@ type TraverseAction =
     | RemoveAllTraverses
     | LoadRimfaxSurface of rootDirectory : list<string> * traverseID : Guid 
     | SetRimfaxImageMode of mode : string * traverseID : Guid * solNumber : int
-    | PickRimfaxSurface of surfaceId : Guid * traverseId : Guid * solNumber : int
 
 module InitTraverseParams =
 
@@ -146,7 +145,7 @@ type RimfaxSurfaceMetrics =
         version: int
         rimfaxImageModeOptions: List<string>
         rimfaxImageMode: string
-        rimfaxSurfaces : HashMap<Guid, SgSurface>
+        rimfaxSurfaces : SurfaceModel
         isVisibleS: bool
     }
 
@@ -165,7 +164,7 @@ module RimfaxSurfaceMetrics =
                     version = current
                     rimfaxImageModeOptions = rimfaxImageModeOptions
                     rimfaxImageMode = rimfaxImageMode
-                    rimfaxSurfaces = HashMap.Empty
+                    rimfaxSurfaces = SurfaceModel.initial
                     isVisibleS = isVisibleS
                 }
         }

--- a/src/PRo3D.Core/Traverse-Model.g.fs
+++ b/src/PRo3D.Core/Traverse-Model.g.fs
@@ -1,5 +1,5 @@
-//89d392ae-36bd-a5b1-961d-8aa759096e16
-//a72739d7-0c27-cc36-4689-a3f0d8b9df9c
+//ce267fa6-1d94-91e0-79d6-0a5c2a754302
+//96621443-ecb8-8020-1938-4ddc136b0022
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -53,11 +53,7 @@ type AdaptiveRimfaxSurfaceMetrics(value : RimfaxSurfaceMetrics) =
     let _version_ = FSharp.Data.Adaptive.cval(value.version)
     let _rimfaxImageModeOptions_ = FSharp.Data.Adaptive.cval(value.rimfaxImageModeOptions)
     let _rimfaxImageMode_ = FSharp.Data.Adaptive.cval(value.rimfaxImageMode)
-    let _rimfaxSurfaces_ =
-        let inline __arg2 (m : PRo3D.Core.Surface.AdaptiveSgSurface) (v : PRo3D.Core.Surface.SgSurface) =
-            m.Update(v)
-            m
-        FSharp.Data.Traceable.ChangeableModelMap(value.rimfaxSurfaces, (fun (v : PRo3D.Core.Surface.SgSurface) -> PRo3D.Core.Surface.AdaptiveSgSurface(v)), __arg2, (fun (m : PRo3D.Core.Surface.AdaptiveSgSurface) -> m))
+    let _rimfaxSurfaces_ = AdaptiveSurfaceModel(value.rimfaxSurfaces)
     let _isVisibleS_ = FSharp.Data.Adaptive.cval(value.isVisibleS)
     let mutable __value = value
     let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
@@ -76,7 +72,7 @@ type AdaptiveRimfaxSurfaceMetrics(value : RimfaxSurfaceMetrics) =
     member __.version = _version_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.int>
     member __.rimfaxImageModeOptions = _rimfaxImageModeOptions_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Collections.List<Microsoft.FSharp.Core.string>>
     member __.rimfaxImageMode = _rimfaxImageMode_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
-    member __.rimfaxSurfaces = _rimfaxSurfaces_ :> FSharp.Data.Adaptive.amap<System.Guid, PRo3D.Core.Surface.AdaptiveSgSurface>
+    member __.rimfaxSurfaces = _rimfaxSurfaces_
     member __.isVisibleS = _isVisibleS_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
 [<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 module RimfaxSurfaceMetricsLenses = 
@@ -84,7 +80,7 @@ module RimfaxSurfaceMetricsLenses =
         static member version_ = ((fun (self : RimfaxSurfaceMetrics) -> self.version), (fun (value : Microsoft.FSharp.Core.int) (self : RimfaxSurfaceMetrics) -> { self with version = value }))
         static member rimfaxImageModeOptions_ = ((fun (self : RimfaxSurfaceMetrics) -> self.rimfaxImageModeOptions), (fun (value : Microsoft.FSharp.Collections.List<Microsoft.FSharp.Core.string>) (self : RimfaxSurfaceMetrics) -> { self with rimfaxImageModeOptions = value }))
         static member rimfaxImageMode_ = ((fun (self : RimfaxSurfaceMetrics) -> self.rimfaxImageMode), (fun (value : Microsoft.FSharp.Core.string) (self : RimfaxSurfaceMetrics) -> { self with rimfaxImageMode = value }))
-        static member rimfaxSurfaces_ = ((fun (self : RimfaxSurfaceMetrics) -> self.rimfaxSurfaces), (fun (value : FSharp.Data.Adaptive.HashMap<System.Guid, PRo3D.Core.Surface.SgSurface>) (self : RimfaxSurfaceMetrics) -> { self with rimfaxSurfaces = value }))
+        static member rimfaxSurfaces_ = ((fun (self : RimfaxSurfaceMetrics) -> self.rimfaxSurfaces), (fun (value : SurfaceModel) (self : RimfaxSurfaceMetrics) -> { self with rimfaxSurfaces = value }))
         static member isVisibleS_ = ((fun (self : RimfaxSurfaceMetrics) -> self.isVisibleS), (fun (value : Microsoft.FSharp.Core.bool) (self : RimfaxSurfaceMetrics) -> { self with isVisibleS = value }))
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 type AdaptiveRimfaxMetrics(value : RimfaxMetrics) =

--- a/src/PRo3D.SimulatedViews/Comparison/AreaComparison.fs
+++ b/src/PRo3D.SimulatedViews/Comparison/AreaComparison.fs
@@ -278,6 +278,7 @@ module AreaComparison =
 
             let sendRay ray surfFilter =
                 let hitInfo, c = SurfaceIntersection.doKdTreeIntersection surfaceModel 
+                                                                           None
                                                                            referenceSystem 
                                                                            (constF None)
                                                                            None

--- a/src/PRo3D.SimulatedViews/Comparison/ComparisonUtils.fs
+++ b/src/PRo3D.SimulatedViews/Comparison/ComparisonUtils.fs
@@ -89,6 +89,7 @@ module ComparisonUtils =
     
         let ray = new Ray3d (fromLocation, direction)
         let intersected = SurfaceIntersection.doKdTreeIntersection surfaceModel 
+                                                                   None
                                                                    refSystem 
                                                                    (constF None)
                                                                    None

--- a/src/PRo3D.SimulatedViews/Snapshots/HaltonPlacement.fs
+++ b/src/PRo3D.SimulatedViews/Snapshots/HaltonPlacement.fs
@@ -86,14 +86,14 @@ module HaltonPlacement =
                     let dir = (p-camLocation).Normalized
                     FastRay3d(camLocation, dir)
                 
-                match SurfaceIntersection.doKdTreeIntersection surfaces refSystem observedSystem observerSystem ray surfaceFilter cache true with
+                match SurfaceIntersection.doKdTreeIntersection surfaces None refSystem observedSystem observerSystem ray surfaceFilter cache true with
                 | Some (t,surf), c ->                             
                     cache <- c; ray.Ray.GetPointOnRay t.RayHit.T |> Some
                 | None, c ->
                     cache <- c; None
                                   
             let result = 
-                match SurfaceIntersection.doKdTreeIntersection surfaces refSystem observedSystem observerSystem (FastRay3d(ray)) surfaceFilter cache true with
+                match SurfaceIntersection.doKdTreeIntersection surfaces None refSystem observedSystem observerSystem (FastRay3d(ray)) surfaceFilter cache true with
                 | Some (t,surf), c ->                         
                     cache <- c
                     let hit = ray.GetPointOnRay(t.RayHit.T)

--- a/src/PRo3D.SimulatedViews/Viewplanner/ViewPlanApp.fs
+++ b/src/PRo3D.SimulatedViews/Viewplanner/ViewPlanApp.fs
@@ -149,7 +149,7 @@ module ViewPlanApp =
         let ray = FastRay3d(p, dir)  
                  
         match SurfaceIntersection.doKdTreeIntersection 
-            surfaceModel refSystem (constF None) None ray (fun id l surf -> l.active) cache true with
+            surfaceModel None refSystem (constF None) None ray (fun id l surf -> l.active) cache true with
         | Some (t,_), _ -> ray.Ray.GetPointOnRay(t.RayHit.T) |> Some
         | None, _ -> None
 

--- a/src/PRo3D.Viewer/ProvenanceApp.fs
+++ b/src/PRo3D.Viewer/ProvenanceApp.fs
@@ -76,7 +76,7 @@ module ProvenanceApp =
             Ignore
         | ViewerMessage (ViewerAction.LoadScene s) ->   
             TrackMessage (PMessage.LoadScene s)
-        | ViewerMessage (ViewerAction.DrawingMessage _) | ViewerMessage (ViewerAction.PickSurface(_,_,_)) -> 
+        | ViewerMessage (ViewerAction.DrawingMessage _) | ViewerMessage (ViewerAction.PickSurface(_,_,_,_)) -> 
             match oldModel.drawing.working, newModel.drawing.working with
             | Some o, None -> PMessage.FinishAnnotation o.key |> TrackMessage
             | _ -> Ignore

--- a/src/PRo3D.Viewer/TraverseApp.fs
+++ b/src/PRo3D.Viewer/TraverseApp.fs
@@ -77,6 +77,8 @@ module TraversePropertiesApp =
                     Html.row "Color:"      [ColorPicker.view m.color |> UI.map SetTraverseColor ]
                     Html.row "Linewidth:"  [Numeric.view' [NumericInputType.InputBox] m.tLineWidth |> UI.map SetLineWidth ]  
                     Html.row "Height offset:"  [Numeric.view' [NumericInputType.InputBox] m.heightOffset |> UI.map SetHeightOffset ]  
+                    Html.row "Priority:"    [Numeric.view' [NumericInputType.InputBox] m.priority |> UI.map SetPriority ] 
+                    Html.row "Use Priority"  [GuiEx.iconCheckBox m.priorityEnabled  TogglePriorityRenderingEnabled]
                 ]
             )
 

--- a/src/PRo3D.Viewer/TraverseApp.fs
+++ b/src/PRo3D.Viewer/TraverseApp.fs
@@ -19,6 +19,10 @@ open PRo3D.Core.Surface
 open OpcViewer.Base
 open Viewer
 
+open Aether
+open Aether.Operators
+
+
 module TraversePropertiesApp =
 
     let update (model : Traverse) (action : TraversePropertiesAction) : Traverse = 
@@ -343,17 +347,43 @@ module TraverseApp =
                     else
                         false
 
+                let importRimfaxObjsForSol (solNumber : int)=
+
+                    let surfaces =       
+                        IndexList.ofList
+                            (
+                            Directory.GetFiles(path, "*.obj", SearchOption.AllDirectories) 
+                            |> Array.filter (fun filePath -> (pathBelongsToSol filePath solNumber))
+                            |> Array.toList
+                            |> List.map(fun file -> SurfaceUtils.mk SurfaceType.Mesh MeshLoaderType.Wavefront Int32.MaxValue file)
+                            )
+      
+                    let leafs = surfaces |> IndexList.map Leaf.Surfaces
+
+                    let sgSurfaces = SurfaceUtils.ObjectFiles.CustomWavefrontLoader.createSgObjectsWavefront surfaces
+
+                    let surfaceModel = SurfaceModel.initial
+
+                    let surfaceModel = 
+                        { surfaceModel with 
+                            surfaces = 
+                                surfaceModel.surfaces
+                                |> GroupsApp.addLeaves surfaceModel.surfaces.activeGroup.path leafs;
+                            sgSurfaces = sgSurfaces
+                        }
+                    
+                    surfaceModel 
+                      |> SurfaceModel.triggerSgGrouping 
+
                 let sols = 
                         model.rimfaxTraverses[traverseID].sols 
                         |> List.map (fun sol ->
                             match sol.solMetrics with
                             | Some (SolMetrics.RimfaxM solMetrics) ->
-                                let objSurfaces =                   
-                                    Directory.GetFiles(path, "*.obj", SearchOption.AllDirectories) 
-                                    |> Array.filter (fun filePath -> (pathBelongsToSol filePath sol.solNumber))
-                                    |> Array.toList
-                                    |> List.map(fun file -> SurfaceUtils.mk SurfaceType.Mesh MeshLoaderType.Wavefront Int32.MaxValue file) 
-                                let rimfaxSurfaces = SurfaceUtils.ObjectFiles.CustomWavefrontLoader.createSgObjectsWavefront (IndexList.ofList objSurfaces)
+                                let rimfaxSurfaceModel = 
+                                    match solMetrics.rimfaxSurfaceProperties with
+                                    | Some _
+                                    | None -> importRimfaxObjsForSol sol.solNumber
                                 let rimfaxImageModeOptions =
                                     Directory.GetFiles(path, "*.obj", SearchOption.AllDirectories) 
                                     |> Array.filter (fun filePath -> (pathBelongsToSol filePath sol.solNumber))
@@ -369,7 +399,7 @@ module TraverseApp =
                                     | _ ->
                                         Some { 
                                             version = RimfaxSurfaceMetrics.current
-                                            rimfaxSurfaces = rimfaxSurfaces
+                                            rimfaxSurfaces = rimfaxSurfaceModel
                                             rimfaxImageModeOptions = (rimfaxImageModeOptions)
                                             rimfaxImageMode = rimfaxImageModeOptions.[0]
                                             isVisibleS = true
@@ -410,15 +440,6 @@ module TraverseApp =
                 model.rimfaxTraverses 
                     |> HashMap.alter traverseID (function None -> None | Some t -> Some { t with sols = sols})
             { model with
-                rimfaxTraverses = rimfaxTraverses'
-            }
-        | PickRimfaxSurface (surfaceID, traverseID, solNumber) ->
-            let rimfaxTraverses' =  
-                model.rimfaxTraverses 
-                    |> HashMap.alter traverseID (function None -> None | Some t -> Some { t with selectedSol = Some solNumber})
-            { model with
-                selectedRimfaxSurface = Some surfaceID
-                selectedTraverse = Some traverseID
                 rimfaxTraverses = rimfaxTraverses'
             }
         |_-> model
@@ -723,105 +744,6 @@ module TraverseApp =
             |> Sg.noEvents
             |> Sg.onOff traverse.showDots
 
-
-        let viewRimfaxSurfaces
-            (refSystem : AdaptiveReferenceSystem)
-            (traverse : AdaptiveTraverse) 
-            (traverseModel  : AdaptiveTraverseModel)
-            : ISg<TraverseAction> =
-
-            let pickable
-                (bb : aval<Box3d>)
-                (trafo : aval<Trafo3d>) = 
-                (bb, trafo)
-                ||>  AVal.map2( fun (a:Box3d) (b:Trafo3d) -> 
-                    { shape = PickShape.Box (a); trafo = Trafo3d.Identity }
-                ) 
-
-            let createSg 
-                (surface : SgSurface)
-                (traverseId : Guid)
-                (solNumber : int)=
-                let isSelected = 
-                    adaptive {
-                        let! (selected : Option<Guid>) =  traverseModel.selectedRimfaxSurface
-                        match selected with
-                        | Some id -> return (id = surface.surface)
-                        | None -> return false
-                    }
-
-                let colorTransformationExpr =
-                    <@ fun (c : V4d) ->
-                        let tolerance = 0.05
-                        let isWhite =
-                            abs (c.X - 1.0) < tolerance &&
-                            abs (c.Y - 1.0) < tolerance &&
-                            abs (c.Z - 1.0) < tolerance
-
-                        if isWhite then
-                            V4d(1.0, 1.0, 0.0, c.W)
-                        else
-                            c
-                    @>
-
-                let sg = 
-                    surface.sceneGraph 
-                    |> Sg.pickable' (pickable (adaptive { return surface.globalBB }) (adaptive { return surface.trafo.previewTrafo }))
-                    |> Sg.noEvents
-                    |> Sg.withEvents [
-                        SceneEventKind.Click, (
-                            fun (sceneHit : SceneHit) -> 
-                                true, Seq.ofList [PickRimfaxSurface (surface.surface, traverseId, solNumber)])
-                        ] 
-                    |> Sg.uniform "selected" isSelected
-                    |> Sg.uniform "selectionColor" (AVal.constant (C4b (200uy,200uy,255uy,255uy)))
-
-                let sg = 
-                    isSelected
-                    |> AVal.map (fun s ->
-                        sg
-                        |> Sg.shader {
-                            do! DefaultSurfaces.stableTrafo
-                            do! DefaultSurfaces.diffuseTexture 
-                            if s then do! DefaultSurfaces.transformColor colorTransformationExpr
-                        }
-                    )
-                    |> Sg.dynamic
-
-                sg
-
-            let getRimfaxImageModeFromPath (filePath : string) : option<string> =
-                let folders = Path.GetDirectoryName(filePath).Split(Path.DirectorySeparatorChar)
-                if folders.Length >= 1 then
-                    Some folders.[folders.Length - 1]
-                else
-                    None
-
-            let surfaceSg =
-                traverse.sols
-                |> AVal.map (List.map (fun sol -> 
-                    match sol.solMetrics with
-                    | Some (RimfaxM solMetrics) ->
-                        match solMetrics.rimfaxSurfaceProperties with
-                        | Some rimfaxSurfaceProperties ->
-                            rimfaxSurfaceProperties.rimfaxSurfaces
-                            |> HashMap.filter(fun guid surf -> 
-                                ((getRimfaxImageModeFromPath surf.sgImportPath) = Some rimfaxSurfaceProperties.rimfaxImageMode && rimfaxSurfaceProperties.isVisibleS)
-                            )
-                            |> HashMap.map (fun x value -> createSg value traverse.guid sol.solNumber)
-                        | None -> HashMap.Empty
-                    | _ -> HashMap.Empty
-                ) 
-                >> HashMap.unionMany
-                )
-
-            surfaceSg
-            |> AMap.ofAVal
-            |> ASet.ofAMap
-            |> ASet.map (snd)
-            |> Sg.set
-            |> Sg.noEvents 
-
             
         let viewTraverseFast  
             (view : aval<CameraView>)
@@ -831,7 +753,6 @@ module TraverseApp =
             Sg.ofList [
                 viewTraverseCoordinateFrames view refSystem traverse
                 viewTraverseDots refSystem view traverse
-                viewRimfaxSurfaces refSystem traverse traverseModel |> Sg.onOff traverse.showRimfaxSurfaces
             ]
             |> Sg.onOff traverse.isVisibleT
 

--- a/src/PRo3D.Viewer/Viewer-Model.fs
+++ b/src/PRo3D.Viewer/Viewer-Model.fs
@@ -82,6 +82,12 @@ type PickPivot =
 //type ScaleToolAction = 
 //    | PlaneExtrudeAction of PlaneExtrude.App.Action
 
+type RimfaxScenePickInfo = {
+    surface : Guid
+    traverseId : Guid
+    solNumber : int
+}
+
 type ViewerAction =                
 | DrawingMessage                  of DrawingAction
 | AnnotationGroupsMessageViewer   of GroupsAppAction
@@ -117,7 +123,7 @@ type ViewerAction =
 | DeleteLast
 | AddSg                           of ISg
 
-| PickSurface                     of SceneHit * string * bool
+| PickSurface                     of hit : SceneHit * name : string * pickingEnabled : bool * rimfaxSurfaceInfo : option<RimfaxScenePickInfo>
 | PreviewPickSurface              of SceneHit * string * bool
 | PreviewPickSurfaceFinished      of SceneHit * string * Option<Aardvark.Geometry.ObjectRayHit * V3d>
 

--- a/src/PRo3D.Viewer/Viewer/Picking.fs
+++ b/src/PRo3D.Viewer/Viewer/Picking.fs
@@ -47,7 +47,7 @@ module Picking =
                       
 
         let hit = 
-            match SurfaceIntersection.doKdTreeIntersection (Optic.get _surfacesModel m) m.scene.referenceSystem observedSystem observerSystem r surfaceFilter cache Config.diagnosticTimings with
+            match SurfaceIntersection.doKdTreeIntersection (Optic.get _surfacesModel m) (Some m.scene.traverses) m.scene.referenceSystem observedSystem observerSystem r surfaceFilter cache Config.diagnosticTimings with
             | Some (hit,surf), c ->                         
                 cache <- c
                 let t = hit.RayHit.T

--- a/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
@@ -534,7 +534,7 @@ module ViewerUtils =
                                 let name  = surf.name |> AVal.force        
                                 let surfacePicking = surfacePicking |> AVal.force
                                 //Log.warn "[SurfacePicking] spawning picksurface action %s" name //TODO remove spanwning altogether when interaction is not "PickSurface"
-                                true, Seq.ofList [PickSurface (sceneHit, name, surfacePicking)]
+                                true, Seq.ofList [PickSurface (sceneHit, name, surfacePicking, None)]
                          )
                        ]  
                     // handle surface visibility
@@ -1018,7 +1018,6 @@ module ViewerUtils =
                 group
                 |> AMap.map(fun guid surface ->   
 
-
                     let observationSystem = Gis.GisApp.getSpiceReferenceSystemAdaptive m.scene.gisApp guid
                     let s =
                         viewSingleSurfaceSg 
@@ -1054,7 +1053,6 @@ module ViewerUtils =
                             |> Sg.uniform "LoDColor" (AVal.constant C4b.Gray)
                             |> Sg.uniform "LodVisEnabled" m.scene.config.lodColoring
 
-
                     surfaceSg
                 )
 
@@ -1085,8 +1083,120 @@ module ViewerUtils =
             Sg.ofList [surfaces; depthComposed]
         )  
 
+    let createRimfaxSurfaces
+        (traverse : AdaptiveTraverse) 
+        (traverseModel  : AdaptiveTraverseModel)
+        : ISg<ViewerAction> =
+
+        let pickable
+            (bb : aval<Box3d>)
+            (trafo : aval<Trafo3d>) = 
+            (bb, trafo)
+            ||>  AVal.map2( fun (a:Box3d) (b:Trafo3d) -> 
+                { shape = PickShape.Box (a); trafo = Trafo3d.Identity }
+            ) 
+
+        let createSg 
+            (sgSurface : SgSurface)
+            (surfaceModel : SurfaceModel)
+            (traverseId : Guid)
+            (solNumber : int) =
+
+            let surface = HashMap.tryFind sgSurface.surface surfaceModel.surfaces.flat
+            let name = 
+                match surface with
+                | Some (Surfaces s) -> s.name
+                | _ -> ""
+
+            let isSelected = 
+                adaptive {
+                    let! (selected : Option<Guid>) =  traverseModel.selectedRimfaxSurface
+                    match selected with
+                    | Some id -> return (id = sgSurface.surface)
+                    | None -> return false
+                }
+
+            let colorTransformationExpr =
+                <@ fun (c : V4d) ->
+                    let tolerance = 0.05
+                    let isWhite =
+                        abs (c.X - 1.0) < tolerance &&
+                        abs (c.Y - 1.0) < tolerance &&
+                        abs (c.Z - 1.0) < tolerance
+
+                    if isWhite then
+                        V4d(1.0, 1.0, 0.0, c.W)
+                    else
+                        c
+                @>
+
+            let sg = 
+                sgSurface.sceneGraph 
+                |> Sg.pickable' (pickable (adaptive { return sgSurface.globalBB }) (adaptive { return sgSurface.trafo.previewTrafo }))
+                |> Sg.noEvents
+                |> Sg.withEvents [
+                    yield SceneEventKind.Click, (
+                        fun sceneHit -> 
+                            //Log.warn "[SurfacePicking] spawning picksurface action %s" name //TODO remove spanwning altogether when interaction is not "PickSurface"
+                            true, Seq.ofList [PickSurface (sceneHit, name, true, Some ({
+                                surface = sgSurface.surface
+                                traverseId = traverseId
+                                solNumber = solNumber
+                            }))]
+                        )
+                    ] 
+                |> Sg.uniform "selected" isSelected
+                |> Sg.uniform "selectionColor" (AVal.constant (C4b (200uy,200uy,255uy,255uy)))
+
+            let sg = 
+                isSelected
+                |> AVal.map (fun s ->
+                    sg
+                    |> Sg.shader {
+                        do! DefaultSurfaces.stableTrafo
+                        do! DefaultSurfaces.diffuseTexture 
+                        if s then do! DefaultSurfaces.transformColor colorTransformationExpr
+                    }
+                )
+                |> Sg.dynamic
+
+            sg
+
+        let getRimfaxImageModeFromPath (filePath : string) : option<string> =
+            let folders = Path.GetDirectoryName(filePath).Split(Path.DirectorySeparatorChar)
+            if folders.Length >= 1 then
+                Some folders.[folders.Length - 1]
+            else
+                None
+
+        let surfaceSg =
+            traverse.sols
+            |> AVal.map (List.map (fun sol -> 
+                match sol.solMetrics with
+                | Some (RimfaxM solMetrics) ->
+                    match solMetrics.rimfaxSurfaceProperties with
+                    | Some rimfaxSurfaceProperties ->
+                        rimfaxSurfaceProperties.rimfaxSurfaces.sgSurfaces
+                        |> HashMap.filter(fun guid surf -> 
+                            ((getRimfaxImageModeFromPath surf.sgImportPath) = Some rimfaxSurfaceProperties.rimfaxImageMode && rimfaxSurfaceProperties.isVisibleS)
+                        )
+                        |> HashMap.map (fun x value -> createSg value rimfaxSurfaceProperties.rimfaxSurfaces traverse.guid sol.solNumber)
+                    | None -> HashMap.Empty
+                | _ -> HashMap.Empty
+            ) 
+            >> HashMap.unionMany
+            )
+
+        surfaceSg
+        |> AMap.ofAVal
+        |> ASet.ofAMap
+        |> ASet.map (snd)
+        |> Sg.set
+        |> Sg.noEvents 
+
     let renderCommands 
         (sgGrouped      :alist<amap<Guid,AdaptiveSgSurface>>) 
+        (traverseModel  : AdaptiveTraverseModel)
         (overlayed      : ISg<ViewerAction>)
         (depthTested    : ISg<ViewerAction>)
         (view           : aval<CameraView>)
@@ -1095,10 +1205,19 @@ module ViewerUtils =
         (runtime        : IRuntime) 
         (m              : AdaptiveModel)  =
 
-        let grouped = createGroupedSgs sgGrouped view allowFootprint allowDepthview m
+        let traverseSg = 
+            traverseModel.rimfaxTraverses
+            |> AMap.map(fun id traverse ->
+                Sg.ofList [
+                    createRimfaxSurfaces traverse traverseModel |> Sg.onOff traverse.showRimfaxSurfaces
+                ]
+            )
+            |> AMap.toASet 
+            |> ASet.map snd 
+            |> Sg.set
 
-
-
+        let grouped = createGroupedSgs sgGrouped view allowFootprint allowDepthview m |> AList.append (AList.single traverseSg)
+        
         alist {                    
             for sg in grouped do  
                 yield Aardvark.UI.RenderCommand.Clear(None,Some (AVal.constant 1.0), None)

--- a/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
@@ -971,118 +971,6 @@ module ViewerUtils =
             }                              
         sgs
 
-    let createGroupedSgs 
-        (sgGrouped      :alist<amap<Guid,AdaptiveSgSurface>>) 
-        (view           : aval<CameraView>)
-        (allowFootprint : bool) 
-        (allowDepthview : bool) 
-        (m              : AdaptiveModel)  =
-
-        let usehighlighting = ~~true //m.scene.config.useSurfaceHighlighting
-        let filterTexture = ~~true
-        //let mutable useTC = true
-        //avoids kdtree intersections for certain interactions
-        let surfacePicking = 
-            m.interaction 
-            |> AVal.map(fun x -> 
-                match x with
-                | Interactions.PickAnnotation | Interactions.PickLog -> false
-                | _ -> true
-            )
-
-        let vpVisible = isViewPlanVisible m
-        let selected = m.scene.surfacesModel.surfaces.singleSelectLeaf
-        let refSystem = m.scene.referenceSystem
-        //let view = m.navigation.camera.view
-
-
-        let cursorWorldPos = 
-            (m.surfaceIntersection, m.scene.config.previewIntersectionWorldSize.value, m.scene.config.showPreviewIntersection) 
-            |||> AVal.map3 (fun hitPoint previewSize showIt -> 
-                match hitPoint with
-                | Some hitPoint when showIt -> Some (hitPoint.hitPoint, previewSize)
-                | _ -> None
-            )
-
-        let validSurfacePriority v = 
-            // only relevant in secondary pass with overlayed geometry to render "missing" traverses
-            AVal.constant true
-
-        let observerSystem = Gis.GisApp.getObserverSystemAdaptive m.scene.gisApp
-                               
-
-        sgGrouped 
-        |> AList.map (fun group -> 
-                
-            let surfaces = 
-                group
-                |> AMap.map(fun guid surface ->   
-
-                    let observationSystem = Gis.GisApp.getSpiceReferenceSystemAdaptive m.scene.gisApp guid
-                    let s =
-                        viewSingleSurfaceSg 
-                            surface 
-                            m.scene.surfacesModel.surfaces.flat
-                            m.frustum 
-                            selected 
-                            surfacePicking
-                            m.scene.config.showPreviewIntersection
-                            surface.globalBB
-                            refSystem 
-                            observationSystem
-                            observerSystem
-                            m.footPrint 
-                            vpVisible
-                            usehighlighting filterTexture
-                            allowFootprint
-                            allowDepthview
-                            cursorWorldPos
-                            view
-
-
-                    let surfaceSg = 
-                        match surface.isObj with
-                        | true -> 
-                            s 
-                            |> Sg.effect [
-                                objEffect
-                            ] 
-                        | false -> 
-                            s
-                            |> Sg.effect [surfaceEffect] 
-                            |> Sg.uniform "LoDColor" (AVal.constant C4b.Gray)
-                            |> Sg.uniform "LodVisEnabled" m.scene.config.lodColoring
-
-                    surfaceSg
-                )
-
-            let depthComposed = 
-                group.Content
-                |> AVal.map (fun surfaces -> 
-                    match surfaces |> HashMap.toValueSeq |> Seq.tryHead with
-                    | None -> Sg.empty
-                    | Some someSurf -> 
-                        let priority = 
-                            AMap.tryFind someSurf.surface m.scene.surfacesModel.surfaces.flat
-                            |> AVal.bind (function
-                                | (Some (AdaptiveSurfaces s)) -> 
-                                    s.priority.value |> AVal.map (int >> Some) 
-                                | _ -> AVal.constant None
-                            )
-                        TraverseApp.Sg.view view m.scene.config.nearPlane.value (m.frustum |> AVal.map Frustum.horizontalFieldOfViewInDegrees) refSystem m.scene.traverses priority validSurfacePriority
-                        |> Sg.map ViewerAction.TraverseMessage
-                )
-                |> Sg.dynamic
-
-            let surfaces = 
-                surfaces
-                |> AMap.toASet 
-                |> ASet.map snd           
-                |> Sg.set
-                    
-            Sg.ofList [surfaces; depthComposed]
-        )  
-
     let createRimfaxSurfaces
         (traverse : AdaptiveTraverse) 
         (traverseModel  : AdaptiveTraverseModel)
@@ -1194,6 +1082,151 @@ module ViewerUtils =
         |> Sg.set
         |> Sg.noEvents 
 
+    let createGroupedSgs 
+        (sgGrouped      :alist<amap<Guid,AdaptiveSgSurface>>) 
+        (view           : aval<CameraView>)
+        (allowFootprint : bool) 
+        (allowDepthview : bool) 
+        (m              : AdaptiveModel)  =
+
+        let usehighlighting = ~~true //m.scene.config.useSurfaceHighlighting
+        let filterTexture = ~~true
+        //let mutable useTC = true
+        //avoids kdtree intersections for certain interactions
+        let surfacePicking = 
+            m.interaction 
+            |> AVal.map(fun x -> 
+                match x with
+                | Interactions.PickAnnotation | Interactions.PickLog -> false
+                | _ -> true
+            )
+
+        let vpVisible = isViewPlanVisible m
+        let selected = m.scene.surfacesModel.surfaces.singleSelectLeaf
+        let refSystem = m.scene.referenceSystem
+        //let view = m.navigation.camera.view
+
+
+        let cursorWorldPos = 
+            (m.surfaceIntersection, m.scene.config.previewIntersectionWorldSize.value, m.scene.config.showPreviewIntersection) 
+            |||> AVal.map3 (fun hitPoint previewSize showIt -> 
+                match hitPoint with
+                | Some hitPoint when showIt -> Some (hitPoint.hitPoint, previewSize)
+                | _ -> None
+            )
+
+        let validSurfacePriority v = 
+            // only relevant in secondary pass with overlayed geometry to render "missing" traverses
+            AVal.constant true
+
+        let observerSystem = Gis.GisApp.getObserverSystemAdaptive m.scene.gisApp
+                               
+
+        sgGrouped 
+        |> AList.map (fun group -> 
+                
+            let surfaces = 
+                group
+                |> AMap.map(fun guid surface ->   
+
+                    let observationSystem = Gis.GisApp.getSpiceReferenceSystemAdaptive m.scene.gisApp guid
+                    let s =
+                        viewSingleSurfaceSg 
+                            surface 
+                            m.scene.surfacesModel.surfaces.flat
+                            m.frustum 
+                            selected 
+                            surfacePicking
+                            m.scene.config.showPreviewIntersection
+                            surface.globalBB
+                            refSystem 
+                            observationSystem
+                            observerSystem
+                            m.footPrint 
+                            vpVisible
+                            usehighlighting filterTexture
+                            allowFootprint
+                            allowDepthview
+                            cursorWorldPos
+                            view
+
+
+                    let surfaceSg = 
+                        match surface.isObj with
+                        | true -> 
+                            s 
+                            |> Sg.effect [
+                                objEffect
+                            ] 
+                        | false -> 
+                            s
+                            |> Sg.effect [surfaceEffect] 
+                            |> Sg.uniform "LoDColor" (AVal.constant C4b.Gray)
+                            |> Sg.uniform "LodVisEnabled" m.scene.config.lodColoring
+
+                    surfaceSg
+                )
+
+            let depthComposed = 
+                group.Content
+                |> AVal.map (fun surfaces -> 
+                    match surfaces |> HashMap.toValueSeq |> Seq.tryHead with
+                    | None -> Sg.empty
+                    | Some someSurf -> 
+                        let priority = 
+                            AMap.tryFind someSurf.surface m.scene.surfacesModel.surfaces.flat
+                            |> AVal.bind (function
+                                | (Some (AdaptiveSurfaces s)) -> 
+                                    s.priority.value |> AVal.map (int >> Some) 
+                                | _ -> AVal.constant None
+                            )
+                        (*
+                        m.scene.traverses.rimfaxTraverses 
+                        |> AMap.filterA (fun k v -> 
+                            (priority, v.priority.value, v.priorityEnabled) 
+                            |||> AVal.bind3 (fun filterPriority p enabled -> 
+                                match filterPriority, enabled with
+                                | Some priority, true-> // we have it priorities enabled and we are in a surface pass. check if this is the right prio
+                                    AVal.constant (int p = priority)
+                                | Some _, false -> // we are in a surface pass here, but priorty rendering is not enabled => skip
+                                        AVal.constant false
+                                | None, true -> 
+                                    // we are in overlay pass here.
+                                    // but it has priority enabled -> it was already rendered with the surfaces?
+                                    let surfaceExists = validSurfacePriority (int p)
+                                    surfaceExists |> AVal.map not // if it does not exist, render it now.
+                                | None, false ->  // we are in overlay pass here and prios are not enabled => we need to render it now.
+                                    AVal.constant true
+                            )
+                        )
+                        |> AMap.map(fun id traverse ->
+                            Sg.ofList [createRimfaxSurfaces traverse m.scene.traverses |> Sg.onOff traverse.showRimfaxSurfaces]
+                        )
+                        |> AMap.toASet 
+                        |> ASet.map snd 
+                        |> Sg.set
+                        *)
+                        m.scene.traverses.rimfaxTraverses
+                        |> AMap.map(fun id traverse ->
+                            Sg.ofList [
+                                createRimfaxSurfaces traverse m.scene.traverses |> Sg.onOff traverse.showRimfaxSurfaces
+                            ]
+                        )
+                        |> AMap.toASet 
+                        |> ASet.map snd 
+                        |> Sg.set
+                )
+                |> Sg.dynamic
+
+            let surfaces = 
+                surfaces
+                |> AMap.toASet 
+                |> ASet.map snd           
+                |> Sg.set
+                    
+            Sg.ofList [surfaces; depthComposed]
+        )  
+
     let renderCommands 
         (sgGrouped      :alist<amap<Guid,AdaptiveSgSurface>>) 
         (traverseModel  : AdaptiveTraverseModel)
@@ -1216,7 +1249,7 @@ module ViewerUtils =
             |> ASet.map snd 
             |> Sg.set
 
-        let grouped = createGroupedSgs sgGrouped view allowFootprint allowDepthview m |> AList.append (AList.single traverseSg)
+        let grouped = createGroupedSgs sgGrouped view allowFootprint allowDepthview m
         
         alist {                    
             for sg in grouped do  

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -1090,8 +1090,19 @@ module ViewerApp =
             | _ -> 
                 Log.line "no hit"
                 m
-            
-        | ViewerAction.PickSurface (p,name,true), _ ,true ->
+        // If we are not currently in annotation mode and a ray hits a rimfaxSurface, we want to select it 
+        | ViewerAction.PickSurface (_,_,_, Some rimfaxSurfaceInfo), _ ,false -> 
+            let rimfaxTraverses' =  
+                m.scene.traverses.rimfaxTraverses 
+                    |> HashMap.alter rimfaxSurfaceInfo.traverseId (function None -> None | Some t -> Some { t with selectedSol = Some rimfaxSurfaceInfo.solNumber})
+            let traverses' = {
+                m.scene.traverses with
+                    selectedRimfaxSurface = Some rimfaxSurfaceInfo.surface
+                    selectedTraverse = Some rimfaxSurfaceInfo.traverseId
+                    rimfaxTraverses = rimfaxTraverses'
+                }
+            { m with scene = { m.scene with traverses = traverses' }}
+        | ViewerAction.PickSurface (p,name,true, _), _ ,true ->
             let fray = p.globalRay.Ray
             let r = fray.Ray
             if m.drawing.geometry = Geometry.Ellipse then
@@ -1161,14 +1172,14 @@ module ViewerApp =
                                     FastRay3d(p + (up * 5000.0), -up)  
                                 | _ -> Log.error "projection started without proj mode"; FastRay3d()
                    
-                            match SurfaceIntersection.doKdTreeIntersection (Optic.get _surfacesModel m) m.scene.referenceSystem observedSystem observerSystem ray surfaceFilter cache Config.diagnosticTimings with
+                            match SurfaceIntersection.doKdTreeIntersection (Optic.get _surfacesModel m) (Some m.scene.traverses) m.scene.referenceSystem observedSystem observerSystem ray surfaceFilter cache Config.diagnosticTimings with
                             | Some (t,surf), c ->                             
                                 cache <- c; ray.Ray.GetPointOnRay t.RayHit.T |> Some
                             | None, c ->
                                 cache <- c; None
                                    
                         let result = 
-                            match SurfaceIntersection.doKdTreeIntersection (Optic.get _surfacesModel m) m.scene.referenceSystem observedSystem observerSystem fray surfaceFilter cache Config.diagnosticTimings with
+                            match SurfaceIntersection.doKdTreeIntersection (Optic.get _surfacesModel m) (Some m.scene.traverses) m.scene.referenceSystem observedSystem observerSystem fray surfaceFilter cache Config.diagnosticTimings with
                             | Some (t,surf), c ->                         
                                 cache <- c
                                 let hit = r.GetPointOnRay(t.RayHit.T)
@@ -2232,7 +2243,7 @@ module ViewerApp =
         let depthTested = getDepthTested frustum m.scene.viewPlans.instrumentCam observer id runtime m
 
         // instrument view control
-        let icmds = ViewerUtils.renderCommands m.scene.surfacesModel.sgGrouped ioverlayed depthTested m.scene.viewPlans.instrumentCam false true runtime m // m.scene.surfacesModel.sgGrouped overlayed discs m
+        let icmds = ViewerUtils.renderCommands m.scene.surfacesModel.sgGrouped m.scene.traverses ioverlayed depthTested m.scene.viewPlans.instrumentCam false true runtime m // m.scene.surfacesModel.sgGrouped overlayed discs m
                         |> AList.map ViewerUtils.mapRenderCommand
         
         //onBoot "attachResize('__ID__')" (
@@ -2306,6 +2317,7 @@ module ViewerApp =
         let cmds  = 
             ViewerUtils.renderCommands 
                 m.scene.surfacesModel.sgGrouped 
+                m.scene.traverses
                 overlayed depthTested 
                 m.navigation.camera.view 
                 true 

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -2158,6 +2158,7 @@ module ViewerApp =
                 m.scene.referenceSystem
             |> Sg.map ScaleBarsMessage
        
+
         let traverses =
         
             let isThereASurfaceWithPriority (p : int) = 


### PR DESCRIPTION
Make Rimfax surfaces pickable

For testing : i will provide the RIMFAX obj data in person
After scene-hand-over:

try to annotate RIMFAX surfaces using a modifier key / to select a RIMFAX surface without a modifier key