### PR TITLE
Releases/6.0.0 cross section rimfax updates

### DIFF
--- a/src/PRo3D.Base/Utilities.fs
+++ b/src/PRo3D.Base/Utilities.fs
@@ -80,17 +80,20 @@ module OPCFilter =
             member x.WhiteDiscardEnabled   : bool    = x?WhiteDiscardEnabled
             member x.WhiteDiscardThreshold : float32 = x?WhiteDiscardThreshold
 
-        let improvedDiffuseTextureAndColorDiscardWhite (v : Effects.Vertex) =
+
+        // Discards the large white areas above and beneath the RIMFAX data
+        let discardWhiteBands (v : Effects.Vertex) =
             fragment {
                 if uniform.HasDiffuseColorTexture then
                     let texColor = diffuseSampler.Sample(v.tc,-1.0f)
                     if uniform.WhiteDiscardEnabled then
                         let t = uniform.WhiteDiscardThreshold
-                        if texColor.X >= t && texColor.Y >= t && texColor.Z >= t then
+                        if texColor.Y >= t then
                             discard()
                     return texColor
                 else
                     return v.c
+
             }
 
         let improvedDiffuseTexture (v : Effects.Vertex) =

--- a/src/PRo3D.Core/CrossSection-Model.g.fs
+++ b/src/PRo3D.Core/CrossSection-Model.g.fs
@@ -1,5 +1,5 @@
-//51a55be8-10c1-3aa7-69b8-c42015a5b17e
-//42366d6f-52d2-43a5-d199-5eaa084b5e1a
+//87a1cef8-79f2-3f16-7976-60aca6884698
+//050dad67-7b63-a06a-a78d-ee8e9d56e0e2
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -52,7 +52,7 @@ type AdaptiveCrossSectionModel(value : CrossSectionModel) =
     member __.curtainBaseColor = _curtainBaseColor_
     member __.clippingEnabled = _clippingEnabled_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
 [<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
-module CrossSectionModelLenses =
+module CrossSectionModelLenses = 
     type CrossSectionModel with
         static member crossSection_ = ((fun (self : CrossSectionModel) -> self.crossSection), (fun (value : Microsoft.FSharp.Core.Option<CrossSection>) (self : CrossSectionModel) -> { self with crossSection = value }))
         static member curtainEnabled_ = ((fun (self : CrossSectionModel) -> self.curtainEnabled), (fun (value : Microsoft.FSharp.Core.bool) (self : CrossSectionModel) -> { self with curtainEnabled = value }))

--- a/src/PRo3D.Core/CrossSectionApp.fs
+++ b/src/PRo3D.Core/CrossSectionApp.fs
@@ -49,6 +49,8 @@ module CrossSectionApp =
             { model with clippingEnabled = not model.clippingEnabled }
 
     let viewCurtainSettings (model : AdaptiveCrossSectionModel) =
+        let jsImportTextureDialog =
+            "top.aardvark.dialog.showOpenDialog({title:'Select Cross Section Texture', filters: [{ name: 'Images (*.png, *.jpg, *.jpeg, *.tif, *.tiff)', extensions: ['png','jpg','jpeg','tif','tiff']},], properties: ['openFile']}).then(result => {aardvark.processEvent('__ID__', 'onchoose', result.filePaths);});"
         require GuiEx.semui (
             Html.table [
                 Html.row "Cross Section:" [
@@ -68,12 +70,16 @@ module CrossSectionApp =
                 Html.row "Curtain:"           [ GuiEx.iconCheckBox model.curtainEnabled ToggleCurtainEnabled ]
                 Html.row "Absolute Altitude:" [ GuiEx.iconCheckBox model.curtainAbsoluteMode ToggleCurtainAbsoluteMode ]
                 Html.row "Texture Path:"      [
-                    Incremental.input (AttributeMap.ofAMap (amap {
-                        let! path = model.curtainTexturePath
-                        yield attribute "type" "text"
-                        yield attribute "value" (path |> Option.defaultValue "")
-                        yield onChange SetCurtainTexturePath
-                    })) ]
+                    button [
+                        clazz "ui icon button"
+                        Dialogs.onChooseFiles (fun paths ->
+                            match paths with
+                            | p :: _ -> SetCurtainTexturePath p
+                            | [] -> SetCurtainTexturePath "")
+                        clientEvent "onclick" jsImportTextureDialog
+                    ] [ i [clazz "folder open icon"] [] ] |> UI.wrapToolTip DataPosition.Bottom "Choose image"
+                    br []
+                    Incremental.text (model.curtainTexturePath |> AVal.map (Option.defaultValue "none")) ]
                 Html.row "Depth / Alt (m):" [
                     Incremental.div AttributeMap.empty (
                         alist {

--- a/src/PRo3D.Core/CrossSectionApp.fs
+++ b/src/PRo3D.Core/CrossSectionApp.fs
@@ -57,7 +57,8 @@ module CrossSectionApp =
                             let! cs = model.crossSection
                             match cs with
                             | Some _ ->
-                                yield button [clazz "ui red button"; onClick (fun _ -> ClearCrossSection)] [text "Remove"]
+                                yield button [clazz "ui icon button"; onClick (fun _ -> ClearCrossSection)] [
+                                        i [clazz "remove icon red"] [] ] |> UI.wrapToolTip DataPosition.Bottom "Remove"
                             | None ->
                                 yield text "none (create one from an annotation)"
                         }

--- a/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.g.fs
+++ b/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.g.fs
@@ -1,5 +1,5 @@
 //e4eebad7-e3e9-5330-2090-496649038ecb
-//6b5b11fb-9c2b-6bde-6ca1-76fc5fcc5f1d
+//c64b1c07-8814-5a1f-40ba-73d4c4013561
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -12,10 +12,10 @@ open Adaptify
 open PRo3D.Core.SequencedBookmarks
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
-    let mutable _key_ = FSharp.Data.Adaptive.cval(value.key)
-    let mutable _cameraView_ = FSharp.Data.Adaptive.cval(value.cameraView)
-    let mutable _name_ = FSharp.Data.Adaptive.cval(value.name)
     let mutable _path_ = FSharp.Data.Adaptive.cval(value.path)
+    let mutable _key_ = FSharp.Data.Adaptive.cval(value.key)
+    let mutable _name_ = FSharp.Data.Adaptive.cval(value.name)
+    let mutable _cameraView_ = FSharp.Data.Adaptive.cval(value.cameraView)
     let mutable _filename_ = FSharp.Data.Adaptive.cval(value.filename)
     let _bookmark_ = PRo3D.Core.AdaptiveBookmark(value.bookmark)
     let _metadata_ = FSharp.Data.Adaptive.cval(value.metadata)
@@ -41,10 +41,10 @@ type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
         if Microsoft.FSharp.Core.Operators.not((FSharp.Data.Adaptive.ShallowEqualityComparer<SequencedBookmarkModel>.ShallowEquals(value, __value))) then
             __value <- value
             __adaptive.MarkOutdated()
-            _key_.Value <- value.key
-            _cameraView_.Value <- value.cameraView
-            _name_.Value <- value.name
             _path_.Value <- value.path
+            _key_.Value <- value.key
+            _name_.Value <- value.name
+            _cameraView_.Value <- value.cameraView
             _filename_.Value <- value.filename
             _bookmark_.Update(value.bookmark)
             _metadata_.Value <- value.metadata
@@ -56,10 +56,10 @@ type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
             _duration_.Update(value.duration)
             _observationInfo_.Update(value.observationInfo)
     member __.Current = __adaptive
-    member __.key = _key_ :> FSharp.Data.Adaptive.aval<System.Guid>
-    member __.cameraView = _cameraView_ :> FSharp.Data.Adaptive.aval<Aardvark.Rendering.CameraView>
-    member __.name = _name_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
     member __.path = _path_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
+    member __.key = _key_ :> FSharp.Data.Adaptive.aval<System.Guid>
+    member __.name = _name_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
+    member __.cameraView = _cameraView_ :> FSharp.Data.Adaptive.aval<Aardvark.Rendering.CameraView>
     member __.filename = _filename_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
     member __.version = __value.version
     member __.bookmark = _bookmark_

--- a/src/PRo3D.Core/Surface-Model.fs
+++ b/src/PRo3D.Core/Surface-Model.fs
@@ -724,9 +724,6 @@ type Surface = {
 
     highlightSelected : bool
     highlightAlways   : bool
-
-    whiteDiscardEnabled   : bool
-    whiteDiscardThreshold : NumericInput
 }
 
 module Surface =
@@ -747,14 +744,6 @@ module Surface =
             max = 100000.0
             step = 0.01
             format = "{0:0.000}"
-        }
-
-        let whiteDiscardThreshold (v:float) = {
-            value = v
-            min = 0.0
-            max = 1.0
-            step = 0.01
-            format = "{0:0.00}"
         }
 
     let read0 =
@@ -845,8 +834,6 @@ module Surface =
 
                     highlightSelected     = true
                     highlightAlways       = false
-                    whiteDiscardEnabled   = false
-                    whiteDiscardThreshold = Initial.whiteDiscardThreshold 0.9
                 }
         }
 
@@ -910,8 +897,6 @@ module Surface =
 
             let! highlightSel         = Json.tryRead "highlightSelected"
             let! highlightAl          = Json.tryRead "highlightAlways"
-            let! whiteDiscardEnabled  = Json.tryRead "whiteDiscardEnabled"
-            let! whiteDiscardThresh   = Json.tryRead "whiteDiscardThreshold"
 
             return
                 {
@@ -955,8 +940,6 @@ module Surface =
 
                     highlightSelected     = match highlightSel        with |Some v -> v |None -> true
                     highlightAlways       = match highlightAl         with |Some v -> v |None -> false
-                    whiteDiscardEnabled   = match whiteDiscardEnabled with |Some v -> v |None -> false
-                    whiteDiscardThreshold = match whiteDiscardThresh  with |Some v -> Initial.whiteDiscardThreshold v |None -> Initial.whiteDiscardThreshold 0.9
                 }
         }
 
@@ -1028,8 +1011,6 @@ type Surface with
 
             do! Json.write "highlightSelected"     x.highlightSelected
             do! Json.write "highlightAlways"       x.highlightAlways
-            do! Json.write "whiteDiscardEnabled"   x.whiteDiscardEnabled
-            do! Json.write "whiteDiscardThreshold" x.whiteDiscardThreshold.value
         }
 
 type Picking =

