### PR TITLE
prerelease6: MapView camera option + restore win-x64 standalone zip

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-paket-
 
-      - name: Create GitHub Release
+      # GitHubRelease now depends on the Publish target (it zips
+      # bin/publish/win-x64 into the standalone), so the paket tool + deps must
+      # be restored first.
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Restore paket
+        run: dotnet paket restore
+
+      - name: Create GitHub Release (draft + standalone zip)
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .\build.cmd GitHubRelease

--- a/Build.fs
+++ b/Build.fs
@@ -665,12 +665,12 @@ Target.create "GitHubRelease" (fun _ ->
                 | s when not (System.String.IsNullOrWhiteSpace s) -> s
                 | _ -> failwith "please set the github_token environment variable to a github personal access token with repro access."
 
-            //let files = System.IO.Directory.EnumerateFiles("bin/publish")
-            //let release = sprintf "bin/PRo3D.Viewer-%s-win-x64-standalone.zip" notes.NugetVersion
-            //let z =
-            //    if File.Exists release then
-            //        File.Delete(release)
-            //    System.IO.Compression.ZipFile.CreateFromDirectory("bin/publish/win-x64", release)
+            // Non-electron standalone: zip the self-contained win-x64 publish
+            // (built by the Publish target this depends on) and upload it to the
+            // same draft below, so it lands alongside the electron installers.
+            let standaloneZip = sprintf "bin/PRo3D.Viewer-%s-win-x64-standalone.zip" notes.NugetVersion
+            if File.Exists standaloneZip then File.Delete(standaloneZip)
+            System.IO.Compression.ZipFile.CreateFromDirectory("bin/publish/win-x64", standaloneZip)
 
             // record where the draft came from: append the commit + tag so the
             // release always states its source (the tag itself anchors the
@@ -688,19 +688,23 @@ Target.create "GitHubRelease" (fun _ ->
             let release =
                 GitHub.createClientWithToken token
                 |> GitHub.draftNewRelease "pro3d-space" "PRo3D" tagName (notes.SemVer.PreRelease <> None) body
-                //|> GitHub.uploadFiles (Seq.singleton release)
+                |> GitHub.uploadFiles (Seq.singleton standaloneZip)
                 //|> GitHub.publishDraft
                 |> Async.RunSynchronously
 
             try Branches.pushTag "." "origin" tagName with e -> Trace.logf "could not create tag: %A" e
 
-        with e -> 
+        with e ->
             Trace.logf "failed to create github release: %A" e
             Branches.deleteTag "." tagName
     finally
         ()
-        
+
 )
+
+// GitHubRelease zips bin/publish/win-x64 into the standalone; make sure that
+// self-contained publish exists first (the deploy 'draft' job runs GitHubRelease).
+"Publish" ==> "GitHubRelease" |> ignore
 
 
 Target.create "Pack" (fun _ ->

--- a/PRODUCT_RELEASE_NOTES.md
+++ b/PRODUCT_RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 6.0.0-prerelease6
+- Navigation: the camera-mode dropdown now shows **MapView** even when no reference body is loaded — greyed out with a "needs a planet / reference body" note — instead of hiding the option entirely
+- Release: restored the non-electron Windows standalone build (`PRo3D.Viewer-<version>-win-x64-standalone.zip`) attached to the draft release alongside the installers
+
 ## 6.0.0-prerelease5
 - macOS: fixed PRo3D failing to start on Apple Silicon (and Intel) Macs — a stale x86_64 `libCooTransformation` bundled with the instrument-platform wrappers shadowed the correct-architecture SPICE native; removed it so SPICE/CooTransformation initializes on all platforms
 - Profiles: multi-attribute profile data extraction and export

--- a/src/PRo3D.Core/Drawing/Drawing.UI.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.UI.fs
@@ -17,27 +17,45 @@ open FSharp.Data.Adaptive
 
 module UI =
 
-    let dropDown<'a, 'msg when 'a : enum<int> and 'a : equality> (exclude : HashSet<'a>) (selected : aval<'a>) (change : 'a -> 'msg) (getTooltip : 'a -> string) =
+    /// Enum dropdown with two independent filters:
+    ///  - `exclude`  : values omitted from the list entirely
+    ///  - `disabled` : values shown but greyed out and unselectable, with
+    ///                 `disabledNote` appended to the label + tooltip explaining why
+    /// (An <option> may only contain text, so browsers ignore strike-through/styling
+    /// inside it; the reliable "not selectable" signal is the `disabled` attribute.)
+    let dropDownDisabled<'a, 'msg when 'a : enum<int> and 'a : equality> (exclude : HashSet<'a>) (disabled : HashSet<'a>) (disabledNote : string) (selected : aval<'a>) (change : 'a -> 'msg) (getTooltip : 'a -> string) =
         let names  = Enum.GetNames(typeof<'a>)
-        let values = Enum.GetValues(typeof<'a>) |> unbox<'a[]> 
+        let values = Enum.GetValues(typeof<'a>) |> unbox<'a[]>
         let nv     = Array.zip names values
 
         let attributes (name : string) (value : 'a) =
-            AttributeMap.ofListCond [
-                always (attribute "value" name)
-                onlyWhen (AVal.map ((=) value) selected) (attribute "selected" "selected")
-            ]
-       
+            AttributeMap.ofListCond (
+                [
+                    always (attribute "value" name)
+                    onlyWhen (AVal.map ((=) value) selected) (attribute "selected" "selected")
+                ]
+                @ (if HashSet.contains value disabled then [ always (attribute "disabled" "disabled") ] else [])
+            )
+
         select [onChange (fun str -> Enum.Parse(typeof<'a>, str) |> unbox<'a> |> change); style "color:black"] [
             for (name, value) in nv do
                 if exclude |> HashSet.contains value |> not then
+                    let isDisabled = HashSet.contains value disabled
                     let att = attributes name value
-                    let tooltip = getTooltip value
-                    if tooltip != "" then
-                        yield Incremental.option att (AList.ofList [text name]) |> UI.wrapToolTip DataPosition.Bottom tooltip
-                    else 
-                        yield Incremental.option att (AList.ofList [text name])
+                    let label = if isDisabled && disabledNote <> "" then sprintf "%s  (%s)" name disabledNote else name
+                    let tooltip =
+                        let t = getTooltip value
+                        if isDisabled && disabledNote <> "" then
+                            if t <> "" then sprintf "%s — %s" t disabledNote else disabledNote
+                        else t
+                    if tooltip <> "" then
+                        yield Incremental.option att (AList.ofList [text label]) |> UI.wrapToolTip DataPosition.Bottom tooltip
+                    else
+                        yield Incremental.option att (AList.ofList [text label])
         ]
+
+    let dropDown<'a, 'msg when 'a : enum<int> and 'a : equality> (exclude : HashSet<'a>) (selected : aval<'a>) (change : 'a -> 'msg) (getTooltip : 'a -> string) =
+        dropDownDisabled exclude HashSet.empty "" selected change getTooltip
 
     let viewAnnotationToolsHorizontal (paletteFile : string) (model:AdaptiveDrawingModel) =
         let geometryTooltip (i : Geometry) : string =

--- a/src/PRo3D.Viewer/Navigation.fs
+++ b/src/PRo3D.Viewer/Navigation.fs
@@ -231,13 +231,16 @@ module Navigation =
                     alist {
                         let navMode = model.navigationMode
                         let! p = planet
-                        let exclude = 
-                            if p = Planet.None then 
+                        // MapView needs a reference body (it orients to the planet
+                        // centre with up = north). With Planet.None we still show it,
+                        // but greyed out with a note, instead of hiding it.
+                        let disabled =
+                            if p = Planet.None then
                                 [ NavigationMode.MapView ] |> HashSet.ofList
                             else
-                                HashSet.Empty
+                                HashSet.empty
 
-                        Drawing.UI.dropDown exclude navMode SetNavigationMode geometryTooltip
+                        Drawing.UI.dropDownDisabled HashSet.empty disabled "needs a planet" navMode SetNavigationMode geometryTooltip
                     })]
             ]
 


### PR DESCRIPTION
Targets `releases/6.0.0` for **6.0.0-prerelease6**.

## MapView camera dropdown
Previously MapView was *hidden* from the camera-mode dropdown whenever the scene had no reference body (`Planet.None`). Now it's shown but **disabled** (greyed, unselectable) with a short `(needs a planet)` note + tooltip. New `Drawing.UI.dropDownDisabled` helper; `dropDown` delegates to it, so other callers are unchanged.

## Restore the non-electron standalone zip
The `GitHubRelease` target had its standalone-zip creation + upload commented out, so recent drafts only carried the electron installers. Re-enabled: it zips `bin/publish/win-x64` into `PRo3D.Viewer-<version>-win-x64-standalone.zip` and uploads it to the same draft (`publishDraft` stays disabled → still a draft). `GitHubRelease` now depends on `Publish`, and the deploy `draft` job restores tools + paket first.

Note: local `build Publish` validation was blocked by a PowerShell tool-path quirk (the direct `JR.Wrappers.sln` build succeeds); letting CI validate the deploy path.

Merging this (it bumps `PRODUCT_RELEASE_NOTES.md`) triggers the deploy for the `v6.0.0-prerelease6` draft.