### PR TITLE
fix(screenshot): unwrap the double-encoded /rendering/stats.json body

### DIFF
--- a/src/PRo3D.Base/Utilities.fs
+++ b/src/PRo3D.Base/Utilities.fs
@@ -1444,17 +1444,32 @@ module ScreenshotUtilities =
               frameTime       : float
           }
 
+        /// Aardvark.UI's /rendering/stats.json handler pickles the statistics to a string and
+        /// then hands that string to http.json, which pickles it a second time
+        /// (RenderServer.fs: `http.json (Pickler.json.PickleToString stats)`, Aardvark.UI 5.7.3).
+        /// The body is therefore a JSON string wrapping the actual payload. Peel that layer off
+        /// when it is there, so we keep working against both the current and a fixed
+        /// aardvark.media. See https://github.com/aardvark-platform/aardvark.media/issues/53
+        let private unwrapDoubleEncodedJson (body : string) =
+            if body.TrimStart().StartsWith "\"" then
+                try Newtonsoft.Json.JsonConvert.DeserializeObject<string> body with _ -> body
+            else
+                body
+
         let downloadClientStatistics baseAddress (httpClient : HttpClient) =
             let path = sprintf "%s/rendering/stats.json" baseAddress //sprintf "%s/rendering/stats.json" baseAddress
             Log.line "[Screenshot] querying rendering stats at: %s" path
-            let result = httpClient.GetStringAsync(path).Result
+            let result = httpClient.GetStringAsync(path).Result |> unwrapDoubleEncodedJson
 
             let clientBla : list<ClientStatistics> =
-                Pickler.unpickleOfJson  result
+                try
+                    Pickler.unpickleOfJson result
+                with e ->
+                    failwithf "Could not parse client statistics from %s: %s (body was: %s)" path e.Message result
 
-            match clientBla.Length with
-            | 1 | 2 -> clientBla // clientBla.[1] 
-            | _ -> failwith (sprintf "Could not download client statistics for %s" path)  //"no client bla"
+            match clientBla with
+            | [] -> failwith (sprintf "No rendering client reported statistics at %s" path)
+            | _ -> clientBla
 
         let getScreenshotUrl baseAddress clientStatistic width height =                                
 
@@ -1486,11 +1501,11 @@ module ScreenshotUtilities =
             let clientStatistics = downloadClientStatistics baseAddress httpClient
             
             let cs =
-                match clientStatistics.Length with
-                | 2 -> clientStatistics.[1] 
-                | 1 -> clientStatistics.[0]
-                | _ -> failwith (sprintf "Could not download client statistics")
-                
+                match clientStatistics with
+                | _ :: second :: _ -> second
+                | first :: _ -> first
+                | [] -> failwith (sprintf "Could not download client statistics")
+
             let screenshot = getScreenshotUrl baseAddress cs width height
             let filename = getScreenshotFilename folder name cs format
             httpClient.DownloadFile(screenshot,filename)        

--- a/src/PRo3D.SimulatedViews/Screenshots/ScreenshotApp.fs
+++ b/src/PRo3D.SimulatedViews/Screenshots/ScreenshotApp.fs
@@ -25,7 +25,10 @@ module ScreenshotApp =
         let stats = ScreenshotUtilities.Utilities.downloadClientStatistics baseUrl httpClient
         
         let color = m.backgroundColor.c.ToC4f().ToV4f()
-        let renderingNodeId = stats.[0].name
+        let renderingNodeId =
+            match stats with
+            | first :: _ -> first.name
+            | [] -> failwith "[Screenshots] no rendering client available"
         let url = 
             sprintf "%s/rendering/screenshot/%s?w=%i&h=%i&samples=%i&fmt=%s&background=[%f,%f,%f,%f]" 
                 baseUrl 


### PR DESCRIPTION
Fixes #660 — taking a screenshot from the GUI has been dead since the Suave -> Giraffe port (6.0.0-prerelease4-media57), throwing

```
Error deserializing object of type 'FSharpList`1[…ClientStatistics]'
 ---> expected start of Json object but was 'String'.
```

### Cause

Upstream, in Aardvark.UI 5.7.3. `RenderServer.fs` pickles the statistics to a string and then hands that string to `http.json`, which pickles it a **second** time:

```fsharp
let stats = clients |> Array.map _.GetStatistics() |> Array.filter (fun s -> s.frameCount > 0)
http.json (Pickler.json.PickleToString stats)      // http.json already serializes its argument
```

So `/rendering/stats.json` answers with a JSON *string* wrapping the payload rather than the payload itself, and since Aardvark.UI's pickler is created with `omitHeader = true` (the first token has to be the value), unpickling blows up. Confirmed against a running `PRo3D.Viewer.exe --port 54321`:

```
$ curl -i http://localhost:54321/rendering/stats.json
HTTP/1.1 200 OK
Content-Type: application/json

"[{\"session\":\"f66df171-…\",\"name\":\"n1241\",\"frameCount\":3,\"invalidateTime\":0.011,…}]"
```

Filed upstream as aardvark-platform/aardvark.media#53.

### Change

`downloadClientStatistics` peels the extra encoding layer off when it is there, so PRo3D works against both the current and a fixed aardvark.media — no package pin needed, and nothing to revert once upstream lands.

```fsharp
let private unwrapDoubleEncodedJson (body : string) =
    if body.TrimStart().StartsWith "\"" then
        try Newtonsoft.Json.JsonConvert.DeserializeObject<string> body with _ -> body
    else
        body
```

Folded in while here:

* a parse failure now reports the offending body instead of a bare FsPickler exception,
* `downloadClientStatistics` no longer rejects more than two render clients (it only rejects an empty list now),
* the two unchecked list indexings — `stats.[0]` in `ScreenshotApp.createUrl` and `clientStatistics.[1]` in `takeScreenshot` — are pattern matches, per the total-functions rule in CLAUDE.md. Selection behaviour is unchanged (`createUrl` takes the first client, `takeScreenshot` the second when there is one).

### Verification

Against a live `PRo3D.Viewer.exe --port 54321`, using the real response body:

* unpickling the **raw** body reproduces the reported exception,
* unpickling the **unwrapped** body succeeds (`name=n1241 frameCount=3`),
* the unwrap is a **no-op** on a correctly encoded body, i.e. on what a fixed aardvark.media will send.

And the endpoint the recovered name feeds into is fine:

```
$ curl -g -o shot.png "http://localhost:54321/rendering/screenshot/n1241?w=640&h=480&samples=4&fmt=png&background=[0,0,0,1]"
http=200 type=image/png size=1075   ->  PNG image data, 640 x 480, 8-bit/color RGB
```

Solution builds clean (the one warning in `InstrumentProjection.fs` is pre-existing).

### Not in this PR

* No `PRODUCT_RELEASE_NOTES.md` entry — in this repo those are written in the release commit.
* `ClientStatistics` is still declared three times (`PRo3D.Base/Utilities.fs:123`, `:1436`, `PRo3D.Viewer/RemoteControlApp.fs:16`), and `PRo3D.Viewer/Utilities.fs:34 Net.getClient` is dead code with a hardcoded port 54321. Both noted on #660.
* `PRo3D.Snapshots` goes through the same `downloadClientStatistics`, so it is fixed by this change too, but I have not run a batch snapshot render to confirm.