--- a/src/PRo3D.Core/Surface-Model.g.fs
+++ b/src/PRo3D.Core/Surface-Model.g.fs
@@ -196,8 +196,6 @@ type AdaptiveSurface(value : Surface) =
     let _contourModel_ = PRo3D.Core.AdaptiveContourLineModel(value.contourModel)
     let _highlightSelected_ = FSharp.Data.Adaptive.cval(value.highlightSelected)
     let _highlightAlways_ = FSharp.Data.Adaptive.cval(value.highlightAlways)
-    let _whiteDiscardEnabled_ = FSharp.Data.Adaptive.cval(value.whiteDiscardEnabled)
-    let _whiteDiscardThreshold_ = Aardvark.UI.Primitives.AdaptiveNumericInput(value.whiteDiscardThreshold)
     let mutable __value = value
     let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
     static member Create(value : Surface) = AdaptiveSurface(value)
@@ -241,8 +239,6 @@ type AdaptiveSurface(value : Surface) =
             _contourModel_.Update(value.contourModel)
             _highlightSelected_.Value <- value.highlightSelected
             _highlightAlways_.Value <- value.highlightAlways
-            _whiteDiscardEnabled_.Value <- value.whiteDiscardEnabled
-            _whiteDiscardThreshold_.Update(value.whiteDiscardThreshold)
     member __.Current = __adaptive
     member __.version = _version_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.int>
     member __.guid = _guid_ :> FSharp.Data.Adaptive.aval<SurfaceId>
