### PR TITLE
fix(snapshots): load bookmark/panorama snapshot files

### DIFF
--- a/src/PRo3D.SimulatedViews/Snapshots/Snapshot-Model.fs
+++ b/src/PRo3D.SimulatedViews/Snapshots/Snapshot-Model.fs
@@ -618,7 +618,11 @@ with
             //| Some legacy -> 
             //    return SnapshotAnimation.LegacyAnimation legacy
             //| None ->
-            let! animation = Json.read "CameraAnimation"
+            // Optional: a snapshot file is a tagged union carrying exactly one of
+            // CameraAnimation / BookmarkAnimation / PanoramaCollection. Using the
+            // required Json.read here made loading any non-camera snapshot fail
+            // ("missing CameraAnimation") before the fallbacks below could run.
+            let! animation = Json.tryRead "CameraAnimation"
             match animation with
             | Some cameraAnimation ->
                 return SnapshotAnimation.CameraAnimation cameraAnimation


### PR DESCRIPTION
## Symptom
`PRo3D.Snapshots.exe` fails to read a snapshot JSON — *"Could not read json File"* — for sequenced-bookmark renders, complaining the `CameraAnimation` field is missing.

## Why the field is (correctly) missing
`SnapshotAnimation` is a tagged union; the serializer writes exactly one of `CameraAnimation` / `BookmarkAnimation` / `PanoramaCollection`. `PRo3D.Viewer` (`Viewer.fs:801` → `SnapshotAnimation.fromBookmarks`) writes a **`BookmarkAnimation`** when there's a bookmark tour (`orderList > 0`), so there is no `CameraAnimation` field — by design. The writer is correct.

## The bug (reader)
`SnapshotAnimation.FromJson` began with a **required** `Json.read "CameraAnimation"`, which errors on the absent field before the `BookmarkAnimation`/`PanoramaCollection` fallbacks (already present right below) can run. Switched that one read to `Json.tryRead` → missing field yields `None` → fallbacks run.

One-line change; `PRo3D.SimulatedViews` builds clean.