### PR TITLE
GUI fixes: group tree icons, DistanceFilter home position, traverse label size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ testbed-output/
 # test run artifacts
 /Aardvark.log
 /logs/
+/tools/profileDrawing/test_profile_*.svg
 
 # Yarn (Berry) local state / cache
 **/.yarn/*

--- a/docs/SurfaceDistanceFilter.md
+++ b/docs/SurfaceDistanceFilter.md
@@ -1,0 +1,37 @@
+# Surface Distance Filter
+
+Per-surface filter that hides all geometry farther away than a given radius from the
+surface's **home position**. Useful to cut away distant parts of a large OPC surface
+(e.g. to look at a single outcrop without the rest of the tile set in the way).
+
+## Using it
+
+The controls live in the surface properties (select a surface in the *Surfaces* panel):
+
+| Row | Meaning |
+| --- | --- |
+| `DistanceFilter` | enables the filter |
+| `FilterDistance` | radius in meters around the home position that stays visible |
+| `Home Position`  | stores the **current camera position** as the reference point; shows `set` / `not set` |
+
+**The filter has no effect until a home position is set.** There is no other reference
+point, so with `homePosition = None` the filter is silently disabled
+(`Viewer-Utils.fs`, `filterByDistance`). Workflow:
+
+1. navigate to the area of interest,
+2. click *Home Position* (the button stores the camera view and switches to `set`),
+3. tick *DistanceFilter* and adjust *FilterDistance*.
+
+The home position is saved with the scene.
+
+## Implementation
+
+The test runs in the geometry shader `Shader.triangleSizeFilter` (`Viewer-Utils.fs`),
+together with the triangle size filter. Everything happens in **view space**: the home
+position is transformed on the CPU (`HomePositionViewSpace`, a clean `V3f`) and each
+triangle is discarded unless all three vertices are within `FilterDistance` of it. This
+keeps the comparison numerically stable at planetary scale — see
+[ai/CONVENTIONS.md](../ai/CONVENTIONS.md) on precision.
+
+`FilterDistance` is uploaded as `float32` (`AVal.map float32`) and read as `float32` in
+the shader; a mismatch here silently clips the whole surface away.

--- a/docs/TraverseLabels.md
+++ b/docs/TraverseLabels.md
@@ -1,0 +1,43 @@
+### Traverse Sol Labels
+
+Every traverse can display its sol numbers next to the waypoints (*Show Text* in the traverse
+properties). Two render paths exist, selected per traverse with the *Fast Text* checkbox:
+
+| Mode | Path | Trade-off |
+| --- | --- | --- |
+| *Fast Text* on (default) | `drawSolTextsFast`, one batched billboard draw (`Sg.textsWithConfig`) | fast for long traverses, but the world-space trafo is applied in `float32` in the shader, so labels jitter at planetary scale |
+| *Fast Text* off | `drawSolText` → `PRo3D.Base.Sg.text`, one stable-trafo label each | numerically stable, no jitter, slower |
+
+### Text size
+
+*Textsize* is **not** a size in meters: labels keep a constant size on screen, and the value is a
+fraction of the viewport. Both paths use the same convention, `PRo3D.Base.Sg.invariantScale`:
+
+```
+scale = tan(hfov / 2) · size · distance-to-camera
+```
+
+This is the same convention used by annotation labels, scale bars, the reference system and
+surface name labels — a *Textsize* of `0.05` (the default) means the same thing everywhere in
+PRo3D. Both paths are fed the **actual** horizontal field of view, so labels keep their size when
+the focal length changes.
+
+Do not reimplement this formula. It exists once, in `PRo3D.Base.Sg.invariantScale`; the batched
+path calls it on the CPU per label, the stable path through `invariantScaleTrafo`.
+
+### Migration of stored sizes
+
+Before this convention was shared, the batched path scaled with `size · 2 · dist · tan(hfov)` —
+a factor of **6** larger than the stable path at the 60° reference field of view, which is why
+saved scenes contain unusually small values (e.g. `0.005`).
+
+Stored values are converted when a scene is loaded (`Traverse.migrateTextSize`), so labels keep
+the size the user picked:
+
+- scenes written with the current convention carry a `tTextSizeConvention` marker and are left alone,
+- scenes without the marker have their `tTextSize` multiplied by 6 (clamped to the input's `max`),
+  unless the traverse explicitly stored `fastText = false` — the stable path formula did not change.
+
+The marker is an **additional field** read with `Json.tryRead`, so the scene file version was
+deliberately *not* bumped and older PRo3D versions still load the files. The one asymmetry: an
+older PRo3D version reading a migrated scene renders the labels 6× too large.

--- a/src/PRo3D.Base/Utilities.fs
+++ b/src/PRo3D.Base/Utilities.fs
@@ -1163,28 +1163,31 @@ module Sg =
         |> Sg.trafo trafo
 
     //## TEXT ##
-    let invariantScaleTrafo 
-        (view : aval<CameraView>) 
-        (near : aval<float>) 
-        (pos  : aval<V3d>) 
-        (size : aval<double>) 
-        (hfov : aval<float>) 
+    /// Scale factor that keeps geometry at a constant size on screen ("fixed pixel size"):
+    /// size is a fraction of the viewport and does not depend on the distance to the camera.
+    /// This is the single definition of the text size convention used throughout PRo3D
+    /// (annotations, scale bars, reference system, traverse sol labels) - the constants matter,
+    /// do not reimplement it: half the field of view, no additional factor.
+    let invariantScale (hfovInDegrees : float) (distance : float) (size : float) =
+        let hfov_rad = Conversion.RadiansFromDegrees hfovInDegrees
+        Fun.Tan(hfov_rad / 2.0) * size * distance
+
+    let invariantScaleTrafo
+        (view : aval<CameraView>)
+        (near : aval<float>)   // unused: the near plane cancels out in the scale factor
+        (pos  : aval<V3d>)
+        (size : aval<double>)
+        (hfov : aval<float>)
         : aval<Trafo3d> =
 
         adaptive {
             let! hfov = hfov
-            let hfov_rad = Conversion.RadiansFromDegrees(hfov)
-
-            let! near = near
-            let! size = size 
-            let wz = Fun.Tan(hfov_rad / 2.0) * near * size
-
+            let! size = size
             let! p = pos
             let! v = view
-            let dist = Vec.Distance(p, v.Location)
-            let scale = ( wz / near ) * dist
 
-            return Trafo3d.Scale scale
+            let dist = Vec.Distance(p, v.Location)
+            return Trafo3d.Scale (invariantScale hfov dist size)
         }
 
     let private screenAlignedTrafo (forw : V3d) (up : V3d) (modelTrafo: Trafo3d) =

--- a/src/PRo3D.Core/Drawing/Drawing.UI.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.UI.fs
@@ -230,9 +230,9 @@ module UI =
                                                   
         let setActiveAttributes = GroupsApp.setActiveGroupAttributeMap path model group GroupsMessage
                        
-        let color = sprintf "color: %s" (Html.color C4b.White)
+        let colorAttributes = GroupsApp.activeGroupColorAttributes model group ""
         let desc =
-            div [style color] [       
+            Incremental.div colorAttributes <| AList.ofList [
                 Incremental.text group.name
                 Incremental.i setActiveAttributes AList.empty 
                 |> UI.wrapToolTip DataPosition.Bottom "Set active"
@@ -257,11 +257,14 @@ module UI =
             amap {
                 yield onMouseClick (fun _ -> DrawingAction.GroupsMessage(GroupsAppAction.ToggleExpand path))
                 let! expanded = group.expanded
-                if expanded then 
+                if expanded then
                     yield clazz "icon outline open folder"
-                else 
+                else
                     yield clazz "icon outline folder"
-                    yield style "overflow-y : visible"
+                // the icon is a sibling of the (white) description div and would
+                // otherwise inherit semantic ui's default (black) on our dark background
+                let! color = GroupsApp.activeGroupColor model group
+                yield style ("overflow-y : visible; " + color)
             } |> AttributeMap.ofAMap
           
         let childrenAttribs =

--- a/src/PRo3D.Core/GroupsApp.fs
+++ b/src/PRo3D.Core/GroupsApp.fs
@@ -586,11 +586,34 @@ module GroupsApp =
 
     let activeIcon (model : AdaptiveGroupsModel)
                    (group : AdaptiveNode) =
-        adaptive { 
+        adaptive {
             let! activeGroup = model.activeGroup
             let! group  =  group.key
-            return if (activeGroup.id = group) then "circle icon" else "circle thin icon"
+            // "circle thin" is font-awesome 4; the shipped semantic ui knows only "circle outline",
+            // and silently falls back to the filled circle - making active and inactive indistinguishable
+            return if (activeGroup.id = group) then "circle icon" else "circle outline icon"
         }
+
+    /// css color for a group in the tree view: green if it is the active group, white otherwise.
+    /// (the tree renders on a dark background, hence white rather than the semantic ui default)
+    let activeGroupColor (model : AdaptiveGroupsModel)
+                         (group : AdaptiveNode) : aval<string> =
+        adaptive {
+            let! activeGroup = model.activeGroup
+            let! key = group.key
+            let c = if activeGroup.id = key then C4b.VRVisGreen else C4b.White
+            return sprintf "color: %s" (Html.color c)
+        }
+
+    /// style attributes highlighting the active group; use with Incremental.div/i so that
+    /// switching the active group only updates the style instead of rebuilding the tree node
+    let activeGroupColorAttributes (model : AdaptiveGroupsModel)
+                                   (group : AdaptiveNode)
+                                   (additionalStyle : string) =
+        amap {
+            let! color = activeGroupColor model group
+            yield style (additionalStyle + color)
+        } |> AttributeMap.ofAMap
 
     let setActiveGroupAttributeMap (path : list<Index>)
                                    (model : AdaptiveGroupsModel)

--- a/src/PRo3D.Core/Surface/Surface-Properties.fs
+++ b/src/PRo3D.Core/Surface/Surface-Properties.fs
@@ -176,15 +176,29 @@ module SurfaceProperties =
                 yield Html.row "Quality:"            [Numeric.view' [NumericInputType.Slider]   model.quality  |> UI.map SetQuality ]
                 yield Html.row "TriangleFilter:"     [GuiEx.iconCheckBox model.filterByTriangleSize ToggleFilterByTriangleSize ]
                 yield Html.row "TriangleSize:"       [Numeric.view' [NumericInputType.InputBox]   model.triangleSize  |> UI.map SetTriangleSize ]
-                yield Html.row "DistanceFilter:"     [GuiEx.iconCheckBox model.filterByDistance ToggleFilterByDistance ]
-                yield Html.row "FilterDistance:"     [Numeric.view' [NumericInputType.InputBox]   model.filterDistance  |> UI.map SetFilterDistance ]
+                yield Html.row "DistanceFilter:"     [
+                    GuiEx.iconCheckBox model.filterByDistance ToggleFilterByDistance
+                    |> UI.wrapToolTip DataPosition.Bottom
+                        "Hides all geometry farther away than FilterDistance from this surface's home position. Has no effect until a home position is set (see 'Home Position' below)."
+                ]
+                yield Html.row "FilterDistance:"     [
+                    Numeric.view' [NumericInputType.InputBox] model.filterDistance |> UI.map SetFilterDistance
+                    |> UI.wrapToolTip DataPosition.Bottom "Radius [m] around the home position kept visible when DistanceFilter is enabled."
+                ]
+                yield Html.row "Home Position:"      [
+                    button [clazz "ui button tiny"; onClick (fun _ -> SetHomePosition )] [
+                        i [clazz "home icon"] []
+                        Incremental.text (model.homePosition |> AVal.map (function None -> "not set" | Some _ -> "set"))
+                    ]
+                    |> UI.wrapToolTip DataPosition.Bottom
+                        "Stores the current camera position as this surface's home position - the reference point for DistanceFilter. Navigate to the spot of interest, then click."
+                ]
                 // Html.row "Scale:"       [Numeric.view' [NumericInputType.InputBox]   model.scaling  |> UI.map SetScaling ]
                 yield Html.row "Fillmode:"           [Html.SemUi.dropDown model.fillMode SetFillMode]                
                 yield Html.row "Scalars:"            [UI.dropDown'' (model |> scalarLayerList)  (AVal.map Adaptify.FSharp.Core.Missing.AdaptiveOption.toOption model.selectedScalar)  (fun x -> SetScalarMap (x |> Option.map(fun y -> y.Current |> AVal.force)))   (fun x -> x.label |> AVal.force)]
                 // Html.row "Scalars:"     [UI.dropDown'' (model |> scalarLayerList)  model.selectedScalar   (fun x -> SetScalarMap (x |> Option.map(fun y -> y.Current ))) (fun x -> x.label |> AVal.force)]
                        
                 yield Html.row "Cull Faces:"        [Html.SemUi.dropDown model.cullMode SetCullMode]
-                yield Html.row "Set Homeposition:"  [button [clazz "ui button tiny"; onClick (fun _ -> SetHomePosition )] []] //[text "DiscoverOpcs" ]  
 
                 yield Html.row "OPCx Info path:"    [div [style "max-width: 200px"] [Incremental.text (model.opcxPath |> AVal.map (function None -> "none" | Some p -> p))]]
                 yield Html.row "Primary Texture:"   [UI.dropDown'' model.textureLayers model.primaryTexture  (fun x -> SetPrimaryTexture x) (fun x -> x.label)]

--- a/src/PRo3D.Core/Surface/SurfaceApp.fs
+++ b/src/PRo3D.Core/Surface/SurfaceApp.fs
@@ -1289,28 +1289,27 @@ module SurfaceApp =
 
         alist {
 
-            let! s = model.activeGroup
-            let color = sprintf "color: %s" (Html.color C4b.White)                
-            let children = AList.collecti (fun i v -> viewTree scenePath (i::path) v model) group.subNodes    
+            let children = AList.collecti (fun i v -> viewTree scenePath (i::path) v model) group.subNodes
             let activeAttributes = GroupsApp.setActiveGroupAttributeMap path model group GroupsMessage
-                                   
-            let toggleIcon = 
+            let colorAttributes = GroupsApp.activeGroupColorAttributes model group ""
+
+            let toggleIcon =
                 AVal.constant "unhide icon" //group.visible |> AVal.map(fun toggle -> if toggle then "unhide icon" else "hide icon")                
 
             let toggleAttributes = GroupsApp.clickIconAttributes toggleIcon (GroupsMessage(GroupsAppAction.ToggleGroup path))
                
             let desc =
-                div [style color] [       
+                Incremental.div colorAttributes <| AList.ofList [
                     Incremental.text group.name
-                    Incremental.i activeAttributes AList.empty 
+                    Incremental.i activeAttributes AList.empty
                     |> UI.wrapToolTip DataPosition.Bottom "Set active"
-                        
-                    i [clazz "plus icon"
-                       onMouseClick (fun _ -> 
-                         GroupsMessage(GroupsAppAction.AddGroup path))] []
-                    |> UI.wrapToolTip DataPosition.Bottom "Add Group"           
 
-                    Incremental.i toggleAttributes AList.empty 
+                    i [clazz "plus icon"
+                       onMouseClick (fun _ ->
+                         GroupsMessage(GroupsAppAction.AddGroup path))] []
+                    |> UI.wrapToolTip DataPosition.Bottom "Add Group"
+
+                    Incremental.i toggleAttributes AList.empty
                     |> UI.wrapToolTip DataPosition.Bottom "Toggle Group"
                    // GuiEx.iconCheckBox group.visible (GroupsMessage(Groups.ToggleGroup path))
                 ]
@@ -1319,10 +1318,13 @@ module SurfaceApp =
                 amap {
                     yield onMouseClick (fun _ -> SurfaceAppAction.GroupsMessage(GroupsAppAction.ToggleExpand path))
                     let! selected = group.expanded
-                    if selected 
+                    if selected
                     then yield clazz "icon outline open folder"
                     else yield clazz "icon outline folder"
-                    yield style "overflow-y : visible"
+                    // the icon is a sibling of the (white) description div and would
+                    // otherwise inherit semantic ui's default (black) on our dark background
+                    let! color = GroupsApp.activeGroupColor model group
+                    yield style ("overflow-y : visible; " + color)
                 } |> AttributeMap.ofAMap
             
             let childrenAttribs =

--- a/src/PRo3D.Core/Traverse-Model.fs
+++ b/src/PRo3D.Core/Traverse-Model.fs
@@ -581,6 +581,23 @@ module Traverse =
     let withColor(color: C4b) (t: Traverse) =
         { t with color = { c = color } }
 
+    /// Sol labels used to be scaled with `size * 2 * dist * tan(hfov)` in the batched ("fast")
+    /// text path instead of the common `size * dist * tan(hfov/2)` convention
+    /// (PRo3D.Base.Sg.invariantScale) - a factor of 6 at the 60 deg reference field of view the
+    /// stable path assumed. Values tuned against the old formula are converted on load so labels
+    /// keep the size the user picked.
+    let private legacyFastTextSizeFactor = 6.0
+
+    /// Scenes written with the current convention carry a "tTextSizeConvention" marker. It is an
+    /// *additional* field read with tryRead - no scene file version bump, older PRo3D versions
+    /// simply ignore it (they do render migrated labels 6x too large, though).
+    let private migrateTextSize (convention: Option<int>) (fastText: bool) (textSize: NumericInput) =
+        match convention with
+        | Some _ -> textSize                 // already written with the current convention
+        | None when not fastText -> textSize // the stable path formula did not change
+        | None ->
+            { textSize with value = min textSize.max (textSize.value * legacyFastTextSizeFactor) }
+
     let readV0 =
         json {
             let! sols = Json.read "sols"
@@ -613,6 +630,7 @@ module Traverse =
             let! showLines = Json.read "showLines"
             let! showText = Json.read "showText"
             let! tTextSize = Json.readWith Ext.fromJson<NumericInput, Ext> "tTextSize"
+            let! textSizeConvention = Json.tryRead "tTextSizeConvention"
             let! tLWidth = Json.tryRead "tLineWidth"
             let! showDots = Json.read "showDots"
             let! isVisibleT = Json.read "isVisibleT"
@@ -620,15 +638,15 @@ module Traverse =
             let! heightOffset = Json.tryRead "heightOffset"
             let! priorityEnabled = Json.tryRead "priorityEnabled"
 
-            let tLineWidth = 
+            let tLineWidth =
                 match tLWidth with
                 | Some w -> InitTraverseParams.tLineW w
                 | None -> InitTraverseParams.tLineW 1.5
 
-            let! priority = Json.tryRead "priority" 
+            let! priority = Json.tryRead "priority"
 
             return
-                { ( empty () ) with 
+                { ( empty () ) with
                     version = current
                     guid = guid |> Guid
                     tName = tName
@@ -636,7 +654,8 @@ module Traverse =
                     selectedSol = None
                     showLines = showLines
                     showText = showText
-                    tTextSize = tTextSize
+                    // this version predates the fastText flag, so these labels were drawn by the fast path
+                    tTextSize = migrateTextSize textSizeConvention true tTextSize
                     tLineWidth = tLineWidth
                     showDots = showDots
                     isVisibleT = isVisibleT
@@ -655,6 +674,7 @@ module Traverse =
             let! showLines = Json.read "showLines"
             let! showText = Json.read "showText"
             let! tTextSize = Json.readWith Ext.fromJson<NumericInput, Ext> "tTextSize"
+            let! textSizeConvention = Json.tryRead "tTextSizeConvention"
             let! tLWidth = Json.tryRead "tLineWidth"
             let! showDots = Json.read "showDots"
             let! isVisibleT = Json.read "isVisibleT"
@@ -704,7 +724,7 @@ module Traverse =
                     showLines = showLines
                     showText = showText
                     fastText = fastText |> Option.defaultValue true
-                    tTextSize = tTextSize
+                    tTextSize = migrateTextSize textSizeConvention (fastText |> Option.defaultValue true) tTextSize
                     tLineWidth = tLineWidth
                     showDots = showDots
                     isVisibleT = isVisibleT
@@ -743,6 +763,9 @@ type Traverse with
             do! Json.write "showText" x.showText
             do! Json.write "fastText" x.fastText
             do! Json.writeWith (Ext.toJson<NumericInput, Ext>) "tTextSize" x.tTextSize
+            // marks tTextSize as written with the invariantScale convention (see Traverse.migrateTextSize).
+            // additional field, read with tryRead - deliberately no scene file version bump
+            do! Json.write "tTextSizeConvention" 1
             do! Json.write "showDots" x.showDots
             do! Json.write "isVisibleT" x.isVisibleT
             do! Json.writeWith (Ext.toJson<ColorInput, Ext>) "color" x.color

--- a/src/PRo3D.GIS/GisApp.fs
+++ b/src/PRo3D.GIS/GisApp.fs
@@ -422,15 +422,14 @@ module GisApp =
                      (surfaces : AdaptiveGroupsModel) 
                      (m : AdaptiveGisApp) =
         alist {
-            let! s = surfaces.activeGroup
-            let color = sprintf "color: %s" (Html.color C4b.White)                
-            let children = AList.collecti (fun i v -> viewTree (i::path) v surfaces m) group.subNodes    
+            let children = AList.collecti (fun i v -> viewTree (i::path) v surfaces m) group.subNodes
             let activeAttributes = GroupsApp.setActiveGroupAttributeMap path surfaces group GroupsMessage
-                                   
+            let colorAttributes = GroupsApp.activeGroupColorAttributes surfaces group ""
+
             let desc =
-                div [style color] [       
+                Incremental.div colorAttributes <| AList.ofList [
                     Incremental.text group.name
-                    Incremental.i activeAttributes AList.empty 
+                    Incremental.i activeAttributes AList.empty
                     |> UI.wrapToolTip DataPosition.Bottom "Set active"
                 ]
                  
@@ -438,10 +437,13 @@ module GisApp =
                 amap {
                     yield onMouseClick (fun _ -> SurfaceAppAction.GroupsMessage(GroupsAppAction.ToggleExpand path))
                     let! selected = group.expanded
-                    if selected 
+                    if selected
                     then yield clazz "icon outline open folder"
                     else yield clazz "icon outline folder"
-                    yield style "overflow-y : visible"
+                    // the icon is a sibling of the (white) description div and would
+                    // otherwise inherit semantic ui's default (black) on our dark background
+                    let! color = GroupsApp.activeGroupColor surfaces group
+                    yield style ("overflow-y : visible; " + color)
                 } |> AttributeMap.ofAMap
             
             let childrenAttribs =

--- a/src/PRo3D.Viewer/Bookmarks.fs
+++ b/src/PRo3D.Viewer/Bookmarks.fs
@@ -333,13 +333,11 @@ module Bookmarks =
 
         alist {
 
-            let! active = model.activeGroup
-            let color = sprintf "color: %s" (Html.color C4b.White)                
-            
             let map = GroupsApp.setActiveGroupAttributeMap path model group GroupsMessage
-               
+            let colorAttributes = GroupsApp.activeGroupColorAttributes model group ""
+
             let desc =
-                div [style color] [       
+                Incremental.div colorAttributes <| AList.ofList [
                     Incremental.text group.name
                     Incremental.i map AList.empty |> UI.wrapToolTip DataPosition.Bottom "Set active"
                         
@@ -353,10 +351,13 @@ module Bookmarks =
                 amap {
                     yield onMouseClick (fun _ -> BookmarkAction.GroupsMessage(GroupsAppAction.ToggleExpand path))
                     let! selected = group.expanded
-                    if selected 
+                    if selected
                     then yield clazz "icon large outline open folder"
                     else yield clazz "icon large outline folder"
-                    yield style "overflow-y : visible"
+                    // the icon is a sibling of the (white) description div and would
+                    // otherwise inherit semantic ui's default (black) on our dark background
+                    let! color = GroupsApp.activeGroupColor model group
+                    yield style ("overflow-y : visible; " + color)
                 } |> AttributeMap.ofAMap
             
             let childrenAttribs =

--- a/src/PRo3D.Viewer/Properties/launchSettings.json
+++ b/src/PRo3D.Viewer/Properties/launchSettings.json
@@ -20,7 +20,7 @@
       "commandLineArgs": "--disableCors --port 4321 --remoteApi --defaultSpiceKernel \"../../../../spice/kernels/mk/hera_ops.tm\"",
       "nativeDebugging": true
     },
-    "Profile 1": {
+    "default": {
       "commandName": "Project",
       "nativeDebugging": true
     }

--- a/src/PRo3D.Viewer/TraverseApp.fs
+++ b/src/PRo3D.Viewer/TraverseApp.fs
@@ -568,16 +568,12 @@ module TraverseApp =
                     let hfov = horizontalFovInDegrees.GetValue(token)
                     sols 
                     |> Seq.toArray
-                    |> Array.map (fun sol -> 
-                        let scaleTrafo = 
-                            let screenSpaceScaling = true
-                            if screenSpaceScaling then
-                                let distance = Vec.distance sol.location[0] view.Location
-                                let scaling = size * 2.0 * distance * Math.Tan(Conversion.RadiansFromDegrees hfov)
-                                Trafo3d.Scale(scaling)
-                            else
-                                Trafo3d.Scale(size) 
-                                
+                    |> Array.map (fun sol ->
+                        // same screen-constant size convention as the stable path (PRo3D.Base.Sg.text)
+                        let scaleTrafo =
+                            let distance = Vec.distance sol.location[0] view.Location
+                            Trafo3d.Scale(PRo3D.Base.Sg.invariantScale hfov distance size)
+
                         let loc = sol.location[0] + sol.location[0].Normalized * 1.5
                         let trafo = scaleTrafo * (Trafo3d.Translation loc)
 
@@ -597,7 +593,7 @@ module TraverseApp =
                 //|> Sg.viewTrafo' Trafo3d.Identity
             sg 
 
-        let drawSolText view near (model : AdaptiveTraverse) =
+        let drawSolText view (horizontalFovInDegrees : aval<float>) near (model : AdaptiveTraverse) =
             alist {
                 let! sols = model.sols
                 let! showText = model.showText
@@ -607,7 +603,7 @@ module TraverseApp =
                         let loc = ~~(sol.location[0] + sol.location[0].Normalized * 1.5)
                         let trafo = loc |> AVal.map Trafo3d.Translation
                         
-                        yield Sg.text view near (AVal.constant 60.0) loc trafo model.tTextSize.value  (~~sol.solNumber.ToString()) (AVal.constant C4b.White)
+                        yield Sg.text view near horizontalFovInDegrees loc trafo model.tTextSize.value  (~~sol.solNumber.ToString()) (AVal.constant C4b.White)
             } 
             |> ASet.ofAList 
             |> Sg.set
@@ -624,7 +620,7 @@ module TraverseApp =
                         drawSolTextsFast view horiztonalFieldOfViewInDegrees near traverse
                     else
                         // per-label stable-trafo text: slower, numerically stable
-                        drawSolText view near traverse)
+                        drawSolText view horiztonalFieldOfViewInDegrees near traverse)
                 |> Sg.dynamic
                 |> Sg.trafo (getTraverseOffsetTransform refSystem traverse)
 


### PR DESCRIPTION
Three unrelated GUI/rendering fixes reported from a 6.0.0 build.

**Group trees** (surfaces, annotations, bookmarks, GIS)
- `circle thin` is font-awesome 4 and no longer renders in the semantic ui bundle of Aardvark.UI 5.7, so the active group indicator was always a filled circle. Now `circle outline`.
- Group names were hard coded to white; the active group is now highlighted.
- The folder icon inherited semantic ui's default black on our dark panels; it is now colored explicitly.

**Surface DistanceFilter**
The filter is silently disabled while a surface has no home position. Adds tooltips, labels the previously empty button, shows set/not set, and moves it next to the filter rows. New `docs/SurfaceDistanceFilter.md`.

**Traverse sol labels**
The batched path scaled with `size * 2 * dist * tan(hfov)` instead of `size * dist * tan(hfov/2)` (6x off at 60 deg), and the stable path used a hard coded 60 deg fov. Both now share `PRo3D.Base.Sg.invariantScale`, so Textsize means the same as for annotations and scale bars. Stored sizes are migrated on load via a `tTextSizeConvention` marker - an additional field read with `tryRead`, **no scene file version bump**; older PRo3D versions still load the files but render migrated labels 6x too large. New `docs/TraverseLabels.md`.

Builds clean. Not verified in the running app - worth eyeballing a traverse in both text modes.