@@ -280,8 +276,6 @@ type AdaptiveSurface(value : Surface) =
     member __.contourModel = _contourModel_
     member __.highlightSelected = _highlightSelected_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
     member __.highlightAlways = _highlightAlways_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
-    member __.whiteDiscardEnabled = _whiteDiscardEnabled_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
-    member __.whiteDiscardThreshold = _whiteDiscardThreshold_
 [<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 module SurfaceLenses = 
     type Surface with
@@ -321,8 +315,6 @@ module SurfaceLenses =
         static member contourModel_ = ((fun (self : Surface) -> self.contourModel), (fun (value : PRo3D.Core.ContourLineModel) (self : Surface) -> { self with contourModel = value }))
         static member highlightSelected_ = ((fun (self : Surface) -> self.highlightSelected), (fun (value : Microsoft.FSharp.Core.bool) (self : Surface) -> { self with highlightSelected = value }))
         static member highlightAlways_ = ((fun (self : Surface) -> self.highlightAlways), (fun (value : Microsoft.FSharp.Core.bool) (self : Surface) -> { self with highlightAlways = value }))
-        static member whiteDiscardEnabled_ = ((fun (self : Surface) -> self.whiteDiscardEnabled), (fun (value : Microsoft.FSharp.Core.bool) (self : Surface) -> { self with whiteDiscardEnabled = value }))
-        static member whiteDiscardThreshold_ = ((fun (self : Surface) -> self.whiteDiscardThreshold), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : Surface) -> { self with whiteDiscardThreshold = value }))
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 type AdaptiveSgSurface(value : SgSurface) =
     let _trafo_ = Aardvark.UI.Trafos.AdaptiveTransformation(value.trafo)

