### PR TITLE
fix(release): attach standalone zip in a post-electron job (single draft)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,16 +99,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-paket-
 
-      # GitHubRelease now depends on the Publish target (it zips
-      # bin/publish/win-x64 into the standalone), so the paket tool + deps must
-      # be restored first.
-      - name: Restore tools
-        run: dotnet tool restore
-
-      - name: Restore paket
-        run: dotnet paket restore
-
-      - name: Create GitHub Release (draft + standalone zip)
+      # Keep this job fast: it only creates the empty draft + tag, so
+      # electron-builder attaches its installers to a single draft. The
+      # non-electron standalone zip is added later by the `standalone` job.
+      - name: Create GitHub Release
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .\build.cmd GitHubRelease
@@ -378,3 +372,42 @@ jobs:
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash ./build.sh PublishToElectron
+
+  # Non-electron Windows standalone build. Runs AFTER all electron jobs so the
+  # single draft (created by `draft`, populated by electron-builder) already
+  # exists; UploadStandalone builds bin/publish/win-x64, zips it, and attaches it
+  # to that draft via `gh release upload --clobber`. Skips together with the rest
+  # when the release already exists (its electron `needs` are gated on `test`).
+  standalone:
+    name: Standalone Zip
+    runs-on: windows-2022
+    needs: [win32_x64, mac_x64, mac_arm64, linux_x64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Dotnet
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache Paket
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.nuget/packages
+            paket-files
+          key: ${{ runner.os }}-paket-${{ hashFiles('paket.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-paket-
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Restore paket
+        run: dotnet paket restore
+
+      - name: Build standalone + upload to draft
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .\build.cmd UploadStandalone

--- a/Build.fs
+++ b/Build.fs
@@ -665,13 +665,6 @@ Target.create "GitHubRelease" (fun _ ->
                 | s when not (System.String.IsNullOrWhiteSpace s) -> s
                 | _ -> failwith "please set the github_token environment variable to a github personal access token with repro access."
 
-            // Non-electron standalone: zip the self-contained win-x64 publish
-            // (built by the Publish target this depends on) and upload it to the
-            // same draft below, so it lands alongside the electron installers.
-            let standaloneZip = sprintf "bin/PRo3D.Viewer-%s-win-x64-standalone.zip" notes.NugetVersion
-            if File.Exists standaloneZip then File.Delete(standaloneZip)
-            System.IO.Compression.ZipFile.CreateFromDirectory("bin/publish/win-x64", standaloneZip)
-
             // record where the draft came from: append the commit + tag so the
             // release always states its source (the tag itself anchors the
             // published release to this commit once pushed below).
@@ -681,14 +674,16 @@ Target.create "GitHubRelease" (fun _ ->
                 | _ -> try Information.getCurrentSHA1 "." with _ -> "unknown"
             let body = Seq.append notes.Notes [ ""; sprintf "_release %s — built from commit %s_" tagName commit ]
 
-            // use the v-prefixed tag as the release tag_name so it matches both
-            // the pushed git tag and electron-builder's default (v{version});
-            // this is what makes the standalone zip and the electron artifacts
-            // share one draft instead of two.
+            // Create the canonical draft with the v-prefixed tag_name so
+            // electron-builder (default vPrefixedTagName = v{version}) attaches
+            // its installers to THIS draft. The non-electron standalone zip is
+            // added afterwards by the UploadStandalone target (a deploy job that
+            // runs after the electron jobs): uploading an asset here makes
+            // electron-builder fork a SECOND draft, so it must not happen at
+            // draft-creation time. Keep this draft empty.
             let release =
                 GitHub.createClientWithToken token
                 |> GitHub.draftNewRelease "pro3d-space" "PRo3D" tagName (notes.SemVer.PreRelease <> None) body
-                |> GitHub.uploadFiles (Seq.singleton standaloneZip)
                 //|> GitHub.publishDraft
                 |> Async.RunSynchronously
 
@@ -702,9 +697,26 @@ Target.create "GitHubRelease" (fun _ ->
 
 )
 
-// GitHubRelease zips bin/publish/win-x64 into the standalone; make sure that
-// self-contained publish exists first (the deploy 'draft' job runs GitHubRelease).
-"Publish" ==> "GitHubRelease" |> ignore
+// Non-electron standalone build: zip the self-contained win-x64 publish and
+// attach it to the EXISTING draft (the one electron-builder created/attached to,
+// keyed by tag v{version}). This runs in its own deploy job AFTER the electron
+// jobs, so the single draft already exists; `gh release upload --clobber` is
+// idempotent and unambiguous because there is exactly one draft for the tag.
+Target.create "UploadStandalone" (fun _ ->
+    let version = notes.NugetVersion
+    let tagName = "v" + version
+    let zip = sprintf "bin/PRo3D.Viewer-%s-win-x64-standalone.zip" version
+    if File.Exists zip then File.Delete zip
+    System.IO.Compression.ZipFile.CreateFromDirectory("bin/publish/win-x64", zip)
+
+    Trace.tracefn "uploading %s to release %s" zip tagName
+    let psi = System.Diagnostics.ProcessStartInfo("gh", sprintf "release upload %s \"%s\" --clobber --repo pro3d-space/PRo3D" tagName zip)
+    psi.UseShellExecute <- false
+    use p = System.Diagnostics.Process.Start(psi)
+    p.WaitForExit()
+    if p.ExitCode <> 0 then failwithf "gh release upload failed with exit code %d" p.ExitCode
+)
+"Publish" ==> "UploadStandalone" |> ignore
 
 
 Target.create "Pack" (fun _ ->


### PR DESCRIPTION
Follow-up to the prerelease6 work.

## Problem
Uploading the standalone zip *inside* `GitHubRelease` attached it to GitHubRelease's own draft, but **electron-builder does not reuse that draft — it creates its own**. So every release forked into two drafts with split artifacts (had to consolidate prerelease6 by hand).

## Fix
- `GitHubRelease` goes back to creating only the **empty** draft + tag (electron attaches its installers there, the proven single-draft behavior). Removed the `Publish` dependency and the draft job's restore steps.
- New `UploadStandalone` FAKE target: builds `bin/publish/win-x64`, zips it, and attaches it to the **existing** draft via `gh release upload v{version} --clobber` (unambiguous — one draft per tag).
- New deploy job `standalone` (`needs: [win32_x64, mac_x64, mac_arm64, linux_x64]`) runs it *after* the electron jobs, so the single draft already exists. Skips together with the rest when the release already exists.

No version bump — takes effect on the next real release (prerelease7). Merging triggers a deploy that **skips** (prerelease6 draft already exists), so the current draft is untouched.

Build.fs verified to compile locally (`build.cmd Version`).