### PR TITLE
Add AI-agent documentation (AGENTS.md, CLAUDE.md, ai/)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,140 @@
+# AI Agent Entry Point
+
+This file provides AI coding assistants with essential context for working with the **PRo3D** codebase — the **P**lanetary **Ro**botics **3D** Viewer, an F# application for interactive visualization of high-resolution 3D reconstructions of planetary surfaces (Mars, Moon, asteroids).
+
+For detailed documentation, see [ai/README.md](ai/README.md).
+
+PRo3D is built on top of the [Aardvark Platform](https://github.com/aardvark-platform) and uses the **aardvark.media** ELM-style UI/rendering framework. The base framework (DomNode, App, camera controllers, animation, RenderControl, ThreadPool) is documented in aardvark.media's own AI docs — see [Relationship to aardvark.media](#relationship-to-aardvarkmedia) below. **These PRo3D docs only cover what is specific to PRo3D.**
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `dotnet tool restore` | Restore .NET tools (Paket, Adaptify, Aardpack, Fantomas) |
+| `dotnet paket restore` | Restore NuGet dependencies via Paket |
+| `build.cmd` / `build.sh` | Restore tools+deps, then run the FAKE build (`dotnet run`) |
+| `dotnet run` | Run the FAKE build script (`Build.fs`) — default target compiles the solution + adds native resources |
+| `adapt.cmd` / `adapt.sh` | Run Adaptify code generation for all projects (regenerates `*.g.fs`) |
+| `dotnet run --project src/PRo3D.Viewer` | Run the main viewer directly |
+| `dotnet fantomas src/` | Format F# source |
+
+## Technology Stack
+
+| Component | Version | Purpose |
+|-----------|---------|---------|
+| .NET SDK | 9.0.0 (`global.json`, `rollForward: latestFeature`) | Runtime/SDK |
+| F# | All projects | Language (one C# helper project: `CSharpUtils`) |
+| Paket | 9.0.2 | Dependency management |
+| Adaptify | 1.3.7 | Code generation for adaptive models (`*.g.fs`) |
+| Aardpack | 2.0.5 | NuGet packaging |
+| Fantomas | 6.2.3 | F# code formatter |
+| FAKE | 6.1.4 | Build orchestration (`Build.fs`) |
+| Aardvark.Rendering / UI | ~> 5.6.0 | Rendering + aardvark.media UI |
+| Aardvark.Base / Geometry | ~> 5.3.2 / ~> 5.5.0 | Math, geometry, intersection |
+| Aardvark.Data.Opc | ~> 0.11.0 | OPC terrain data |
+| Aardvark.GeoSpatial.Opc | ~> 5.13.0-prerelease | OPC level-of-detail rendering |
+| PRo3D.SPICE | ~> 1.0.6 | Planetary ephemeris / coordinate transforms |
+
+## Dependency Management: Paket
+
+**DO NOT** use `dotnet add package` or edit `<PackageReference>` in `.fsproj` files.
+
+Dependencies are declared centrally in [`paket.dependencies`](paket.dependencies); per-project subsets live in `paket.references` files. Locked versions are in [`paket.lock`](paket.lock) (commit this).
+
+| Task | Command |
+|------|---------|
+| Restore all | `dotnet paket restore` |
+| Add dependency | edit `paket.dependencies` + the project's `paket.references`, then `dotnet paket install` |
+| Update dependency | `dotnet paket update <package>` |
+
+## Code Generation: Adaptify
+
+Adaptify generates adaptive (`A...`) counterparts for model record types annotated with `[<ModelType>]`. This is how the immutable model is bridged to the incremental/adaptive model the `view` function consumes (see [ai/ARCHITECTURE.md](ai/ARCHITECTURE.md)).
+
+- Generated files: `*.g.fs` (e.g. `Surface-Model.g.fs` next to `Surface-Model.fs`).
+- Triggered automatically by the build (`Adaptify.MSBuild`), or manually via `adapt.cmd` / `adapt.sh` (each project has a `RunAdaptify.fsx`).
+- **DO NOT edit `*.g.fs` files** — change the source `.fs` model and regenerate.
+- Convention: model files are named `*-Model.fs` (or `*Model.fs`), e.g. `Viewer-Model.fs`, `Surface-Model.fs`.
+
+## Project Structure
+
+The solution is [`src/PRo3D.sln`](src/PRo3D.sln). Key projects:
+
+```
+src/
+├── PRo3D.Base/            # Foundations: annotations, coordinate transforms (SPICE),
+│                          #   serialization, KdTrees, shaders/effects, GIS models, dialogs
+├── PRo3D.Core/            # Domain sub-apps: surfaces, drawing, groups, bookmarks,
+│                          #   reference systems, scale bars, traverses, GIS, transformations
+├── PRo3D.Viewer/          # Main executable: root model/update/view, hosting, command line,
+│                          #   remote API, provenance, scene persistence
+├── PRo3D.SimulatedViews/  # Simulated instrument/rover camera views, view planning, screenshots
+├── PRo3D.Snapshots/       # Headless batch rendering tool (camera/animation snapshots)
+├── PRo3D.Lite/            # Lightweight orbit-camera viewer variant
+├── PRo3D.GIS/             # Geospatial tooling (image projection, SPICE-backed entities/frames)
+├── PRo3D.CorrelationPanels/ # Geologic correlation visualization
+├── OpcViewer/             # Shared OPC viewing base functionality
+├── opc-tool/              # CLI: validate OPC datasets, build/convert textures + KdTrees
+├── ModelViewer/           # Standalone mesh model viewer
+├── CSharpUtils/           # C# helper utilities (netstandard2.1)
+└── Tests/                 # NUnit/FsUnit tests + notebooks
+```
+
+Native code wrappers (instruments) live under `src/InstrumentPlatforms` (built into `lib/JR.Wrappers.dll`). See [ai/RENDERING.md](ai/RENDERING.md) and [ai/AUTOMATION.md](ai/AUTOMATION.md).
+
+## Native Dependencies
+
+- Native libraries are embedded as `native.zip` resources in assemblies and extracted at build time by [`UnpackNativeDependencies.fs`](UnpackNativeDependencies.fs) (uses Mono.Cecil), matched per `os/arch`.
+- SPICE coordinate-transform config ships as an embedded resource in `PRo3D.Base` and is initialized at startup via `CooTransformation.initCooTrafo` (see [ai/DOMAIN.md](ai/DOMAIN.md#reference-systems--spice)).
+- `JR.Wrappers` native instrument libs are placed under `lib/Native/JR.Wrappers/<platform>/`.
+
+## Framework Rules
+
+1. **F# first** — only `CSharpUtils` and native-wrapper projects are non-F#.
+2. **Paket only** — never bypass Paket for dependencies.
+3. **Never edit `*.g.fs`** — they are Adaptify output.
+4. **Models are immutable records** annotated `[<ModelType>]`; updates return new models. Don't mutate adaptive values directly outside `transact`.
+5. **Sub-app composition** — each domain (surfaces, drawing, …) is an ELM sub-app with its own Model/Update/View, composed by the viewer's root update via lenses. See [ai/ARCHITECTURE.md](ai/ARCHITECTURE.md).
+6. **Serialization is versioned** — `Scene` carries a `version` int with per-version readers. **Adding a field needs no version bump** if the reader uses `Json.tryRead` + a default; bump `current` and add a `readN` only for breaking changes (rename/remove/retype/changed semantics). See [ai/ARCHITECTURE.md](ai/ARCHITECTURE.md#scene-persistence--versioning).
+7. **Document every feature** — each feature ships with a technical doc page under [`docs/`](docs/) (one `.md` per feature). Add/update it as part of the same change. (`docs/` = human feature docs; `ai/` = agent docs.)
+8. **Follow [ai/CONVENTIONS.md](ai/CONVENTIONS.md)** — adaptive usage (never `AVal.force` inside an adaptive computation; choose model collection types deliberately), **total functions only** (no `List.find`/`Option.get`/etc.), prefix generic syntax (`Option<int>`, not `int option`), and performance rules (no `Seq`/LINQ or O(n) ops like `List.length`/`List.append` on large/hot data — discuss asymptotically slow choices first).
+
+## Contribution Workflow
+
+PRo3D uses an **issue + feature-branch + PR** workflow (full details in [CONTRIBUTING.md](CONTRIBUTING.md)). When making changes:
+
+- **Never commit directly to `main`/`develop`.** Work on a branch named `features/[issue#]_name` or `bugs/[issue#]_name`, and open a Pull Request for review.
+- A PR is expected to include the corresponding [`docs/`](docs/) page for any feature it adds or changes (see rule 7 above).
+- Releases are driven by editing `PRODUCT_RELEASE_NOTES.md` / `aardium/package.json` (CI builds and tags). See [docs/Build-Deploy-System.md](docs/Build-Deploy-System.md).
+
+## Common Failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Build fails: missing packages | Paket restore not run | `dotnet paket restore` |
+| Build fails: missing tools | Tools not restored | `dotnet tool restore` |
+| Type errors referencing `Adaptive*` types | Stale/missing `*.g.fs` | Rebuild, or run `adapt.cmd` |
+| Old scene fails to load | New field read with `Json.read` instead of `Json.tryRead` (no default), or a breaking change without a version bump | Use `Json.tryRead`+default for additive fields; add a `readN` + bump `current` for breaking changes |
+| SPICE / coordinate calls return garbage | `CooTransformation` not initialized | Ensure `initCooTrafo` ran with valid kernels at startup |
+| Picking does nothing | No KdTrees for the surface | Build KdTrees via `opc-tool` (see [ai/RENDERING.md](ai/RENDERING.md#picking)) |
+
+## Relationship to aardvark.media
+
+PRo3D is an aardvark.media application. For the **base framework** — `App<'model,'mmodel,'msg>`, `Unpersist`, `[<ModelType>]`, `DomNode`, attributes/events, `RenderControl`, camera controllers (`FreeFly`/`ArcBall`/`Orbit`), the animation system, `ThreadPool`/`proclist`, and Suave/`MutableApp.toWebPart` hosting — consult the upstream docs:
+
+- https://github.com/aardvark-platform/aardvark.media/tree/main/ai
+  - `ARCHITECTURE.md` — ELM pattern, App type, Unpersist, ThreadPool
+  - `UI.md` — DomNode, attributes, events, RenderControl
+  - `RENDERING.md` — RenderTask pipeline, server setup
+  - `PRIMITIVES.md` — camera controllers, animation, layout
+  - `ADVANCED.md` — JS interop, multi-app, custom scene graphs
+
+The PRo3D `ai/` docs assume that knowledge and focus on PRo3D's own architecture and planetary domain.
+
+## Tips for AI Agents
+
+- Read [ai/README.md](ai/README.md) first to route to the right detailed doc.
+- Check the longer-form human docs in [`docs/`](docs/) for feature deep-dives (e.g. `ProvenanceTracking.md`, `KdTrees.md`, `spice.md`, `Transformations.md`).
+- When changing a model, remember the `*.g.fs` regeneration step.
+- When changing persisted state, bump/extend `Scene` versioning.
+- Prefer editing the relevant sub-app over the monolithic viewer update where possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,18 +22,22 @@ PRo3D is built on top of the [Aardvark Platform](https://github.com/aardvark-pla
 
 | Component | Version | Purpose |
 |-----------|---------|---------|
-| .NET SDK | 9.0.0 (`global.json`, `rollForward: latestFeature`) | Runtime/SDK |
+| .NET SDK | 9.0.100 (`global.json`, `rollForward: latestFeature`) | Runtime/SDK |
 | F# | All projects | Language (one C# helper project: `CSharpUtils`) |
 | Paket | 9.0.2 | Dependency management |
 | Adaptify | 1.3.7 | Code generation for adaptive models (`*.g.fs`) |
 | Aardpack | 2.0.5 | NuGet packaging |
 | Fantomas | 6.2.3 | F# code formatter |
 | FAKE | 6.1.4 | Build orchestration (`Build.fs`) |
-| Aardvark.Rendering / UI | ~> 5.6.0 | Rendering + aardvark.media UI |
-| Aardvark.Base / Geometry | ~> 5.3.2 / ~> 5.5.0 | Math, geometry, intersection |
+| Aardvark.Rendering | ~> 5.6.9 | Rendering backend (GL/Vulkan, Text) |
+| Aardvark.UI / UI.Primitives / UI.Giraffe | ~> 5.7.3 | aardvark.media UI + Giraffe hosting |
+| Aardvark.Base / Aardvark.Geometry | ~> 5.3.2 | Math, geometry |
+| Aardvark.Geometry.Intersection / .PointTree / .PolyMesh / .Clustering | ~> 5.5.0 | Intersection, spatial queries, meshes |
 | Aardvark.Data.Opc | ~> 0.11.0 | OPC terrain data |
-| Aardvark.GeoSpatial.Opc | ~> 5.13.0-prerelease | OPC level-of-detail rendering |
-| PRo3D.SPICE | ~> 1.0.6 | Planetary ephemeris / coordinate transforms |
+| Aardvark.GeoSpatial.Opc | ~> 5.13.0-prerelease0002 | OPC level-of-detail rendering |
+| PRo3D.SPICE | ~> 1.0.9 | Planetary ephemeris / coordinate transforms |
+
+Versions above are the `paket.dependencies` constraints; resolved versions are in `paket.lock`. Note that `Aardvark.Rendering` and `Aardvark.UI` are on **different** version lines — do not assume they move together.
 
 ## Dependency Management: Paket
 
@@ -77,7 +81,7 @@ src/
 ├── opc-tool/              # CLI: validate OPC datasets, build/convert textures + KdTrees
 ├── ModelViewer/           # Standalone mesh model viewer
 ├── CSharpUtils/           # C# helper utilities (netstandard2.1)
-└── Tests/                 # NUnit/FsUnit tests + notebooks
+└── Tests/                 # Expecto tests (NUnit/FsUnit also referenced) + notebooks
 ```
 
 Native code wrappers (instruments) live under `src/InstrumentPlatforms` (built into `lib/JR.Wrappers.dll`). See [ai/RENDERING.md](ai/RENDERING.md) and [ai/AUTOMATION.md](ai/AUTOMATION.md).
@@ -105,7 +109,7 @@ PRo3D uses an **issue + feature-branch + PR** workflow (full details in [CONTRIB
 
 - **Never commit directly to `main`/`develop`.** Work on a branch named `features/[issue#]_name` or `bugs/[issue#]_name`, and open a Pull Request for review.
 - A PR is expected to include the corresponding [`docs/`](docs/) page for any feature it adds or changes (see rule 7 above).
-- Releases are driven by editing `PRODUCT_RELEASE_NOTES.md` / `aardium/package.json` (CI builds and tags). See [docs/Build-Deploy-System.md](docs/Build-Deploy-System.md).
+- Releases are driven by editing `PRODUCT_RELEASE_NOTES.md` / `aardium/Aardium/package.json` (CI builds and tags). See [docs/Build-Deploy-System.md](docs/Build-Deploy-System.md).
 
 ## Common Failures
 
@@ -120,7 +124,7 @@ PRo3D uses an **issue + feature-branch + PR** workflow (full details in [CONTRIB
 
 ## Relationship to aardvark.media
 
-PRo3D is an aardvark.media application. For the **base framework** — `App<'model,'mmodel,'msg>`, `Unpersist`, `[<ModelType>]`, `DomNode`, attributes/events, `RenderControl`, camera controllers (`FreeFly`/`ArcBall`/`Orbit`), the animation system, `ThreadPool`/`proclist`, and Suave/`MutableApp.toWebPart` hosting — consult the upstream docs:
+PRo3D is an aardvark.media application. For the **base framework** — `App<'model,'mmodel,'msg>`, `Unpersist`, `[<ModelType>]`, `DomNode`, attributes/events, `RenderControl`, camera controllers (`FreeFly`/`ArcBall`/`Orbit`), the animation system, `ThreadPool`/`proclist`, and Giraffe/`MutableApp.toWebPart` hosting — consult the upstream docs:
 
 - https://github.com/aardvark-platform/aardvark.media/tree/main/ai
   - `ARCHITECTURE.md` — ELM pattern, App type, Unpersist, ThreadPool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# PRo3D — Instructions for AI Assistants
+
+PRo3D (Planetary Robotics 3D Viewer) is an F# application built on the **Aardvark Platform** / **aardvark.media** ELM-style framework.
+
+**Read [AGENTS.md](AGENTS.md) first** for build commands, dependency management (Paket), code generation (Adaptify), and project structure. Then route to the detailed docs via **[ai/README.md](ai/README.md)**:
+
+- [ai/ARCHITECTURE.md](ai/ARCHITECTURE.md) — root model, sub-app composition, hosting, scene versioning
+- [ai/DOMAIN.md](ai/DOMAIN.md) — surfaces, annotations, reference systems/SPICE, GIS, bookmarks, …
+- [ai/RENDERING.md](ai/RENDERING.md) — OPC data, scene graph, shaders, KdTree picking
+- [ai/CONVENTIONS.md](ai/CONVENTIONS.md) — **must-read** adaptive/F# coding conventions
+- [ai/AUTOMATION.md](ai/AUTOMATION.md) — command line, remote API, snapshots, provenance
+
+The base framework (App/Unpersist/DomNode/controllers/animation/ThreadPool) is documented upstream at https://github.com/aardvark-platform/aardvark.media/tree/main/ai — the PRo3D `ai/` docs cover only what is specific to PRo3D.
+
+## Hard rules
+
+- **Paket only** — never `dotnet add package` or edit `<PackageReference>`. Edit `paket.dependencies` + `paket.references`.
+- **Never edit `*.g.fs`** — they are Adaptify output. Change the `*-Model.fs` source and run `adapt.cmd` / `adapt.sh`.
+- **Models are immutable `[<ModelType>]` records**; updates return new models.
+- **Persisted state is versioned** — *adding* a field needs no version bump if read with `Json.tryRead` + a default; bump `Scene.current` / add a `readN` only for breaking changes (rename/remove/retype/changed meaning).
+- **Never `AVal.force` inside an adaptive computation** (`AVal.map`/`AList.collect`/CEs) — bind with `let!`. Forcing is OK only in imperative/UI callbacks; inside a custom `Sg`/`RenderObject` use the provided token (`x.GetValue(t)`). See [ai/CONVENTIONS.md](ai/CONVENTIONS.md).
+- **Total functions only** — no `List.find`, `List.head`, `Option.get`, `Map.find`, etc. Use `tryFind`/pattern matching/`Option`.
+- **Prefix generic syntax** — `Option<int>`, `IndexList<T>`, `HashMap<K,V>`; never postfix `int option`.
+- **Mind data structures & complexity** — no `Seq`/LINQ or O(n) ops (`List.length`, `List.append`) on large/hot data; use `array` loops / `HashMap`. Fuse pipelines (`choose` over `map`+`filter`, `collect` over `map`+`concat`) — also for adaptive ops. Large-map type choice (`Map` vs `HashMap` vs mutable `Dictionary`) is a trade-off — discuss; discuss asymptotically slow choices first.
+- **Choosing a model collection type is a design decision** — `IndexList`/`HashSet`/`HashMap` give per-element adaptive tracking; a plain field gives `aval<whole>`. Ask when unsure.
+- **Precision (planetary scale) — never transform world coordinates in a `float32` shader.** Geometry lives in **local space** (OPC patch-local; annotations relative to their first point), placed with `Sg.trafo`; the MVP is composed on the **CPU in `double`** (`stableTrafo`) and the shader goes **local → view space** directly. Do **lighting** and **large-triangle filtering** in **view space**, not world space.
+- **Scene graph (Aardvark.Rendering)** — instance repeated geometry (`Sg.instanced`), cache/reuse composed effects, update the graph rather than rebuilding it, and **discuss shader-vs-CPU trade-offs** with the user. See [ai/CONVENTIONS.md](ai/CONVENTIONS.md#scene-graph--rendering-aardvarkrendering).
+- **Every feature gets a `docs/<Feature>.md` page** — add/update it in the same change (`docs/` = human docs, `ai/` = agent docs).
+- **Contribute via PRs** — work on a `features/[issue#]_name` or `bugs/[issue#]_name` branch, never commit straight to `main`/`develop`. See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@ The process for contributing to PRo3D is optimized for easy peer reviews by the 
  * Create an issue for the feature/bug
  * Discuss the feature with the community. High-frequency discussion should happen in our discord channel
  * Implement the feature in a feature branch `features/[issue#]_thename` or `bugs/[issue#]_bugname`
- * Create a PullRequest (PR), ask for contributors to review the PR and merge the PR when done
+ * Document the feature: every feature must ship with a technical documentation page under [`docs/`](docs/) (one Markdown file per feature, e.g. `docs/MyFeature.md`). Update the page when the feature's behavior changes. AI-agent-facing documentation lives separately under [`ai/`](ai/) — see [AGENTS.md](AGENTS.md).
+ * Create a PullRequest (PR), ask for contributors to review the PR and merge the PR when done. The PR is expected to include the corresponding `docs/` page.
  * For creating a new release, change the PRODUCT_RELEASE_NOTES.md / package.json accordingly. For details please look at https://github.com/pro3d-space/PRo3D/blob/main/docs/Build-Deploy-System.md 
  * The CI will trigger a build and create a tag accordingly
  * Please put into the release - the version, humand readable description of the new features/fixes and references to issues etc. (in github choose the release, press  edit button, apply the changes and use "publish release")

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 How PRo3D is structured on top of aardvark.media's ELM architecture.
 
-> **Prerequisite:** This document assumes the aardvark.media model — `App<'model,'mmodel,'msg>`, `Unpersist`, `[<ModelType>]`, the adaptive (`aval`/`aset`/`alist`/`amap`) update model, `ThreadPool`/`proclist`, and Suave/`MutableApp.toWebPart` hosting. See [aardvark.media/ai/ARCHITECTURE.md](https://github.com/aardvark-platform/aardvark.media/tree/main/ai). Here we only cover what PRo3D adds.
+> **Prerequisite:** This document assumes the aardvark.media model — `App<'model,'mmodel,'msg>`, `Unpersist`, `[<ModelType>]`, the adaptive (`aval`/`aset`/`alist`/`amap`) update model, `ThreadPool`/`proclist`, and Giraffe/`MutableApp.toWebPart` hosting. See [aardvark.media/ai/ARCHITECTURE.md](https://github.com/aardvark-platform/aardvark.media/tree/main/ai). Here we only cover what PRo3D adds.
 
 ---
 
@@ -38,7 +38,7 @@ Defined in `src/PRo3D.Viewer/Viewer-Model.fs`.
 
 Two layers matter:
 
-1. **`Scene`** (`Viewer-Model.fs:207`) — the **persisted** part of the application: everything that is saved to a `.pro3d` scene file. It carries a `version : int` for migration and aggregates the persisted sub-models:
+1. **`Scene`** (`Viewer-Model.fs:211`) — the **persisted** part of the application: everything that is saved to a `.pro3d` scene file. It carries a `version : int` for migration and aggregates the persisted sub-models:
 
    ```fsharp
    type Scene = {
@@ -65,7 +65,7 @@ Two layers matter:
    }
    ```
 
-2. **`Model`** (`Viewer-Model.fs:574`) — the **full runtime** model. It embeds `scene : Scene` plus transient/runtime-only state that is *not* persisted: the live `drawing : DrawingModel`, `navigation : NavigationModel`, `animations`/`animator`, `provenanceModel`, picking flags (`picking`, `pivotType`, `surfaceIntersection`), the `messagingMailbox`, undo/redo (`past`/`future`, marked `[<TreatAsValue>]`), background thread pools (`snapshotThreads`, `backgroundPicking`), and so on.
+2. **`Model`** (`Viewer-Model.fs:584`) — the **full runtime** model. It embeds `scene : Scene` plus transient/runtime-only state that is *not* persisted: the live `drawing : DrawingModel`, `navigation : NavigationModel`, `animations`/`animator`, `provenanceModel`, picking flags (`picking`, `pivotType`, `surfaceIntersection`), the `messagingMailbox`, undo/redo (`past`/`future`, marked `[<TreatAsValue>]`), background thread pools (`snapshotThreads`, `backgroundPicking`), and so on.
 
    Fields annotated `[<NonAdaptive>]` (e.g. `animator`) are excluded from the adaptive model; `[<TreatAsValue>]` fields (e.g. undo history) are treated as opaque values rather than adaptified deeply.
 
@@ -87,7 +87,7 @@ type ViewerAction =
     // ... plus many viewer-level actions (imports, picking, config, key/mouse, IO)
 ```
 
-The app is actually started with a slightly wider message type that layers animation + provenance on top of `ViewerAction` (`Viewer-Model.fs:650`):
+The app is actually started with a slightly wider message type that layers animation + provenance on top of `ViewerAction` (`Viewer-Model.fs:666`):
 
 ```fsharp
 type ViewerAnimationAction =
@@ -134,7 +134,7 @@ The dispatch chain in `src/PRo3D.Viewer/Viewer/Viewer.fs`:
 
 ## App Startup & Hosting
 
-The app record is assembled and started in `ViewerApp.start` (`src/PRo3D.Viewer/Viewer/Viewer.fs:2490`):
+The app record is assembled and started in `ViewerApp.start` (`src/PRo3D.Viewer/Viewer/Viewer.fs:2634`):
 
 ```fsharp
 let app = {
@@ -147,7 +147,7 @@ let app = {
 app.startAndGetState()   // -> (AdaptiveModel, MutableApp<...>)
 ```
 
-The initial model `m` is built from `Viewer.initial` and then, depending on `StartupArgs`, optionally pipelined through scene loaders (`LoadScene`, `Viewer.fs:2475`):
+The initial model `m` is built from `Viewer.initial` and then, depending on `StartupArgs`, optionally pipelined through scene loaders (`ViewerStartupLoad`, `Viewer.fs:2629`):
 `SceneLoader.loadSceneFromFile` → `loadRoverData` → `loadAnnotations` → `loadCorrelations` → `loadSequencedBookmarks` → `addScaleBarSegments` → `addGeologicSurfaces`.
 
 Process startup, backend selection, and SPICE init happen in `src/PRo3D.Viewer/Program.fs` (`[<EntryPoint; STAThread>]`):
@@ -155,7 +155,7 @@ Process startup, backend selection, and SPICE init happen in `src/PRo3D.Viewer/P
 - `Aardvark.Init()`, create `OpenGlApplication` (Vulkan optionally), apply GPU workarounds.
 - Initialize SPICE coordinate transforms (`CooTransformation.initCooTrafo`).
 - Parse command line (`CommandLine.parseArguments`, see [AUTOMATION.md](AUTOMATION.md)).
-- Host via Suave `MutableApp.toWebPart' runtime false mainApp` (`Program.fs:393`), optionally mounting the remote API and remote-control app. UI is shown through **Aardium** (the Aardvark Electron-style shell), or headless in server mode.
+- Host via Giraffe `MutableApp.toWebPart' runtime false mainApp` (`Program.fs:373`, `open Aardvark.UI.Giraffe`), optionally mounting the remote API and remote-control app. UI is shown through **Aardium** (the Aardvark Electron-style shell), or headless in server mode.
 
 ### Dockable UI
 
@@ -181,7 +181,7 @@ PRo3D uses aardvark.media's `ThreadPool<'msg>`/`proclist` for background work th
 
 Scenes are saved as `.pro3d` files using **Chiron** JSON codecs (with `PRo3D.Base/Serialization.fs` providing the serializers; see [RENDERING.md](RENDERING.md#serialization) for the binary/JSON split). The key pattern is **explicit versioning**:
 
-- `Scene.version` holds the schema version; `Scene.current = 3` (`Viewer-Model.fs:242`).
+- `Scene.version` holds the schema version; `Scene.current = 3` (`Viewer-Model.fs:247`).
 - Per-version reader functions `read0`, `read1`, `read2`, `read3` deserialize the corresponding on-disk schema, filling missing fields with defaults so **older scenes load into the current model**.
 - Version history is noted in comments, e.g. v2 added traverses/sequenced-bookmarks/comparison, v3 added view plans.
 

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -1,0 +1,209 @@
+# Architecture
+
+How PRo3D is structured on top of aardvark.media's ELM architecture.
+
+> **Prerequisite:** This document assumes the aardvark.media model — `App<'model,'mmodel,'msg>`, `Unpersist`, `[<ModelType>]`, the adaptive (`aval`/`aset`/`alist`/`amap`) update model, `ThreadPool`/`proclist`, and Suave/`MutableApp.toWebPart` hosting. See [aardvark.media/ai/ARCHITECTURE.md](https://github.com/aardvark-platform/aardvark.media/tree/main/ai). Here we only cover what PRo3D adds.
+
+---
+
+## The Big Picture
+
+PRo3D is one large aardvark.media app whose model is composed of many **domain sub-apps**. Each sub-app (surfaces, drawing, bookmarks, GIS, …) is itself an ELM unit with its own `Model`/`Action`/`update`/`view`, living in `PRo3D.Core` or `PRo3D.Base`. The **viewer** in `PRo3D.Viewer` is the orchestrator: it owns the root model, routes messages to sub-apps, recombines their results, and builds the dockable UI.
+
+```
+                 PRo3D.Viewer  (root app)
+   Model ── Scene ──┬── SurfaceModel        (SurfaceApp)
+     │              ├── GroupsModel          (bookmarks / GroupsApp)
+     │              ├── ScaleBarsModel       (ScaleBarsApp)
+     │              ├── TraverseModel         (TraverseApp)
+     │              ├── ViewPlanModel         (ViewPlanApp)
+     │              ├── SceneObjectsModel     (SceneObjectsApp)
+     │              ├── GeologicSurfacesModel (GeologicSurfaceApp)
+     │              ├── SequencedBookmarks    (SequencedBookmarksApp)
+     │              ├── GisApp                (Gis.GisApp)
+     │              ├── ReferenceSystem / ViewConfigModel / ...
+     ├── DrawingModel        (DrawingApp)
+     ├── NavigationModel     (Navigation)
+     ├── AnimationModel      (animation system)
+     ├── ProvenanceModel     (ProvenanceApp)
+     └── ...
+   ViewerAction  ──(nested union)──▶ updateViewer ──▶ each sub-app update
+```
+
+---
+
+## The Root Model
+
+Defined in `src/PRo3D.Viewer/Viewer-Model.fs`.
+
+Two layers matter:
+
+1. **`Scene`** (`Viewer-Model.fs:207`) — the **persisted** part of the application: everything that is saved to a `.pro3d` scene file. It carries a `version : int` for migration and aggregates the persisted sub-models:
+
+   ```fsharp
+   type Scene = {
+       version           : int          // schema version, see below
+       cameraView        : CameraView
+       navigationMode    : NavigationMode
+       exploreCenter     : V3d
+       interaction       : InteractionMode
+       surfacesModel     : SurfaceModel
+       config            : ViewConfigModel
+       scenePath         : Option<string>
+       referenceSystem   : ReferenceSystem
+       bookmarks         : GroupsModel
+       scaleBars         : ScaleBarsModel
+       traverses         : TraverseModel
+       viewPlans         : ViewPlanModel
+       dockConfig        : DockConfig
+       // ...
+       sceneObjectsModel     : SceneObjectsModel
+       geologicSurfacesModel : GeologicSurfacesModel
+       sequencedBookmarks    : SequencedBookmarks
+       screenshotModel       : ScreenshotModel
+       gisApp                : PRo3D.Core.Gis.GisApp
+   }
+   ```
+
+2. **`Model`** (`Viewer-Model.fs:574`) — the **full runtime** model. It embeds `scene : Scene` plus transient/runtime-only state that is *not* persisted: the live `drawing : DrawingModel`, `navigation : NavigationModel`, `animations`/`animator`, `provenanceModel`, picking flags (`picking`, `pivotType`, `surfaceIntersection`), the `messagingMailbox`, undo/redo (`past`/`future`, marked `[<TreatAsValue>]`), background thread pools (`snapshotThreads`, `backgroundPicking`), and so on.
+
+   Fields annotated `[<NonAdaptive>]` (e.g. `animator`) are excluded from the adaptive model; `[<TreatAsValue>]` fields (e.g. undo history) are treated as opaque values rather than adaptified deeply.
+
+### Messages: `ViewerAction` and `ViewerAnimationAction`
+
+`ViewerAction` (`Viewer-Model.fs:85`) is a large discriminated union whose cases are mostly **wrappers around sub-app messages**:
+
+```fsharp
+type ViewerAction =
+    | NavigationMessage       of Navigation.Action
+    | DrawingMessage          of Drawing.DrawingAction
+    | SurfaceActions          of SurfaceAppAction
+    | BookmarkMessage         of ...
+    | SequencedBookmarkMessage of ...
+    | ViewPlanMessage         of ViewPlanApp.Action
+    | SceneObjectsMessage     of ...
+    | TraverseMessage         of TraverseAction
+    | GisAppMessage           of Gis.GisAppAction
+    // ... plus many viewer-level actions (imports, picking, config, key/mouse, IO)
+```
+
+The app is actually started with a slightly wider message type that layers animation + provenance on top of `ViewerAction` (`Viewer-Model.fs:650`):
+
+```fsharp
+type ViewerAnimationAction =
+    | ViewerMessage     of ViewerAction
+    | ProvenanceMessage of ProvenanceApp.ProvenanceMessage
+    | AnewmationMessage of AnimatorMessage<Model>   // (sic)
+```
+
+So the started app is effectively `App<Model, AdaptiveModel, ViewerAnimationAction>`.
+
+---
+
+## Sub-App Composition
+
+The pattern: a sub-app exposes `update : SubModel -> SubAction -> SubModel` (and a `view`). The viewer's root `updateViewer` matches a `ViewerAction` case, calls the sub-app's update on the corresponding field of the model, and writes the result back — typically through an **Aether/optics lens** (the `Lenses` helper in `PRo3D.Base/Utilities.fs` wraps `get`/`set`/`update`).
+
+```fsharp
+// conceptual shape inside updateViewer (src/PRo3D.Viewer/Viewer/Viewer.fs)
+| SurfaceActions a ->
+    let surfaces' = SurfaceApp.update model.scene.surfacesModel a ...
+    Optic.set _surfacesModel surfaces' model
+| DrawingMessage a ->
+    let drawing' = DrawingApp.update model.drawing a ...
+    { model with drawing = drawing' }
+```
+
+The dispatch chain in `src/PRo3D.Viewer/Viewer/Viewer.fs`:
+
+| Function | Role |
+|----------|------|
+| `updateViewer` | The master `match` over `ViewerAction`, routing to sub-app updates |
+| `updateInternal` | Thin wrapper that invokes `updateViewer` |
+| `updateWithProvenanceTracking` | Top-level `update` actually wired into the app; optionally records provenance around `updateInternal` |
+
+**To add a new sub-app:**
+1. Define its `Model`/`Action`/`update`/`view` (usually in `PRo3D.Core`), with `[<ModelType>]` on the model.
+2. Embed the model in `Scene` (if persisted) or `Model` (if transient).
+3. Add a wrapper case to `ViewerAction`.
+4. Handle that case in `updateViewer`, delegating to the sub-app and writing back.
+5. Mount the sub-app's `view` in the dock layout (see below) and surface it in a `DockConfig`.
+6. Run `adapt.cmd` to regenerate `*.g.fs`, and extend `Scene` versioning if persisted.
+
+---
+
+## App Startup & Hosting
+
+The app record is assembled and started in `ViewerApp.start` (`src/PRo3D.Viewer/Viewer/Viewer.fs:2490`):
+
+```fsharp
+let app = {
+    unpersist = Unpersist.instance
+    threads   = threadPool
+    view      = view runtime
+    update    = updateWithProvenanceTracking runtime enableProvenance signature sendQueue messagingMailbox
+    initial   = m
+}
+app.startAndGetState()   // -> (AdaptiveModel, MutableApp<...>)
+```
+
+The initial model `m` is built from `Viewer.initial` and then, depending on `StartupArgs`, optionally pipelined through scene loaders (`LoadScene`, `Viewer.fs:2475`):
+`SceneLoader.loadSceneFromFile` → `loadRoverData` → `loadAnnotations` → `loadCorrelations` → `loadSequencedBookmarks` → `addScaleBarSegments` → `addGeologicSurfaces`.
+
+Process startup, backend selection, and SPICE init happen in `src/PRo3D.Viewer/Program.fs` (`[<EntryPoint; STAThread>]`):
+- Set up `%APPDATA%/PRo3D` paths and logging.
+- `Aardvark.Init()`, create `OpenGlApplication` (Vulkan optionally), apply GPU workarounds.
+- Initialize SPICE coordinate transforms (`CooTransformation.initCooTrafo`).
+- Parse command line (`CommandLine.parseArguments`, see [AUTOMATION.md](AUTOMATION.md)).
+- Host via Suave `MutableApp.toWebPart' runtime false mainApp` (`Program.fs:393`), optionally mounting the remote API and remote-control app. UI is shown through **Aardium** (the Aardvark Electron-style shell), or headless in server mode.
+
+### Dockable UI
+
+The window layout is data-driven via `Aardvark.UI.Primitives` docking:
+- `src/PRo3D.Viewer/DockConfigs.fs` defines named layouts (e.g. `full`, `gis`, `comparison`, `core`, `renderOnly`, `provenance`, view-planner / M2020 modes) as nested horizontal/vertical splits with stacked, named panels (`"render"`, `"surfaces"`, `"annotations"`, `"config"`, `"bookmarks"`, …).
+- `src/PRo3D.Viewer/DashboardModes.fs` bundles a `DockConfig` with a name into selectable dashboard presets. The current one is stored as `Model.dashboardMode` / `Scene.dockConfig`.
+
+The root `view` renders the 3D `RenderControl` plus the panel for each dock element, dispatching each panel's messages back through the corresponding `ViewerAction` wrapper.
+
+---
+
+## Threads, Messaging & Async
+
+PRo3D uses aardvark.media's `ThreadPool<'msg>`/`proclist` for background work that yields messages (see upstream docs). PRo3D-specific pieces:
+
+- **`messagingMailbox` / `MessagingMailbox`** — an async mailbox the viewer uses to inject messages from outside the normal update loop (e.g. remote API, async load completions). Carried on the root `Model`.
+- **`snapshotThreads` / `backgroundPicking`** — dedicated `ThreadPool<ViewerAction>` fields for batch snapshot rendering and background surface picking, kept separate so they can be started/stopped independently.
+- **Async picking** — surface picking results arrive via async values (`pickPreviewRequested : ConsumableAsyncValue<...>`); picking work is only spawned when an interaction actually requires it (see [RENDERING.md](RENDERING.md#picking)).
+
+---
+
+## Scene Persistence & Versioning
+
+Scenes are saved as `.pro3d` files using **Chiron** JSON codecs (with `PRo3D.Base/Serialization.fs` providing the serializers; see [RENDERING.md](RENDERING.md#serialization) for the binary/JSON split). The key pattern is **explicit versioning**:
+
+- `Scene.version` holds the schema version; `Scene.current = 3` (`Viewer-Model.fs:242`).
+- Per-version reader functions `read0`, `read1`, `read2`, `read3` deserialize the corresponding on-disk schema, filling missing fields with defaults so **older scenes load into the current model**.
+- Version history is noted in comments, e.g. v2 added traverses/sequenced-bookmarks/comparison, v3 added view plans.
+
+**Adding a field does NOT require a version bump** — as long as the reader uses **`Json.tryRead`** (which yields `Option`) for that field and a sensible **default** exists for when it's absent. This is the common case and the codebase relies on it heavily (`Viewer-Model.fs` reads `comparisonApp`, `sequencedBookmarks`, `gisApp`, … via `Json.tryRead` and defaults them). So:
+
+```fsharp
+// additive change — no version bump needed
+let! newThing = Json.tryRead "newThing"            // Option<_>
+// ...
+newThing = newThing |> Option.defaultValue Defaults.newThing
+```
+
+**Bump `current` and add a new `readN` only for changes a `tryRead`+default can't handle gracefully**: removing/renaming a field, changing a field's type or units, or otherwise changing the *meaning* of existing data so an old file would deserialize incorrectly. Never silently change the semantics of an existing field without a version bump — old scenes would mis-deserialize.
+
+Sub-models that are persisted (e.g. `SurfaceModel`, `GroupsModel`, `ScaleBarsModel`, `GisApp`) typically also carry their own `version` field and `FromJson`/`ToJson` codecs, following the same discipline (additive via `tryRead`+default; bump only for breaking changes).
+
+---
+
+## See Also
+
+- [DOMAIN.md](DOMAIN.md) — the sub-apps referenced here, in detail
+- [RENDERING.md](RENDERING.md) — surface scene graphs, OPC, picking, serialization internals
+- [AUTOMATION.md](AUTOMATION.md) — command line, remote API, snapshots, provenance
+- [../docs/ProvenanceTracking.md](../docs/ProvenanceTracking.md), [../docs/ModelTypes.md](../docs/ModelTypes.md)
+- aardvark.media: [ARCHITECTURE.md](https://github.com/aardvark-platform/aardvark.media/tree/main/ai) — App type, Unpersist, ThreadPool, MutableApp hosting

--- a/ai/AUTOMATION.md
+++ b/ai/AUTOMATION.md
@@ -30,7 +30,7 @@ Startup then optionally pipelines scene/data loading into the initial model (see
 
 ## Remote API
 
-When enabled, an HTTP API is mounted by the Suave server alongside the UI (`src/PRo3D.Viewer/Program.fs:395`, `prefix "/api" >=> remoteApi`). It is implemented in `src/PRo3D.Viewer/RemoteApi.fs` (plus `QueriesRemoteApi.fs`), and turns messages into the running app's update loop via the `messagingMailbox`. This is how external Python/notebook clients control a live PRo3D instance (see `provex/PROVEX.MD`).
+When enabled, an HTTP API is mounted by the Giraffe server alongside the UI (`src/PRo3D.Viewer/Program.fs:375`, `http.subRoute "/api" remoteApi`). It is implemented in `src/PRo3D.Viewer/RemoteApi.fs` (plus `QueriesRemoteApi.fs`), and turns messages into the running app's update loop via the `messagingMailbox`. This is how external Python/notebook clients control a live PRo3D instance (see `provex/PROVEX.MD`).
 
 Route groups under `/api`:
 
@@ -47,7 +47,7 @@ Route groups under `/api`:
 | `/api/queries/findAnnotation`, `/queryAnnotationAsJson`, `/queryAnnotationAsObj` | Run [queries](DOMAIN.md#queries) against surfaces and return JSON/OBJ |
 | `/api/annotations/%s/points` | Per-annotation point data |
 
-The viewer also serves `/websocket` (UI updates), `/crash.txt`, and `/minilog.txt`. A separate **remote-control** app (`RemoteControlApp.fs`) exposes `POST /shots` and `POST /platformshots` for screenshot/platform-shot capture (`Program.fs:473`).
+The viewer also serves `/websocket` (UI updates), `/crash.txt`, and `/minilog.txt`. A separate **remote-control** app (`RemoteControlApp.fs`) exposes `POST /shots` and `POST /platformshots` for screenshot/platform-shot capture (`Program.fs:446`).
 
 ---
 

--- a/ai/AUTOMATION.md
+++ b/ai/AUTOMATION.md
@@ -1,0 +1,88 @@
+# Automation: Command Line, Remote API, Snapshots & Provenance
+
+PRo3D can run beyond the interactive window: launched with arguments, driven over HTTP, rendered headlessly in batch, and recorded for reproducibility. These features are what make PRo3D usable from scripts and notebooks (see `provex/` and `notebooks/`).
+
+---
+
+## Command Line
+
+Arguments are parsed at startup in `src/PRo3D.Viewer/Program.fs` via the parsers under `src/PRo3D.Viewer/CommandLine.fs` and `src/PRo3D.Viewer/CommandLine/CommandLine.fs`, producing the `StartupArgs` carried on the root `Model`. Use `--help` (or `--h`) to print the authoritative list. Common flags (verify against the source — flags evolve):
+
+| Flag | Purpose |
+|------|---------|
+| `--opc <path[;path…]>` / `--opcs <path[;…]>` | Load one / many OPC datasets |
+| `--obj <path[;…]>` | Load OBJ meshes |
+| `--scene <path>` | Load a `.pro3d` scene |
+| `--snap <path>` | Load camera views (snapshot file) |
+| `--asnap <path>` | Load an animation snapshot (camera sequence) |
+| `--out <folder>` | Output directory for screenshots/snapshots |
+| `--port <n>` | Web server port |
+| `--samples <n>` | MSAA sample count |
+| `--backgroundColor <c>` | Background color |
+| `--defaultSpiceKernel <path>` | SPICE kernel to load at startup |
+| `--excentre`, `--refsystem` | Show exploration centre / reference system |
+| `--verbose` | Verbose logging |
+| `--gui <mode>` | Select a dashboard/dock layout |
+
+Startup then optionally pipelines scene/data loading into the initial model (see [ARCHITECTURE.md](ARCHITECTURE.md#app-startup--hosting)). Headless/server operation (no Aardium window) is selected via startup args and is the basis for batch rendering.
+
+---
+
+## Remote API
+
+When enabled, an HTTP API is mounted by the Suave server alongside the UI (`src/PRo3D.Viewer/Program.fs:395`, `prefix "/api" >=> remoteApi`). It is implemented in `src/PRo3D.Viewer/RemoteApi.fs` (plus `QueriesRemoteApi.fs`), and turns messages into the running app's update loop via the `messagingMailbox`. This is how external Python/notebook clients control a live PRo3D instance (see `provex/PROVEX.MD`).
+
+Route groups under `/api`:
+
+| Route | Purpose |
+|-------|---------|
+| `/api/loadScene` | Load a scene file |
+| `/api/importOpc` | Import an OPC dataset |
+| `/api/saveScene` | Save the current scene |
+| `/api/discoverSurfaces` | Enumerate loadable surfaces under a path |
+| `/api/v2/captureSnapshot`, `/api/v2/activateSnapshot` | Trigger / activate batch snapshots |
+| `/api/v2/getProvenanceGraph`, `/api/v2/provenanceGraph`, `/api/v2/provenanceGraphChanges` | Read the provenance graph (and live changes) |
+| `/api/v2/importAnnotations`, `/api/v2/importAnnotationsFromGraph`, `/api/v2/getFullStateFor` | Annotation/state import & retrieval |
+| `/api/integration/geojson_latlon`, `/api/integration/ws/geojson_xyz` | Export annotations as GeoJSON (lat/lon, or world-XYZ over a WebSocket) |
+| `/api/queries/findAnnotation`, `/queryAnnotationAsJson`, `/queryAnnotationAsObj` | Run [queries](DOMAIN.md#queries) against surfaces and return JSON/OBJ |
+| `/api/annotations/%s/points` | Per-annotation point data |
+
+The viewer also serves `/websocket` (UI updates), `/crash.txt`, and `/minilog.txt`. A separate **remote-control** app (`RemoteControlApp.fs`) exposes `POST /shots` and `POST /platformshots` for screenshot/platform-shot capture (`Program.fs:473`).
+
+---
+
+## Snapshots & Headless Rendering
+
+Two related mechanisms produce images without interactive use:
+
+- **In-viewer snapshots** — `Snapshot-Model.fs` (+ `ScreenshotModel`, `snapshotThreads` on the root model) define camera/surface state for batch capture. Sequenced bookmarks (see [DOMAIN.md](DOMAIN.md#bookmarks--sequenced-bookmarks)) can drive a sequence of snapshots / a panorama, rendering RGB and depth. Triggered interactively, via `--snap`/`--asnap`, or via the `/api/v2/*Snapshot` endpoints.
+- **`PRo3D.Snapshots`** (`src/PRo3D.Snapshots/`) — a standalone headless tool that reads snapshot JSON and renders many viewpoints without the full interactive UI. **`PRo3D.SimulatedViews`** supplies the realistic rover/instrument camera models (e.g. mission instruments) used to define those viewpoints, and underpins view planning.
+
+The snapshot file formats mirror the camera/surface model state, so they round-trip with the same Chiron codecs as scenes.
+
+---
+
+## Provenance Tracking
+
+PRo3D can record a reproducible graph of user interactions — essential for scientific workflows. See `docs/ProvenanceTracking.md`.
+
+| File | Role |
+|------|------|
+| `src/PRo3D.Viewer/ProvenanceModel.fs` | `ProvenanceModel`, `PNode`/`PEdge`, the tracked `PMessage` set |
+| `src/PRo3D.Viewer/ProvenanceApp.fs` | Recording logic; `updateWithProvenanceTracking` wraps the viewer update |
+
+- The root `update` is `updateWithProvenanceTracking`, which (when enabled) records the message and a model snapshot around each `updateInternal` step (see [ARCHITECTURE.md](ARCHITECTURE.md#sub-app-composition)).
+- **`ProvenanceModel`** is a graph: `nodes` (versioned snapshots) and `edges` (message transitions), with the current trail of recent messages.
+- Only a curated set of interactions is tracked (`PMessage`: camera changes, finishing annotations, drawing actions, branch/create-node, scene loads) — not every internal message.
+- The graph is exposed over the remote API (`/api/v2/getProvenanceGraph`, `provenanceGraphChanges`) so external tools can observe and replay sessions.
+
+Provenance is opt-in (enabled together with the remote API at startup) since recording snapshots has a cost.
+
+---
+
+## See Also
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — the update loop, `messagingMailbox`, and how remote messages enter it
+- [DOMAIN.md](DOMAIN.md#queries) — what the query endpoints compute
+- `../provex/PROVEX.MD`, `../provex/*.ipynb` — Python/notebook remote-control examples
+- `../docs/ProvenanceTracking.md`

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -1,0 +1,230 @@
+# Coding Conventions
+
+How to write code that fits PRo3D. Two parts: **FSharp.Data.Adaptive usage** (the rules that keep the incremental system correct and fast) and **general F# style** (which mostly defers to the official standard).
+
+> Adaptive basics — `aval`/`aset`/`alist`/`amap`, `AVal.map`/`bind`, the `[<ModelType>]` → adaptive-model bridge — are in [aardvark.media/ai/ARCHITECTURE.md](https://github.com/aardvark-platform/aardvark.media/tree/main/ai) and [ARCHITECTURE.md](ARCHITECTURE.md). This page is about *using them well*.
+
+---
+
+## FSharp.Data.Adaptive Rules
+
+### 1. Never `AVal.force` inside an adaptive computation
+
+Do **not** call `AVal.force` (or `.GetValue()` with a fresh token) inside `AVal.map`/`bind`, `AList.collect`/`map`, `ASet.*`, `AMap.*`, or inside an `aval`/`alist`/`aset`/`amap` computation expression. Forcing there reads a value *without registering a dependency*, so the result will **not** recompute when that value changes — a silent staleness bug.
+
+Bind dependencies instead, with `let!` / `and!` (CE) or the combinators:
+
+```fsharp
+// ❌ breaks dependency tracking
+let bad = model.count |> AVal.map (fun _ -> AVal.force model.name)
+
+// ✅ both inputs tracked
+let good =
+    aval {
+        let! count = model.count
+        let! name  = model.name
+        return sprintf "%s: %d" name count
+    }
+// or: AVal.map2 (fun c n -> ...) model.count model.name
+```
+
+### 2. Ask: adaptive collection vs. `aval<collection>`
+
+When a model holds many items, there are two representations, and the choice is a real trade-off — **raise it with the user / reviewer rather than picking silently:**
+
+- **Adaptive collection** (`aset` / `alist` / `amap`, or the Adaptify-generated `Adaptive*` collection): tracks changes **per element**. Adding/removing/updating one item only re-runs work for that item. Best when the collection is large, changes incrementally, and each element maps to its own UI node or scene-graph object. Cost: per-element bookkeeping overhead.
+- **`aval<collection>`** (e.g. `aval<HashMap<_,_>>`): tracks the collection as **one value**. Any change invalidates the whole thing and recomputes everything downstream. Best when the collection is small, replaced wholesale, or consumed by an operation that needs all of it at once. Cost: no fine-grained reuse.
+
+Rule of thumb: per-element rendering / large, incrementally-edited data → adaptive collection; small or wholesale-replaced data, or feeding an all-at-once computation → `aval<collection>`. **When it's not obvious, ask and document the decision.**
+
+### 3. `.Current` / `.Content` can beat chains of operators
+
+A long pipeline of adaptive operators carries per-operator overhead. For a **complex** computation it is sometimes cheaper to grab the whole current value as a single `aval` and run a plain, non-incremental function over it:
+
+- Adaptify generates a **`.Current`** member on every adaptive model type — the whole value as one `aval<'T>` (e.g. `fcm.Current : aval<FalseColors>`).
+- Adaptive collections expose **`.Content`** — the content as one `aval` (e.g. `model.selectedLeaves.Content : aval<HashSet<_>>`).
+
+```fsharp
+// Instead of composing many ASet/AList operators, do the heavy work once per change:
+adaptive {
+    let! content = someAdaptiveSet.Content   // aval<HashSet<_>>
+    return expensivePureComputation content
+}
+```
+
+The trade-off mirrors rule 2: you lose per-element incrementality (the whole thing recomputes on any change) but avoid operator overhead. **This is per-case — measure/reason about it; don't apply it blindly.**
+
+### 4. `AVal.force` is fine in imperative callbacks
+
+UI event handlers and similar imperative callbacks (`onClick`, `onMouseMove`, button/menu handlers, command-line/remote-API handlers) run **outside** any adaptive computation — they just need the current value *now*. `AVal.force` is appropriate there.
+
+```fsharp
+button [ onClick (fun _ ->
+    let current = AVal.force model.value   // ✅ one-shot read in an event callback
+    DoSomething current) ] [ text "go" ]
+```
+
+**Inside a custom `Sg`/`RenderObject`** you are handed an `AdaptiveToken` — use it: `someAval.GetValue(token)` (e.g. `annoSet.Content.GetValue(t)`). That registers the dependency against the render evaluation, so it is *not* the same mistake as rule 1. Never substitute `AVal.force` for the provided token.
+
+### 5. Model collection types decide the adaptive mapping — choose deliberately
+
+The decision in rules 2–3 is actually made **when you pick the field type in the immutable model**: Adaptify maps each model type to a specific adaptive type in the generated `Adaptive*` record (`*-Model.g.fs`). The collection type you write *is* the per-element-vs-whole-value choice.
+
+| Model field type | Generated adaptive type | Tracking |
+|------------------|-------------------------|----------|
+| `IndexList<'T>` | `alist<'T>` | per-element (ordered) |
+| `HashSet<'T>` | `aset<'T>` | per-element (set) |
+| `HashMap<'K,'V>` | `amap<'K,'V>` | per-element (keyed) |
+| plain value (`int`, `V3d`, `string`, `Trafo3d`, …) | `aval<'T>` | whole value |
+| `Option<'T>` | adaptive option (`aval`-like) | whole value |
+| nested `[<ModelType>]` record | its `Adaptive<Record>` | per-field |
+| any field marked `[<TreatAsValue>]` | `aval<'T>` (opaque) | whole value, not descended into |
+| any field marked `[<NonAdaptive>]` | plain `'T` | excluded from the adaptive model |
+
+Two consequences worth internalizing (both visible in `Groups-Model.g.fs`):
+
+- **Element type matters too.** If the elements of an `IndexList`/`HashMap` are themselves `[<ModelType>]`, Adaptify makes the *elements* adaptive — `IndexList<Node>` → `alist<AdaptiveNode>`, `HashMap<Guid,Leaf>` → `amap<Guid, AdaptiveLeafCase>` — so a change to one field of one element only re-runs that field's dependents. With a plain element type you only get add/remove/replace granularity.
+- **Wrapping kills granularity.** `aval<HashMap<_,_>>` (or putting a collection behind `[<TreatAsValue>]`) collapses the whole collection to one value — any change recomputes everything downstream. Use that on purpose (rules 2–3), not by accident.
+
+So: **don't reach for a plain field or `Option<collection>` when you want incremental UI/scene-graph updates, and don't pay for `alist`/`amap`/`aset` element-tracking on a collection you always replace wholesale.** When the right choice isn't obvious, ask (rule 2). After changing a model type, run `adapt.cmd` and check the regenerated `*.g.fs` is what you intended.
+
+### Quick reference
+
+| Context | Reading an `aval` |
+|---------|-------------------|
+| Inside `AVal.map`/`bind`, `aval`/`alist`/`aset`/`amap` CE | `let!` / `and!` / combinators — **never** `AVal.force` |
+| Inside a custom `Sg` / `RenderObject` (has a token `t`) | `x.GetValue(t)` |
+| UI event / imperative callback | `AVal.force x` is OK |
+| Choosing collection representation | ask: adaptive collection vs `aval<collection>` (rules 2–3) |
+
+---
+
+## General F# Style
+
+For general formatting/naming, use the **official Microsoft F# style guide** as the baseline — **except where a PRo3D-specific rule below overrides it** (notably generic-type syntax). When something isn't covered here, the guide is the default:
+
+- **F# style guide (index):** https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/
+- **Formatting conventions:** https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting
+- **Coding conventions:** https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/conventions
+- **Component design guidelines** (public API shape): https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/component-design-guidelines
+
+Formatting is enforced by **[Fantomas](https://fsprojects.github.io/fantomas/)** (installed as a dotnet tool, v6.2.3): run `dotnet fantomas src/`. Let Fantomas own whitespace/layout — don't hand-fight it.
+
+### Total functions only (no partial functions)
+
+**Do not use partial functions that throw on missing/empty input.** This is a hard rule. Banned in this codebase: `List.find`, `List.head`, `List.last`, `List.item` / `.[i]` on lists, `Seq.head`/`Seq.find`, `Array.find`, `Map.find`, `HashMap.find` (the throwing variants), `Option.get`, `.Value` on an `Option`, and `failwith`/`raise` used as a lookup-miss path.
+
+Use the total alternative and handle the missing case explicitly:
+
+```fsharp
+// ❌ throws if not found / empty
+let s = surfaces |> List.find (fun x -> x.id = id)
+let v = map |> HashMap.find key
+let x = opt.Value
+
+// ✅ total — returns Option, force the caller to handle absence
+let s = surfaces |> List.tryFind (fun x -> x.id = id)      // Surface option
+match HashMap.tryFind key map with
+| Some v -> ...
+| None   -> ...                                            // explicit
+let x = opt |> Option.defaultValue fallback                // or match
+```
+
+Prefer `tryFind`/`tryHead`/`tryItem`/`tryPick`, pattern matching, `Option`/`Result` return types, and `Option.defaultValue`/`Option.map`/`Option.bind`. If absence is genuinely impossible, prove it in the types or make the impossibility obvious — don't rely on a partial function and a comment.
+
+### Naming (per the style guide)
+
+- **PascalCase**: types, modules, members, union cases, the `Option`/`Result`/`List` *modules and types*, namespaces. (`type SurfaceModel`, `module SurfaceApp`, `| SurfaceActions of ...`.)
+- **camelCase**: `let`-bound values and functions, parameters, locals. (`let updateViewer m a = ...`.)
+- Model files: `*-Model.fs`; generated adaptive types: `*-Model.g.fs` (never edited — see [../AGENTS.md](../AGENTS.md)).
+
+### Generic types: prefix angle-bracket form (PRo3D override)
+
+Write generic types with **explicit angle brackets in prefix form** — `Option<int>`, `list<Surface>`, `IndexList<WayPoint>`, `HashMap<Guid, Leaf>`, `aval<'T>`. **Do not** use the postfix abbreviation form `int option`, `Surface list`, `Guid[]`-style aliases in signatures.
+
+```fsharp
+// ✅ PRo3D
+surfaceIntersection : Option<SurfaceIntersection>
+viewPortSizes       : HashMap<string, V2i>
+waypoints           : IndexList<WayPoint>
+
+// ❌ not used here
+surfaceIntersection : SurfaceIntersection option
+```
+
+This is the Aardvark-ecosystem convention and it **intentionally differs from the Microsoft style guide's default** (which prefers postfix `int option`). In PRo3D the prefix form wins — it reads consistently with `aval<_>`/`alist<_>`/`amap<_>` and the generated adaptive types, which are always angle-bracketed.
+
+### Performance & data structures
+
+Pick the data structure for how it's *used*, and keep large/hot-path data out of slow operations.
+
+- **Model state** uses the immutable/adaptive collections from FSharp.Data.Adaptive: `HashMap`, `HashSet`, `IndexList` (mapped to `amap`/`aset`/`alist` — see [rule 5](#5-model-collection-types-decide-the-adaptive-mapping--choose-deliberately)). Prefer these over BCL mutable collections in models.
+- **`Seq` / LINQ-style pipelines are fine for small-to-moderate data** and one-shot/UI code. **Do not run them over large data** (per-vertex/per-patch arrays, point clouds, pixel buffers): the closures and intermediate `IEnumerable`s allocate per element. For large data use **allocation-free `array` loops** (`for`/`while` over arrays, in place where possible). This is the OPC/rendering hot path — see [RENDERING.md](RENDERING.md).
+- **`array` over `list` for large or performance-critical buffers** — arrays are contiguous and O(1)-indexed; F# `list` is a singly-linked cons list (O(n) indexing, per-node allocation). `list`/`seq` are fine for small, locally-constructed, ergonomic data.
+- **Fuse pipeline operations — one pass, not several.** Each `map`/`filter`/etc. is a full traversal + intermediate allocation; collapse them:
+  - `map` + `filter` (in either order) → **`choose`** (`fun x -> if pred x then Some (f x) else None`).
+  - `map` + `concat` / nested results → **`collect`**.
+  - `filter` + `head`/`tryHead` → **`tryFind`**; `map` + `tryFind` → **`tryPick`**.
+
+  This applies equally to `List`, `Seq`, **and the adaptive operators** (`AList.choose`/`collect`, `ASet.choose`/`collect`, `AMap.choose`) — fusing there also reduces the number of adaptive nodes and their bookkeeping.
+
+  ```fsharp
+  // ❌ two passes + an intermediate list
+  xs |> List.map f |> List.filter pred
+  // ✅ one pass
+  xs |> List.choose (fun x -> let y = f x in if pred y then Some y else None)
+  ```
+- **Map types — for large maps, weigh the trade-offs (and ask):** three reasonable choices, each different:
+  - **F# `Map<'K,'V>`** — immutable, balanced-tree, **O(log n)**, ordered by key. Good for small/medium immutable maps where key ordering helps.
+  - **`HashMap<'K,'V>`** (FSharp.Data.Adaptive) — immutable/persistent, hash-based, **~O(1)**. Usually the better immutable choice for **large** maps with frequent lookups, and it's what the model layer uses (maps to `amap`, see [rule 5](#5-model-collection-types-decide-the-adaptive-mapping--choose-deliberately)).
+  - **`Dictionary<'K,'V>`** (BCL) — mutable, **O(1)**, fastest, but not immutable/persistent.
+
+  Rule: **if you need immutability, stay on an immutable map** (`Map`/`HashMap`; prefer `HashMap` when large). **Hot code should at least consider a mutable `Dictionary`**, possibly only *temporarily* (build mutably in a local, then freeze into an immutable map before it escapes). For large maps this is a real trade-off — **discuss it with the user** rather than defaulting.
+- **O(n) operations are a code smell that you picked the wrong structure.** In particular:
+  - `List.length` — if you need a count often, you probably want an `array` or to track the count. It's O(n) on a list.
+  - `List.append` / `@` — O(n) per call, O(n²) in a loop. Repeated appends mean you want an `array`/`ResizeArray`/`IndexList`, or to build then reverse.
+  - `List.item` / indexing into a list — O(n); use `array` or `IndexList`/`HashMap`.
+- **Asymptotically slow operations must be discussed with the user before they go in.** Anything super-linear, or linear work inside a hot loop (e.g. an O(n) lookup per element → O(n²)), is a design decision, not a detail — raise it. Reach for the structure with the right complexity (`HashMap`/`HashSet` for membership/lookup, `array` for sequential/indexed access) instead.
+
+### Other
+
+- **Immutability first** — models are immutable records; updates return new records. Reserve `mutable`/`ref`/caches for genuine performance needs (e.g. the KdTree cache), and keep them out of the persisted model.
+- **Delete dead code** rather than commenting it out (the codebase has accumulated commented blocks — don't add more).
+- Prefer extending the relevant **sub-app** over growing the monolithic viewer `update` (see [ARCHITECTURE.md](ARCHITECTURE.md#sub-app-composition)).
+
+---
+
+## Scene Graph & Rendering (Aardvark.Rendering)
+
+The scene graph (`ISg`) is adaptive, but it is **not free** — each render object is prepared (shaders compiled, buffers uploaded, render state resolved) and every draw call has overhead. Build the graph for efficient GPU submission, and prefer letting the adaptive system *update* an existing graph over *rebuilding* it.
+
+### Numerical precision — read this before touching geometry or shaders
+
+**This is fundamental, not optional.** PRo3D renders planetary-scale data: world coordinates are huge (e.g. a Mars-radius point is ~3.4×10⁶ m). `float32` (GPU) has ~7 significant digits, so transforming *world* coordinates in a shader produces visible jitter / cracks. The whole rendering pipeline is designed around avoiding that:
+
+- **Geometry lives in a local space, never global world space.**
+  - **OPC patches** each have their own local coordinate space (patch-local vertices + a patch transform).
+  - **Annotations** invent a local space by translating from the origin `(0,0,0)` to the annotation's **first point**; vertices are stored relative to that point.
+  - The local geometry is placed with **`Sg.trafo`**.
+- **Compose the model→view→projection matrix on the CPU in `double`**, then hand it to the shader (this is what `DefaultSurfaces.stableTrafo` is for). The shader transforms **directly from local space into view space** — it never reconstructs a global float world position. **Never** introduce a shader path that puts world-space coordinates through a `float32` transform.
+- **Do lighting in view space.** In PRo3D lighting math runs in *view* space (coordinates are small and near the camera there), **not** world space.
+- **Filter / process large triangles in view space.** Operations like culling/filtering big triangles must be done in view space — world space suffers numerical problems at planetary scale.
+
+When you add geometry, a shader, or any per-vertex math: adopt the same discipline — local-space geometry + `Sg.trafo`, double-composed MVP (reuse `stableTrafo` / the existing pattern), and do per-vertex work (lighting, large-triangle filtering, screen-space scaling) in **view space**. If a feature seems to need world-space coordinates on the GPU, that's a red flag — raise it.
+
+### Optimizations
+
+- **Instance repeated geometry — don't emit one `Sg` per copy.** When you draw many copies of the same geometry (markers, scale-bar ticks, points, rover sol markers, preview cones/cylinders), use **`Sg.instanced` / `Sg.instanced'` / `Sg.instancedGeometry`** — one draw call with per-instance attributes (e.g. an `aval<Trafo3d[]>` of transforms) instead of N nodes and N draw calls. PRo3D already does this (`src/PRo3D.Viewer/TraverseApp.fs` sol markers; `src/PRo3D.Core/Drawing/PackedRendering.fs` cones/cylinders). If you find yourself `List.map`-ing geometry into many `Sg` nodes, reach for instancing first.
+- **Cache / reuse effects when it's easy.** FShade effect composition + compilation is expensive. Compose an effect (or effect list) **once** — a module-level `let` value or a value cached per surface — and reuse it; don't rebuild the effect array inside a `view`/per-object/per-frame path (constructing fresh effect lists each time defeats the compilation cache). See `src/PRo3D.Base/OutlineEffect.fs` for composed effect lists. Reuse `IndexedGeometry`/buffers similarly rather than recreating per change.
+- **Shader vs. CPU is always a trade-off — discuss it.** Work in a shader runs massively parallel on the GPU but **recomputes every frame** and can only see GPU-side inputs; the same work on the CPU can be **computed once and cached** but costs memory, must be recomputed (and re-uploaded) when inputs change, and isn't parallelized the same way. The right side depends on data size, how often inputs change, and whether the result is reused (e.g. per-vertex false-color mapping, transforms, culling). **Don't silently pick one — raise the trade-off with the user** when it's a non-trivial amount of work either way.
+- **Update, don't rebuild.** Prefer driving the existing scene graph with adaptive uniforms/attributes/transforms over reconstructing `Sg` nodes when the model changes — rebuilding re-prepares render objects. This is the rendering-side payoff of choosing model collection types for per-element tracking ([rule 5](#5-model-collection-types-decide-the-adaptive-mapping--choose-deliberately)) and of the adaptive rules above. Keep `AVal.force` out of these paths (use the render token; [rule 4](#4-avalforce-is-fine-in-imperative-callbacks)).
+- **Minimize render objects / draw calls and per-frame allocations** — group by geometry/render state, avoid allocating arrays or recomposing scene graphs inside hot adaptive callbacks.
+
+See [RENDERING.md](RENDERING.md) for the concrete PRo3D surface/OPC pipeline these rules apply to.
+
+## See Also
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — the adaptive model bridge and update loop
+- [RENDERING.md](RENDERING.md) — where the array-vs-list / `.GetValue(token)` guidance bites
+- [../AGENTS.md](../AGENTS.md) — framework rules, Adaptify, Paket
+- aardvark.media AI docs — adaptive system fundamentals

--- a/ai/DOMAIN.md
+++ b/ai/DOMAIN.md
@@ -1,0 +1,161 @@
+# Domain Modules
+
+The planetary-science domain of PRo3D, expressed as ELM sub-apps. Each section gives the concept, its model/app files, and the main types. Composition into the viewer is covered in [ARCHITECTURE.md](ARCHITECTURE.md#sub-app-composition); the shared rendering/picking machinery is in [RENDERING.md](RENDERING.md).
+
+Most models live in `src/PRo3D.Core` (with foundational types in `src/PRo3D.Base`), follow the `*-Model.fs` + generated `*-Model.g.fs` convention, carry a `version` field, and serialize via Chiron.
+
+---
+
+## Surfaces
+
+The 3D data being visualized — primarily **OPC** (Ordered Point Cloud) terrain patch hierarchies, and meshes (OBJ/glTF/PLY/etc.).
+
+| File | Purpose |
+|------|---------|
+| `src/PRo3D.Core/Surface-Model.fs` | `Surface`, `SurfaceModel`, `SgSurface`, layer types |
+| `src/PRo3D.Core/Surface/SurfaceApp.fs` | Update/view for the surfaces panel |
+| `src/PRo3D.Core/Surface.fs` | Intersection (`SurfaceIntersection`), triangle/object-set loading |
+| `src/PRo3D.Core/Surface/` | Scene-graph construction, properties, utils |
+| `src/PRo3D.Core/SurfaceTrafoImporter.fs` | Import per-surface transforms |
+
+Key types:
+- **`Surface`** — one logical surface: `guid`, `name`, `importPath`, the contained OPC names/paths, visibility/active flags, quality & render priority, texture layers, scalar layers, color correction, radiometry, and a `preTransform` / `transformation`.
+- **`SurfaceType`** (`SurfaceOPC` | `Mesh`), **`MeshLoaderType`** (Assimp/GlTf/Wavefront/Ply/…).
+- **`ScalarLayer`** — a scalar attribute (e.g. elevation, a measurement) with a `FalseColorsModel` legend (see [Transformations & False-Color](#transformations--false-color)).
+- **`TextureLayer`**, **`ColorCorrection`** (contrast/brightness/gamma/grayscale), **`Radiometry`**, **`TransferFunction`**.
+- **`SgSurface`** — the rendering-side companion: `guid`, `trafo`, global bounding box, the `ISg` scene graph, and picking info. Built from a `Surface`; cached in the model.
+- **`SurfaceModel`** — container: a `GroupsModel` hierarchy of surfaces (see below), an `sgSurfaces : HashMap<Guid, SgSurface>`, a KdTree cache, and surfaces grouped by render priority.
+
+Surfaces are organized hierarchically through the shared groups mechanism, so much of "surface management" is really `GroupsApp`.
+
+---
+
+## Groups (the shared hierarchy)
+
+A generic tree used uniformly for **surfaces, annotations, and bookmarks**. File: `src/PRo3D.Core/Groups-Model.fs`, app `src/PRo3D.Core/GroupsApp.fs`.
+
+- **`Node`** — a group: `key : Guid`, `name`, `leaves : IndexList<Guid>`, `subNodes : IndexList<Node>`, plus `visible`/`expanded`.
+- **`Leaf`** — a tree item, a DU over the kinds it can hold: `Surfaces` | `Bookmarks` | `Annotations`, each exposing `id`/`visible`.
+- **`GroupsModel`** — `rootGroup`, active group/child (`TreeSelection`), a `flat : HashMap<Guid, Leaf>` for O(1) lookup, a groups lookup, and selection state (`selectedLeaves`, `singleSelectLeaf`).
+- Helpers: `Group.flatten`/`flatNodes`, `Leaf.toggleVisibility`/`setName`/`toSurfaces`/`toAnnotations`, `GroupsModel.tryGetSelectedAnnotation`.
+
+When you work with surfaces or annotations, remember the *content* lives in the `flat` map keyed by `Guid` while the *tree* (`Node`s) only carries `Guid` references.
+
+---
+
+## Drawing & Annotations
+
+Interactive measurement/markup placed on surfaces.
+
+| File | Purpose |
+|------|---------|
+| `src/PRo3D.Base/Annotation/Annotation-Model.fs` | The `Annotation` data model and result types |
+| `src/PRo3D.Core/Drawing/Drawing-Model.fs` | `DrawingModel` (live drawing + annotation groups) |
+| `src/PRo3D.Core/Drawing/Drawing-App.fs` | Drawing update/view, measurement computation |
+| `src/PRo3D.Core/Importers/AnnotationGroupsImporter.fs` | Import annotations |
+
+Key types:
+- **`Geometry`** — `Point` | `Line` | `Polyline` | `Polygon` | `DnS` (dip & strike) | `TT` (true thickness) | `Ellipse` | `AxisEllipse` | `Axis4PEllipse`.
+- **`Projection`** — `Linear` | `Viewpoint` | `Sky` | `Bookmark` (how sampled points are projected).
+- **`Semantic`** — geological semantics (`Horizon0..4`, `Crossbed`, `GrainSize`, `None`).
+- **`Segment`** — a span between two picked points plus intermediate sampled points (`IndexList<V3d>`).
+- **`Annotation`** — the full markup: geometry, segments, style (color/thickness), projection/semantic, and computed results.
+- **Results**: `AnnotationResults` (height, length, bearing, slope, area, true thickness, …) and `DipAndStrikeResults` (fitted plane, dip/strike angles & directions, azimuth, center of mass, error stats), plus `Statistics`.
+- **`DrawingModel`** — the live working annotation (`Option<Annotation>`), the annotation `GroupsModel`, current color/thickness/projection/geometry/semantic, and sampling settings. Undo/redo lives on the root `Model` (`past`/`future`), not here.
+
+Annotations can be exported to GeoJSON (see [AUTOMATION.md](AUTOMATION.md#remote-api)). See also `docs/AdvancedAnnotations.md`.
+
+---
+
+## Reference Systems & SPICE
+
+Planetary coordinate frames and the up/north directions everything else is expressed against.
+
+| File | Purpose |
+|------|---------|
+| `src/PRo3D.Core/ReferenceSystem-Model.fs` | `ReferenceSystem` (origin, up/north, planet, scale chart) |
+| `src/PRo3D.Base/CooTransformation.fs` | `Planet`, `SphericalCoo`, coordinate conversions (P/Invoke to native SPICE) |
+| `src/PRo3D.Base/SpiceInterfacing.fs` | Loading SPICE kernels, native call wrappers |
+| `src/PRo3D.Base/GisModels.fs` | `EntitySpiceName`, `FrameSpiceName`, `Entity`, `ReferenceFrame` |
+
+Key types & functions:
+- **`Planet`** — `Earth` | `Mars` | `Moon` | `Phobos` | `Deimos` | `Didymos` | `Dimorphos` | `JPL` | `ENU` | `None`.
+- **`ReferenceSystem`** — `origin : V3d`, `north`/`up` (as `V3dInput` for UI editing), a north-offset angle, `planet`, visibility/size, and a selectable scale chart.
+- **`SphericalCoo`** — longitude/latitude/altitude (+ radian flag).
+- **`CooTransformation`** — conversions `getLatLonAlt`, `getXYZFromLatLonAlt`, `getUpVector`, `getAltitude`/`getElevation'`/`getHeight`, and lifecycle `initCooTrafo`/`deInitCooTrafo`. These wrap the native `CooTransformation` library and are **thread-locked**; they require initialization at startup (done in `Program.fs`).
+- `Planet.inferCoordinateSystem` / `suggestedSystem` heuristically infer the planet from a point's distance from origin.
+
+See `docs/spice.md` and `docs/Transformations.md`.
+
+---
+
+## GIS
+
+Geospatial features driven by SPICE bodies/frames and observation geometry. The interactive sub-app is in `PRo3D.Core/GisApp`; the heavier tooling (image projection, TIFF, instrument metadata) is the separate `src/PRo3D.GIS` project.
+
+| File | Purpose |
+|------|---------|
+| `src/PRo3D.Core/GisApp-Model.fs` | `GisApp` model |
+| `src/PRo3D.Core/GisApp/Entity.fs`, `ReferenceFrame.fs`, `ObservationInfo.fs` | Entity/frame/observation pieces |
+| `src/PRo3D.GIS/GisApp.fs` | Geospatial tooling |
+
+Key types:
+- **`Entity`** — a SPICE body: `spiceName : EntitySpiceName`, label, color, radius, trajectory length, draw/trajectory toggles, default frame.
+- **`ReferenceFrame`** — a SPICE frame: label, description, `spiceName : FrameSpiceName`.
+- **`ObservationInfo`** — `target`, `observer`, `time` (calendar), `referenceFrame` — the observation geometry used to place/orient things.
+- **`GisSurface`** — binds a `SurfaceId` to an optional entity + reference frame.
+- **`GisApp`** — default observation info, `entities`/`referenceFrames`/`gisSurfaces` maps, the active `spiceKernel`, a projected-image list, marker visibility, and mission-time entries (`MissionTimeEntry` for rover ops timelines).
+
+Actions cover assigning bodies/frames to surfaces, observing (positioning at a time), setting the SPICE kernel, and toggling the camera into an observer frame.
+
+---
+
+## Bookmarks & Sequenced Bookmarks
+
+| Concept | File | Notes |
+|---------|------|-------|
+| Bookmarks | `src/PRo3D.Core/Bookmark-Model.fs` | Saved camera views |
+| Sequenced bookmarks | `src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.fs` | Animated tours |
+| Animations | `src/PRo3D.Core/SequencedBookmarks/BookmarkAnimations.fs` | Easing/interpolation between bookmarks |
+
+- **`Bookmark`** — `key : Guid`, `name`, `cameraView`, `exploreCenter`, `navigationMode`. Stored in a `GroupsModel` (the `bookmarks` field of `Scene`).
+- **Sequenced bookmarks** add per-bookmark `delay`/`duration`, an `AnimationLoopMode` (`NoLoop`/`Repeat`/`Mirror`), global animation settings, and a captured **`SceneState`** (camera + view config + reference system + annotation/geologic-surface states). Playing a sequence interpolates camera and restores scene state, and can drive batch snapshot/panorama rendering (see [AUTOMATION.md](AUTOMATION.md#snapshots--headless-rendering)).
+
+---
+
+## Transformations & False-Color
+
+- **`src/PRo3D.Core/TransformationApp.fs`** — per-object placement: translation, yaw/pitch/roll with a selectable `EulerMode` (6 orderings), scaling, and a `PivotMode` (`NoPivot`/`BBCenter`/`PickPivot`). Computes the full `Trafo3d` from a reference-system basis: `getReferenceSystemBasis_global`/`_local`, `calcFullTrafo`, `getNorthAndUpFromPivot`. Used by surfaces, scene objects, scale bars.
+- **`src/PRo3D.Core/VisualizationAndTFApp.fs`** + **`src/PRo3D.Base/FalseColors/`** — false-color legends and transfer functions applied to scalar layers (`FalseColorsModel`: interval, color scheme, legend). See `docs/Contour-Lines.md` and `docs/Feature-Multitexture.md`.
+
+---
+
+## Other Domain Modules
+
+| Domain | Model file | What it is |
+|--------|-----------|------------|
+| **Scale bars** | `src/PRo3D.Core/ScaleBars-Model.fs` | `ScaleVisualization` — camera- or planet-aligned scale bars / coordinate frames with units (mm…km), subdivisions, orientation, pivot. |
+| **Geologic surfaces** | `src/PRo3D.Core/GeologicSurface-Model.fs` | `GeologicSurface` — a mesh built between two point sets (`points1`/`points2`) to visualize a geologic boundary/cross-section; color, transparency, thickness, mesh inversion. |
+| **Scene objects** | `src/PRo3D.Core/SceneObjects-Model.fs` | `SceneObject` — external mesh/model placed in the scene with a full transformation; rendered via a cached `SgSurface`. |
+| **Traverses** | `src/PRo3D.Core/Traverse-Model.fs` | Rover paths and related data. `TraverseType` = `Rover` (SLAM/RMC) \| `Rimfax` (ground-penetrating radar surfaces) \| `WayPoints`. Carries per-sol metrics, distances, and (for RIMFAX) image-mode surfaces. See `docs/RIMFAXTraverse.md`, `docs/TraversePriorities.md`. |
+
+---
+
+## Queries
+
+Spatial/attribute extraction from OPC patches, used by the remote API and analysis workflows. File: `src/PRo3D.Core/Queries/` (e.g. `AnnotationQuery.fs`).
+
+- **`QueryFunctions`** — predicates `boxIntersectsQuery : Box3d -> bool` and `globalWorldPointWithinQuery : V3d -> bool`. Built from an annotation polygon (`queryFunctionsFromAnnotation`) or points-on-plane within a height range (`queryFunctionsFromPointsOnPlane`).
+- **`QueryResult`** — extracted `attributes : Map<string, QueryAttribute>` (channels + raw array), global/local positions, indices, and the source patch path.
+- `handlePatch` extracts a patch's vertices/attributes that fall inside the query region; quadtree traversal (`QTree.foldCulled`) applies frustum/region culling.
+
+See `docs/Feature-Queries.md` and the `notebooks/Query.ipynb` example.
+
+---
+
+## See Also
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — how these sub-apps compose into the viewer
+- [RENDERING.md](RENDERING.md) — surfaces' scene graphs, OPC data, KdTree picking
+- [AUTOMATION.md](AUTOMATION.md) — querying/controlling these features programmatically
+- `../docs/` — feature deep-dives (annotations, transformations, queries, SPICE, traverses, contour lines)

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,59 @@
+# PRo3D AI Documentation Index
+
+AI-agent documentation for **PRo3D** (Planetary Robotics 3D Viewer). PRo3D is an [aardvark.media](https://github.com/aardvark-platform/aardvark.media) application; these docs cover **PRo3D-specific** architecture and domain. For the underlying framework, see [aardvark.media's AI docs](https://github.com/aardvark-platform/aardvark.media/tree/main/ai).
+
+Start at [../AGENTS.md](../AGENTS.md) for build/dependency/project-structure basics.
+
+## Task-Based Lookup
+
+| Task | Document |
+|------|----------|
+| Write idiomatic adaptive/F# code (must-read conventions) | [CONVENTIONS.md](CONVENTIONS.md) |
+| Choose a model collection type (`IndexList`/`HashMap` vs `aval<…>`) | [CONVENTIONS.md](CONVENTIONS.md#5-model-collection-types-decide-the-adaptive-mapping--choose-deliberately) |
+| Understand the root model & how sub-apps compose | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| Add or change a domain feature (surfaces, annotations, bookmarks…) | [DOMAIN.md](DOMAIN.md) |
+| Wire a new sub-app into the viewer's update/view | [ARCHITECTURE.md](ARCHITECTURE.md#sub-app-composition) |
+| Save/load scenes, handle schema changes | [ARCHITECTURE.md](ARCHITECTURE.md#scene-persistence--versioning) |
+| Work with OPC terrain data / level-of-detail | [RENDERING.md](RENDERING.md#opc-ordered-point-clouds) |
+| Build the scene graph for a surface | [RENDERING.md](RENDERING.md#scene-graph-construction) |
+| Implement or debug picking / ray intersection | [RENDERING.md](RENDERING.md#picking) |
+| Add a custom shader/effect (outline, multitexture) | [RENDERING.md](RENDERING.md#shaders--effects) |
+| Coordinate transforms / planetary reference systems | [DOMAIN.md](DOMAIN.md#reference-systems--spice) |
+| GIS entities / SPICE observation setup | [DOMAIN.md](DOMAIN.md#gis) |
+| Drive PRo3D from the command line | [AUTOMATION.md](AUTOMATION.md#command-line) |
+| Control PRo3D remotely (HTTP API) | [AUTOMATION.md](AUTOMATION.md#remote-api) |
+| Headless / batch rendering (snapshots) | [AUTOMATION.md](AUTOMATION.md#snapshots--headless-rendering) |
+| Record/replay provenance of interactions | [AUTOMATION.md](AUTOMATION.md#provenance-tracking) |
+
+## Type-to-Document Mapping
+
+| Type / Module | Document |
+|---------------|----------|
+| `Model` (root), `ViewerAction`, `ViewerAnimationAction` | [ARCHITECTURE.md](ARCHITECTURE.md#the-root-model) |
+| `Scene` (+ versioning) | [ARCHITECTURE.md](ARCHITECTURE.md#scene-persistence--versioning) |
+| `SurfaceModel`, `Surface`, `SgSurface` | [DOMAIN.md](DOMAIN.md#surfaces) / [RENDERING.md](RENDERING.md) |
+| `GroupsModel`, `Node`, `Leaf` | [DOMAIN.md](DOMAIN.md#groups-the-shared-hierarchy) |
+| `DrawingModel`, `Annotation`, `Geometry`, `DipAndStrikeResults` | [DOMAIN.md](DOMAIN.md#drawing--annotations) |
+| `ReferenceSystem`, `Planet`, `SphericalCoo`, `CooTransformation` | [DOMAIN.md](DOMAIN.md#reference-systems--spice) |
+| `GisApp`, `Entity`, `ReferenceFrame`, `ObservationInfo` | [DOMAIN.md](DOMAIN.md#gis) |
+| `Bookmark`, `SequencedBookmarks`, `SceneState` | [DOMAIN.md](DOMAIN.md#bookmarks--sequenced-bookmarks) |
+| `ScaleVisualization`, `GeologicSurface`, `SceneObject`, `TraverseModel` | [DOMAIN.md](DOMAIN.md#other-domain-modules) |
+| `TransformationApp`, `VisualizationAndTFApp`, `FalseColorsModel` | [DOMAIN.md](DOMAIN.md#transformations--false-color) |
+| `Level0KdTree`, `LazyKdTree`, `InCoreKdTree` | [RENDERING.md](RENDERING.md#kdtrees) |
+| `QueryResult`, `QueryFunctions` | [DOMAIN.md](DOMAIN.md#queries) |
+| `ProvenanceModel`, `ProvenanceApp` | [AUTOMATION.md](AUTOMATION.md#provenance-tracking) |
+| `StartupArgs`, `CommandLine` | [AUTOMATION.md](AUTOMATION.md#command-line) |
+
+## Document Overview
+
+- **[CONVENTIONS.md](CONVENTIONS.md)** — Coding conventions agents **must** follow: FSharp.Data.Adaptive usage rules (no `AVal.force` inside adaptive computations; adaptive-collection vs `aval<collection>` trade-offs; the Adaptify model-collection mapping), total-functions-only, prefix generic syntax, and performance/data-structure rules.
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — How PRo3D layers on aardvark.media's ELM pattern: the root `Model`/`Scene`, the nested `ViewerAction` message tree, sub-app composition via lenses, app startup & hosting, the provenance-wrapped update, and versioned scene persistence.
+- **[DOMAIN.md](DOMAIN.md)** — The planetary-science domain: surfaces, the shared groups hierarchy, drawing/annotations, reference systems & SPICE coordinate transforms, GIS, bookmarks, scale bars, geologic surfaces, scene objects, traverses, transformations/false-color, and queries.
+- **[RENDERING.md](RENDERING.md)** — OPC terrain data and level-of-detail, scene-graph construction for surfaces, custom shaders/effects, and KdTree-based picking/intersection. Points at the external `Aardvark.GeoSpatial.Opc` / `OPCViewer.Base` repos.
+- **[AUTOMATION.md](AUTOMATION.md)** — Non-interactive use: command-line arguments, the remote HTTP API, headless snapshot/batch rendering, and provenance recording/replay.
+
+## See Also
+
+- [../AGENTS.md](../AGENTS.md) — build, dependencies, project structure, framework rules
+- [../docs/](../docs/) — long-form human feature docs (`ProvenanceTracking.md`, `KdTrees.md`, `spice.md`, `Transformations.md`, `Feature-Queries.md`, `Feature-Multitexture.md`, …)
+- aardvark.media AI docs — base framework: https://github.com/aardvark-platform/aardvark.media/tree/main/ai

--- a/ai/RENDERING.md
+++ b/ai/RENDERING.md
@@ -1,0 +1,117 @@
+# Rendering, OPC & Picking
+
+How PRo3D turns planetary surface data into a scene graph, renders it with level-of-detail, and picks against it.
+
+> **Prerequisite:** aardvark.media's rendering model — `RenderControl`, `RenderTask`, the adaptive scene graph (`ISg`), FShade shaders — see [aardvark.media/ai/RENDERING.md](https://github.com/aardvark-platform/aardvark.media/tree/main/ai). This document covers the OPC-specific pipeline PRo3D builds on top.
+
+---
+
+## Where the OPC code actually lives
+
+Much of the heavy lifting is **not** in this repo — it's in shared Aardvark platform packages (consumed via Paket). When you need to understand or fix OPC loading/rendering, go to the right repo:
+
+| Concern | Package / repo |
+|---------|----------------|
+| **OPC data loaders** (read patch hierarchies, `.aara` vertex/attribute files, patch file info, paths) | `Aardvark.Data.Opc` — https://github.com/aardvark-platform/aardvark.data/tree/master/src/Aardvark.Data.Opc |
+| **Level-of-detail rendering** (`Sg.patchLod` nodes, LoD metrics, streaming) | `Aardvark.GeoSpatial.Opc` — https://github.com/aardvark-platform/aardvark.geospatial/tree/master/src/Aardvark.GeoSpatial.Opc |
+| **Shared OPC viewer base** (camera, picking helpers, view infrastructure reused by PRo3D) | `OPCViewer.Base` — https://github.com/aardvark-platform/OPCViewer.Base |
+| **Ray/triangle intersection** | `Aardvark.Geometry.Intersection` (`ConcreteKdIntersectionTree`, `RayHit3d`) |
+
+In this repo, the `OpcViewer` project and `src/PRo3D.Core/Surface/` adapt these into PRo3D's model.
+
+---
+
+## OPC (Ordered Point Clouds)
+
+OPC is the patch-based, hierarchical terrain format PRo3D is built around. An OPC dataset is a directory containing `Images/` and `Patches/` plus a `patchhierarchy.xml`. Each patch holds geometry (`.aara` binary vertex/coordinate arrays), texture coordinates, and textures (`.dds`/`.tif`/`.exr`), arranged in a level-of-detail tree so only the needed resolution is loaded and drawn.
+
+- **Loading**: `Aardvark.Data.Opc` parses the hierarchy and patch files; PRo3D discovers/validates dataset folders in `src/PRo3D.Core/Surface/` (folder discovery, `isOpcFolder`/`isSurfaceFolder`).
+- **LoD rendering**: `Aardvark.GeoSpatial.Opc` provides `Sg.patchLod` (and friends), which builds an adaptive scene-graph node that streams and swaps patch levels based on screen-space error / distance metrics.
+- **`opc-tool`** (`src/opc-tool/`) is the offline companion CLI: validate a dataset, resize/convert patch textures (to `.dds`), and **pre-build KdTrees** for picking.
+
+---
+
+## Scene-Graph Construction
+
+PRo3D assembles each surface's `ISg` (stored on its `SgSurface`, see [DOMAIN.md](DOMAIN.md#surfaces)) and combines them into the final render task.
+
+| File | Role |
+|------|------|
+| `src/PRo3D.Core/Surface/` (`Surface.Sg.fs` etc.) | Build a surface's scene graph: `patchLod` geometry + textures + transforms + shaders |
+| `src/PRo3D.Core/Sg.fs` | Reference-system / orientation visualization (north/east/up markers, scale chart) |
+| `src/PRo3D.Base/PatchOverrides.fs` | Override patch materials/shaders for specific patches |
+| `src/PRo3D.Base/Multitexturing.fs` | Multi-layer texture blending (`TextureCombiner`: Primary/Secondary/Multiply/Blend) |
+| `src/PRo3D.Base/OutlineEffect.fs` | Stencil-buffer outlines for selection highlighting |
+| `src/PRo3D.Base/Utilities.fs` (`OPCFilter`) | FShade shader snippets (diffuse+color blend, patch-border marking) |
+
+The pipeline is standard Aardvark: an adaptive `ISg` parameterized by `aval` model values, FShade shader composition, and "stable" transforms (`stableTrafo`) for large planetary world coordinates to avoid float precision loss.
+
+### Precision: local space → view space (critical)
+
+PRo3D's coordinates are planetary-scale (millions of metres), so the pipeline never feeds world-space positions through a `float32` shader transform. Instead:
+
+- Geometry is kept in a **local space** — OPC patches in their own patch-local space; **annotations** in a space translated from `(0,0,0)` to the annotation's first point — and positioned with `Sg.trafo`.
+- The model-view-projection matrix is composed **on the CPU in `double`** (`DefaultSurfaces.stableTrafo`) and the shader transforms **local → view space directly**, skipping a global float world space.
+- **Lighting** and **large-triangle filtering/culling** are done in **view space**; world space would suffer numerical problems at this scale.
+
+This is a hard rule for any new geometry/shader work. The full statement and the other scene-graph optimization rules (instancing via `Sg.instanced`, effect caching, shader-vs-CPU trade-offs, update-don't-rebuild) are in [CONVENTIONS.md → Scene Graph & Rendering](CONVENTIONS.md#scene-graph--rendering-aardvarkrendering). Follow them when touching this pipeline. Per-surface `preTransform`/`transformation` (and SPICE observation transforms, see [DOMAIN.md](DOMAIN.md#reference-systems--spice)) position the surface in world space.
+
+### Shaders & Effects
+
+PRo3D mixes Aardvark `DefaultSurfaces` with custom FShade effects. Notable PRo3D-specific ones: false-color/transfer-function shading for scalar layers (see [DOMAIN.md](DOMAIN.md#transformations--false-color)), multitexturing, outline/selection via stencil modes, and contour-line shading (`docs/Contour-Lines.md`, `docs/Feature-Multitexture.md`).
+
+---
+
+## Picking
+
+PRo3D picks by casting a ray against per-patch **KdTrees** (precomputed triangle acceleration structures), not against the live LoD geometry.
+
+Entry points:
+- `src/PRo3D.Viewer/Viewer/Picking.fs` — high-level `pickRay` from the viewer; visualizes the hit (cone + normal cylinder preview) and feeds annotation/measurement workflows.
+- `src/PRo3D.Core/Surface.fs` — `SurfaceIntersection.doKdTreeIntersection`: the core intersection.
+
+Flow:
+1. Filter to active + visible surfaces.
+2. For each surface, get its KdTree(s) from the cache (loading lazily if needed).
+3. Transform the ray into the surface's local space (accounting for `preTransform`, pivot rotation, scale, and any SPICE/observation transform).
+4. Reject via transformed bounding boxes, then intersect with `ConcreteKdIntersectionTree.Intersect` (from `Aardvark.Geometry.Intersection`), applying a triangle filter.
+5. Return the closest hit (`t`, triangle, surface reference).
+
+**Performance note:** picking is only spawned when the current interaction actually needs it (recent change "Only spawn picking when necessary", commit `14583377`) — surface picking message spawning was previously over-eager. Results may be delivered asynchronously (`Model.pickPreviewRequested`, `backgroundPicking` thread pool; see [ARCHITECTURE.md](ARCHITECTURE.md#threads-messaging--async)).
+
+### KdTrees
+
+File: `src/PRo3D.Base/KdTrees.fs`. See also `docs/KdTrees.md`.
+
+- **`Level0KdTree`** — DU per patch: `LazyKdTree` | `InCoreKdTree`.
+- **`LazyKdTree`** — holds *paths* (kdtree, object-set, coordinates, texture) plus the patch affine `Trafo3d` and bounding box; loads the actual tree on first use to keep memory bounded.
+- **`InCoreKdTree`** — already-loaded tree + bounding box.
+- Helpers: `loadKdtree`/`saveKdTree` (binary, via FsPickler), `expandKdTreePaths` (resolve a hierarchy's per-patch trees into `HashMap<Box3d, Level0KdTree>`), `tryFixPatchFileIfNeeded` (case-sensitivity path repair for cross-platform datasets), and `loadKdTrees'` (bulk loading with caching).
+
+KdTrees are generated offline by `opc-tool`; if a surface has none, picking will silently find nothing.
+
+---
+
+## Serialization
+
+`src/PRo3D.Base/Serialization.fs` provides two serializers, initialized once via `Serialization.init()`:
+
+- **Binary** (MBrace.FsPickler): `save`/`loadAs<'a>` — used for KdTrees and other heavy/internal data.
+- **JSON** (Chiron, with `ChironExt.fs` extensions): `saveJson`/`loadJsonAs<'a>` plus low-level string I/O — used for `.pro3d` scenes and sub-model state. Scene JSON is versioned (see [ARCHITECTURE.md](ARCHITECTURE.md#scene-persistence--versioning)).
+
+---
+
+## Native & Platform Notes
+
+- SPICE coordinate transforms call native libraries through `CooTransformation`/`SpiceInterfacing` (see [DOMAIN.md](DOMAIN.md#reference-systems--spice)); these are thread-locked and must be initialized at startup.
+- Native libs are embedded as `native.zip` resources and unpacked at build time (`UnpackNativeDependencies.fs`); instrument wrappers come from `lib/JR.Wrappers.dll` + `lib/Native/JR.Wrappers/<platform>/`.
+- A GPU workaround disables multisampling on Intel Iris Xe (`Program.fs`).
+
+---
+
+## See Also
+
+- [DOMAIN.md](DOMAIN.md#surfaces) — the `Surface`/`SgSurface`/`SurfaceModel` data side
+- [ARCHITECTURE.md](ARCHITECTURE.md) — where rendering/picking results flow in the update loop
+- `../docs/KdTrees.md`, `../docs/OpcTool.md`, `../docs/Feature-Multitexture.md`, `../docs/Contour-Lines.md`
+- External: [Aardvark.Data.Opc](https://github.com/aardvark-platform/aardvark.data/tree/master/src/Aardvark.Data.Opc), [Aardvark.GeoSpatial.Opc](https://github.com/aardvark-platform/aardvark.geospatial/tree/master/src/Aardvark.GeoSpatial.Opc), [OPCViewer.Base](https://github.com/aardvark-platform/OPCViewer.Base)


### PR DESCRIPTION
Lands the AI-agent documentation on its own, separately from the GoldenLayout work.

## Why separately

The docs were written on `ai-documentation` (`b6f39dc7`) and then merged into
#618 (`features/614-switch-pro3d-ui-to-golden-layout`). They are **not in the
repo anywhere** — `main`, `develop` and `releases/6.0.0` all lack `AGENTS.md`,
`CLAUDE.md` and `ai/`; the only copies live on that unmerged branch and inside
#618.

Since the docs are unrelated to the docking change, they are landed here first.
That leaves #618 as a pure code change, which makes the GoldenLayout rework
(per-user layouts + scene forward/backward compatibility) reviewable on its own.

Note #618 contains **two different `CLAUDE.md` files**: the GoldenLayout commit
`c0520fd8` adds a 98-line one, and `b6f39dc7` adds a 29-line one; #618's merge
kept the latter. This PR lands only `b6f39dc7`'s version.

## Contents

| file | what |
|---|---|
| `AGENTS.md` | entry point: build, Paket, Adaptify, project structure, framework rules, common failures |
| `CLAUDE.md` | auto-loaded pointer + condensed hard rules |
| `ai/README.md` | index: task-based lookup + type-to-document mapping |
| `ai/ARCHITECTURE.md` | root Model/Scene, ViewerAction, sub-app composition, hosting, versioned scene persistence |
| `ai/DOMAIN.md` | surfaces, groups, annotations, reference systems & SPICE, GIS, bookmarks, transformations |
| `ai/RENDERING.md` | OPC data + LoD, scene graph, shaders, KdTree picking, precision |
| `ai/AUTOMATION.md` | command line, remote HTTP API, snapshots, provenance |
| `ai/CONVENTIONS.md` | coding conventions: adaptive usage, total functions, prefix generics, performance rules |
| `CONTRIBUTING.md` | require a `docs/` page per feature; `docs/` = human docs, `ai/` = agent docs |

## Second commit: correctness pass

The docs were written against an older tree, so every factual claim was
re-verified against the current sources. What had drifted:

**Versions** (vs `paket.dependencies`, `.config/dotnet-tools.json`, `global.json`)
- .NET SDK `9.0.0` → `9.0.100`
- "Aardvark.Rendering / UI ~> 5.6.0" was one row collapsing two packages that are
  on *different* version lines — split into `Aardvark.Rendering ~> 5.6.9` and
  `Aardvark.UI/.Primitives/.Giraffe ~> 5.7.3`
- "Aardvark.Base / Geometry ~> 5.3.2 / ~> 5.5.0" split: Base and Geometry are
  `~> 5.3.2`; the `Geometry.Intersection/.PointTree/.PolyMesh/.Clustering`
  packages are `~> 5.5.0`
- `Aardvark.GeoSpatial.Opc ~> 5.13.0-prerelease` → `~> 5.13.0-prerelease0002`
- `PRo3D.SPICE ~> 1.0.6` → `~> 1.0.9`

**Suave → Giraffe** — the viewer now hosts via `Aardvark.UI.Giraffe`. Updated in
`AGENTS.md`, `ai/ARCHITECTURE.md`, `ai/AUTOMATION.md`, including the `/api` mount
(`http.subRoute "/api" remoteApi`, not `prefix "/api" >=> remoteApi`).

**Stale `file:line` references** re-pinned — `Scene` 207→211, `Model` 574→584,
`ViewerAnimationAction` 650→666, `Scene.current` 242→247, `ViewerApp.start`
2490→2634, startup loaders 2475→2629 (and named `ViewerStartupLoad`, the actual
type), host webpart `Program.fs` 393→373, `/api` 395→375, remote-control 473→446.

**Also** — `Tests/` described as Expecto (what `runAllTests.cmd` runs; NUnit/FsUnit
are referenced but not primary), and release-notes path
`aardium/package.json` → `aardium/Aardium/package.json`, which is the file that
actually exists.

Already correct and left alone: Paket 9.0.2, Adaptify 1.3.7, Aardpack 2.0.5,
Fantomas 6.2.3, FAKE 6.1.4, `Aardvark.Data.Opc ~> 0.11.0`.

## Verification

- Diff touches **no** `.fs`, `.fsproj`, `.sln`, `paket.*` or CI file — documentation
  only, so no build or test run is required.
- Every relative markdown link in `AGENTS.md`, `CLAUDE.md` and `ai/*.md` resolves
  to an existing path (checked relative to each file's own directory).
- Every version in the technology-stack table checked individually against its
  source file, not sampled.