--- a/src/PRo3D.Core/Surface-Model.g.fs
+++ b/src/PRo3D.Core/Surface-Model.g.fs
@@ -1,5 +1,5 @@
-//208e6d7e-da2e-6162-2540-818b829e6350
-//aec4bb6b-dd66-a898-cb45-d84ab3a6dd1f
+//6b077406-b3cd-184a-f951-1cc1faa12b69
+//3832da10-ca23-424f-9901-48d87b4c8cf6
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types

--- a/src/PRo3D.Core/Surface/Surface-Properties.fs
+++ b/src/PRo3D.Core/Surface/Surface-Properties.fs
@@ -49,8 +49,6 @@ module SurfaceProperties =
         | SetFilterDistance of Numeric.Action
         | ToggleHighlightSelected
         | ToggleHighlightAlways
-        | ToggleWhiteDiscardEnabled
-        | SetWhiteDiscardThreshold of Numeric.Action
         | PrintIdToConsole
 
     let update (model : Surface) (act : Action) =
@@ -124,10 +122,6 @@ module SurfaceProperties =
             { model with highlightSelected = not model.highlightSelected }
         | ToggleHighlightAlways ->
             { model with highlightAlways = not model.highlightAlways }
-        | ToggleWhiteDiscardEnabled ->
-            { model with whiteDiscardEnabled = not model.whiteDiscardEnabled }
-        | SetWhiteDiscardThreshold a ->
-            { model with whiteDiscardThreshold = Numeric.update model.whiteDiscardThreshold a }
         | PrintIdToConsole ->
             Log.line "\nname: %s"(model.name)
             Log.line "id  : %s"(model.guid.ToString())
@@ -242,11 +236,6 @@ module SurfaceProperties =
                         yield UI.dropDown'' (ColorMaps.colorMaps |> Map.toSeq |> Seq.map fst |> AList.ofSeq) (toColorMapName tf.tf |> AVal.constant) (fun x -> SetColorMappingName x) (fun s -> s)
                     ]
                 | _ -> ()
-
-                let! path = model.importPath
-                if path.EndsWith(".obj", StringComparison.OrdinalIgnoreCase) then
-                    yield Html.row "Discard White:"     [GuiEx.iconCheckBox model.whiteDiscardEnabled ToggleWhiteDiscardEnabled]
-                    yield Html.row "White Threshold:"   [Numeric.view' [NumericInputType.InputBox] model.whiteDiscardThreshold |> UI.map SetWhiteDiscardThreshold]
 
                 yield Html.row ""  [button [clazz "ui button tiny"; onClick (fun _ -> PrintIdToConsole )] [text "print id"]]
             }

--- a/src/PRo3D.Core/Surface/SurfaceApp.fs
+++ b/src/PRo3D.Core/Surface/SurfaceApp.fs
@@ -103,8 +103,6 @@ module SurfaceUtils =
 
             highlightSelected     = true
             highlightAlways       = false
-            whiteDiscardEnabled   = false
-            whiteDiscardThreshold = Surface.Initial.whiteDiscardThreshold 0.9
         }
 
     module ObjectFiles =        

--- a/src/PRo3D.Viewer/TraverseApp.fs
+++ b/src/PRo3D.Viewer/TraverseApp.fs
@@ -756,57 +756,39 @@ module TraverseApp =
                 (surface : SgSurface)
                 (traverseId : Guid)
                 (solNumber : int)=
-                let isSelected = 
-                    adaptive {
-                        let! (selected : Option<Guid>) =  traverseModel.selectedRimfaxSurface
-                        match selected with
-                        | Some id -> return (id = surface.surface)
-                        | None -> return false
-                    }
+                let isSelected =
+                    traverse.selectedSol
+                    |> AVal.map (function Some n -> n = solNumber | None -> false)
 
-                let colorTransformationExpr =
-                    <@ fun (c : V4f) ->
-                        let tolerance = 0.05f
-                        let isWhite =
-                            abs (c.X - 1.0f) < tolerance &&
-                            abs (c.Y - 1.0f) < tolerance &&
-                            abs (c.Z - 1.0f) < tolerance
-
-                        if isWhite then
-                            V4f(1.0f, 1.0f, 0.0f, c.W)
-                        else
-                            c
-                    @>
-
-                let sg = 
-                    surface.sceneGraph 
+                let surfaceSg =
+                    surface.sceneGraph
                     |> Sg.pickable' (pickable (adaptive { return surface.globalBB }) (adaptive { return surface.trafo.previewTrafo }))
                     |> Sg.noEvents
                     |> Sg.withEvents [
                         SceneEventKind.Click, (
-                            fun (sceneHit : SceneHit) -> 
+                            fun (sceneHit : SceneHit) ->
                                 true, Seq.ofList [PickRimfaxSurface (surface.surface, traverseId, solNumber)])
-                        ] 
-                    |> Sg.uniform "selected" isSelected
-                    |> Sg.uniform "selectionColor" (AVal.constant (C4b (200uy,200uy,255uy,255uy)))
+                        ]
                     // imported RIMFAX surfaces always discard their white bands automatically
                     |> Sg.uniform "WhiteDiscardEnabled"   (AVal.constant true)
                     |> Sg.uniform "WhiteDiscardThreshold" (AVal.constant 0.9f)
+                    |> Sg.shader {
+                        do! DefaultSurfaces.stableTrafo
+                        do! DefaultSurfaces.diffuseTexture
+                        do! PRo3D.Base.OPCFilter.discardWhiteBands
+                    }
 
-                let sg = 
-                    isSelected
-                    |> AVal.map (fun s ->
-                        sg
-                        |> Sg.shader {
-                            do! DefaultSurfaces.stableTrafo
-                            do! DefaultSurfaces.diffuseTexture
-                            do! PRo3D.Base.OPCFilter.discardWhiteBands
-                            if s then do! DefaultSurfaces.transformColor colorTransformationExpr
-                        }
-                    )
-                    |> Sg.dynamic
+                // bounding box drawn around the surface while it is selected
+                let boundingBox =
+                    Sg.wireBox (AVal.constant C4b.VRVisGreen) (AVal.constant surface.globalBB)
+                    |> Sg.noEvents
+                    |> Sg.shader {
+                        do! DefaultSurfaces.stableTrafo
+                        do! DefaultSurfaces.vertexColor
+                    }
+                    |> Sg.onOff isSelected
 
-                sg
+                Sg.ofList [surfaceSg; boundingBox]
 
             let getRimfaxImageModeFromPath (filePath : string) : option<string> =
                 let folders = Path.GetDirectoryName(filePath).Split(Path.DirectorySeparatorChar)

--- a/src/PRo3D.Viewer/TraverseApp.fs
+++ b/src/PRo3D.Viewer/TraverseApp.fs
@@ -785,6 +785,9 @@ module TraverseApp =
                         ] 
                     |> Sg.uniform "selected" isSelected
                     |> Sg.uniform "selectionColor" (AVal.constant (C4b (200uy,200uy,255uy,255uy)))
+                    // imported RIMFAX surfaces always discard their white bands automatically
+                    |> Sg.uniform "WhiteDiscardEnabled"   (AVal.constant true)
+                    |> Sg.uniform "WhiteDiscardThreshold" (AVal.constant 0.9f)
 
                 let sg = 
                     isSelected
@@ -792,7 +795,8 @@ module TraverseApp =
                         sg
                         |> Sg.shader {
                             do! DefaultSurfaces.stableTrafo
-                            do! DefaultSurfaces.diffuseTexture 
+                            do! DefaultSurfaces.diffuseTexture
+                            do! PRo3D.Base.OPCFilter.discardWhiteBands
                             if s then do! DefaultSurfaces.transformColor colorTransformationExpr
                         }
                     )

--- a/src/PRo3D.Viewer/TraverseApp.fs
+++ b/src/PRo3D.Viewer/TraverseApp.fs
@@ -60,8 +60,10 @@ module TraversePropertiesApp =
                 Html.table [
                     Html.row "Name:"       [text m.tName]
                     Html.row "Color:"      [ColorPicker.view m.color |> UI.map SetTraverseColor ]
-                    Html.row "Linewidth:"  [Numeric.view' [NumericInputType.InputBox] m.tLineWidth |> UI.map SetLineWidth ]  
-                    Html.row "Height offset:"  [Numeric.view' [NumericInputType.InputBox] m.heightOffset |> UI.map SetHeightOffset ]  
+                    Html.row "Linewidth:"  [Numeric.view' [NumericInputType.InputBox] m.tLineWidth |> UI.map SetLineWidth ]
+                    Html.row "Height offset:"  [Numeric.view' [NumericInputType.InputBox] m.heightOffset |> UI.map SetHeightOffset ]
+                    Html.row "Priority:"    [Numeric.view' [NumericInputType.InputBox] m.priority |> UI.map SetPriority ]
+                    Html.row "Use Priority"  [GuiEx.iconCheckBox m.priorityEnabled  TogglePriorityRenderingEnabled]
                 ]
             )
 
@@ -74,8 +76,10 @@ module TraversePropertiesApp =
                     Html.row "Fast Text:"  [GuiEx.iconCheckBox m.fastText  ToggleFastText]
                     Html.row "Show Surfaces:"  [GuiEx.iconCheckBox m.showRimfaxSurfaces ToggleshowRimfaxSurfaces]
                     Html.row "Color:"      [ColorPicker.view m.color |> UI.map SetTraverseColor ]
-                    Html.row "Linewidth:"  [Numeric.view' [NumericInputType.InputBox] m.tLineWidth |> UI.map SetLineWidth ]  
-                    Html.row "Height offset:"  [Numeric.view' [NumericInputType.InputBox] m.heightOffset |> UI.map SetHeightOffset ]  
+                    Html.row "Linewidth:"  [Numeric.view' [NumericInputType.InputBox] m.tLineWidth |> UI.map SetLineWidth ]
+                    Html.row "Height offset:"  [Numeric.view' [NumericInputType.InputBox] m.heightOffset |> UI.map SetHeightOffset ]
+                    Html.row "Priority:"    [Numeric.view' [NumericInputType.InputBox] m.priority |> UI.map SetPriority ]
+                    Html.row "Use Priority"  [GuiEx.iconCheckBox m.priorityEnabled  TogglePriorityRenderingEnabled]
                 ]
             )
 
@@ -885,29 +889,34 @@ module TraverseApp =
             (view           : aval<CameraView>)
             (nearPlane      : aval<float>)
             (hfovInDegrees  : aval<float>)
-            (refsys         : AdaptiveReferenceSystem) 
+            (refsys         : AdaptiveReferenceSystem)
             (traverseModel  : AdaptiveTraverseModel)
             (filterPriority : aval<Option<int>>) // if Some, only render traverses with this priority
             (surfacePriorityExists : int -> aval<bool>)
-            = 
+            (priorityOverlayPass : bool) // None pass: true = on-top layer for priority-enabled traverses, false = depth-tested layer for the rest
+            =
             let traverses = AMap.union (AMap.union traverseModel.roverTraverses traverseModel.rimfaxTraverses) traverseModel.waypointsTraverses
 
-            traverses 
-            |> AMap.filterA (fun k v -> 
-                (filterPriority, v.priority.value, v.priorityEnabled) 
-                |||> AVal.bind3 (fun filterPriority p enabled -> 
+            traverses
+            |> AMap.filterA (fun k v ->
+                (filterPriority, v.priority.value, v.priorityEnabled)
+                |||> AVal.bind3 (fun filterPriority p enabled ->
                     match filterPriority, enabled with
                     | Some priority, true-> // we have it priorities enabled and we are in a surface pass. check if this is the right prio
                         AVal.constant (int p = priority)
                     | Some _, false -> // we are in a surface pass here, but priorty rendering is not enabled => skip
                          AVal.constant false
-                    | None, true -> 
-                        // we are in overlay pass here.
-                        // but it has priority enabled -> it was already rendered with the surfaces?
-                        let surfaceExists = surfacePriorityExists (int p)
-                        surfaceExists |> AVal.map not // if it does not exist, render it now.
-                    | None, false ->  // we are in overlay pass here and prios are not enabled => we need to render it now.
-                        AVal.constant true
+                    | None, true ->
+                        // priority enabled traverse in the overlay (None) pass.
+                        // if a surface with this priority exists it was already drawn in the surface pass.
+                        // otherwise it has no surface layer to live in => draw it on top in the priority overlay pass.
+                        if priorityOverlayPass then
+                            let surfaceExists = surfacePriorityExists (int p)
+                            surfaceExists |> AVal.map not // if it does not exist, render it on top now.
+                        else
+                            AVal.constant false // handled by the priority overlay pass, not the depth-tested pass
+                    | None, false ->  // priority rendering disabled => render in the regular depth-tested overlay pass
+                        AVal.constant (not priorityOverlayPass)
                 )
             )
             |> AMap.map(fun id traverse ->

--- a/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
@@ -1230,7 +1230,7 @@ module ViewerUtils =
                                     s.priority.value |> AVal.map (int >> Some) 
                                 | _ -> AVal.constant None
                             )
-                        TraverseApp.Sg.view view m.scene.config.nearPlane.value (m.frustum |> AVal.map Frustum.horizontalFieldOfViewInDegrees) refSystem m.scene.traverses priority validSurfacePriority
+                        TraverseApp.Sg.view view m.scene.config.nearPlane.value (m.frustum |> AVal.map Frustum.horizontalFieldOfViewInDegrees) refSystem m.scene.traverses priority validSurfacePriority false
                         |> Sg.map ViewerAction.TraverseMessage
                 )
                 |> Sg.dynamic

--- a/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
@@ -944,7 +944,7 @@ module ViewerUtils =
 
             Shader.textureOrLightingIfPossible |> toEffect
 
-            PRo3D.Base.OPCFilter.improvedDiffuseTextureAndColorDiscardWhite |> toEffect
+            PRo3D.Base.OPCFilter.improvedDiffuseTextureAndColor |> toEffect
             Shader.mapColorAdaption  |> toEffect
             PRo3D.Base.Shader.mapRadiometry |> toEffect
             Shader.fixAlpha          |> toEffect
@@ -1201,27 +1201,12 @@ module ViewerUtils =
                             view
 
 
-                    let surfaceLookup =
-                        m.scene.surfacesModel.surfaces.flat |> AMap.tryFind guid
-
-                    let whiteDiscardEnabled =
-                        surfaceLookup |> AVal.bind (function
-                            | Some (AdaptiveSurfaces s) -> s.whiteDiscardEnabled
-                            | _ -> AVal.constant false)
-
-                    let whiteDiscardThreshold =
-                        surfaceLookup |> AVal.bind (function
-                            | Some (AdaptiveSurfaces s) -> s.whiteDiscardThreshold.value |> AVal.map float32
-                            | _ -> AVal.constant 0.9f)
-
                     let surfaceSg =
                         match surface.isObj with
                         | true ->
                             s
                             |> Sg.effect [objEffect]
-                            |> Sg.uniform "WhiteDiscardEnabled"   whiteDiscardEnabled
-                            |> Sg.uniform "WhiteDiscardThreshold" whiteDiscardThreshold
-                        | false -> 
+                        | false ->
                             s
                             |> Sg.effect [surfaceEffect] 
                             |> Sg.uniform "LoDColor" (AVal.constant C4b.Gray)

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -2159,19 +2159,42 @@ module ViewerApp =
         //    Sg.ofList [text; traverse]
 
         let distancePointsText =
-            ViewPlanApp.Sg.viewText 
+            ViewPlanApp.Sg.viewText
                 m.scene.referenceSystem
-                m.scene.viewPlans 
-            |> Sg.map ViewPlanMessage    
+                m.scene.viewPlans
+            |> Sg.map ViewPlanMessage
 
+        // priority-enabled traverses (rover/rimfax/waypoints) whose priority has no matching
+        // surface layer are drawn here, on top of all surfaces. This is the depth-cleared overlay
+        // layer, so a traverse with priority higher than the surfaces renders above them.
+        let priorityTraverses =
+            let isThereASurfaceWithPriority (p : int) =
+                m.scene.surfacesModel.surfaces.flat
+                |> AMap.toASetValues
+                |> ASet.existsA (fun e ->
+                    match e with
+                    | AdaptiveSurfaces s -> s.priority.value |> AVal.map (fun pS -> int pS = p)
+                    | _ -> AVal.constant false
+                )
+
+            TraverseApp.Sg.view
+                view
+                m.scene.config.nearPlane.value
+                (frustum |> AVal.map Frustum.horizontalFieldOfViewInDegrees)
+                m.scene.referenceSystem
+                m.scene.traverses
+                (AVal.constant None)
+                isThereASurfaceWithPriority
+                true // priority overlay pass: priority-enabled traverses on top
+            |> Sg.map TraverseMessage
 
         [
-            exploreCenter; 
-            refSystem; 
+            exploreCenter;
+            refSystem;
             homePosition;
             annotationTexts |> Sg.noEvents
             scaleBarTexts
-            //traverse
+            priorityTraverses
             distancePointsText
         ] |> Sg.ofList
                                  
@@ -2225,15 +2248,16 @@ module ViewerApp =
                 )
 
 
-            let traverse = 
-                TraverseApp.Sg.view     
-                    view 
-                    m.scene.config.nearPlane.value 
+            let traverse =
+                TraverseApp.Sg.view
+                    view
+                    m.scene.config.nearPlane.value
                     (frustum |> AVal.map Frustum.horizontalFieldOfViewInDegrees)
                     m.scene.referenceSystem
-                    m.scene.traverses   
+                    m.scene.traverses
                     (AVal.constant None)
                     isThereASurfaceWithPriority
+                    false // depth-tested overlay pass: priority-disabled traverses
                 |> Sg.map TraverseMessage
 
             traverse


### PR DESCRIPTION
CHANGES:

### Update 1 : Move 'Discard White' property from surfaces tab to RIMFAX rendering (there are no UI buttons, the white pixels are just removed, as this is a temporary solution anyways until we have the cleaned up images

### Update 2 : Adjust styling of cross sections 'Remove' button

### Update 3 : Add priority rendering to RIMFAX and rover traverse

### Update 4 : Adjust RIMFAX surface shader from yellow pixels to bounding-box and also fix the linking between sol selection in the viewer and the sol-list

### Update 5 : Open file dialog to choose texture for cross section