### PR TITLE
fix(refsys): stop navigation from dragging the coordinate system origin along

### DIFF
--- a/src/PRo3D.Core/ReferenceSystem-Model.fs
+++ b/src/PRo3D.Core/ReferenceSystem-Model.fs
@@ -40,7 +40,10 @@ type ReferenceSystemConfig<'a> = {
 
 type ReferenceSystemAction =
     | InferCoordSystem   of V3d
+    /// places the reference system at the given position (moves `origin`)
     | UpdateUpNorth      of V3d
+    /// recomputes up/north for the given position but leaves `origin` where the user put it
+    | RefreshUpNorth     of V3d
     | SetUp              of Vector3d.Action
     | SetNorth           of Vector3d.Action
     | SetNOffset         of Numeric.Action

--- a/src/PRo3D.Core/ReferenceSystem.fs
+++ b/src/PRo3D.Core/ReferenceSystem.fs
@@ -78,7 +78,12 @@ module ReferenceSystemApp =
         let east = V3d.OOI.Cross(up).Normalized
         up.Cross(east).Normalized
     
-    let updateCoordSystem (p:V3d) (planet:Planet) (model : ReferenceSystem) = 
+    /// Recomputes up/north/northO for the position p. `placeOrigin` decides whether the
+    /// reference system is also *moved* there: placing the coordinate system does, refreshing
+    /// the orientation while navigating must not — `origin` is where the cross is drawn
+    /// (Sg.view), what the reference system panel reports and what gets persisted into scenes
+    /// and bookmarks. See https://github.com/pro3d-space/PRo3D/issues/662
+    let updateCoordSystemAt (placeOrigin:bool) (p:V3d) (planet:Planet) (model : ReferenceSystem) =
         let up = upVector p planet
         let north  = 
             match planet with 
@@ -92,10 +97,13 @@ module ReferenceSystemApp =
             model with 
                 north  = ReferenceSystem.setV3d north
                 up     = ReferenceSystem.setV3d up
-                northO = no 
+                northO = no
                 planet = planet
-                origin = p
+                origin = if placeOrigin then p else model.origin
         }
+
+    let updateCoordSystem (p:V3d) (planet:Planet) (model : ReferenceSystem) =
+        updateCoordSystemAt true p planet model
 
     let update<'a> 
         (bigConfig  : 'a) 
@@ -111,6 +119,8 @@ module ReferenceSystemApp =
             m, bigConfig
         | UpdateUpNorth p ->
             updateCoordSystem p model.planet model, bigConfig
+        | RefreshUpNorth p ->
+            updateCoordSystemAt false p model.planet model, bigConfig
         | SetUp up ->    
             let up = Vector3d.update model.up up
             let up = ReferenceSystem.setV3d up.value.Normalized

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -245,16 +245,24 @@ module ViewerApp =
         | DockNodeConfig.Stack (weight,activeId,children) -> Stack(weight, activeId, List.append [de] children)
         | DockNodeConfig.Element element ->  Stack(0.2, None, List.append [de] [element]) 
 
-    let private updateUpNorthForPosition (pos : V3d) (m : Model) = 
-        let (refSystem',_) = 
+    let private updateReferenceSystemAt (action : V3d -> ReferenceSystemAction) (pos : V3d) (m : Model) =
+        let (refSystem',_) =
             pos
-            |> ReferenceSystemAction.UpdateUpNorth //updates position
-            |> ReferenceSystemApp.update 
-                m.scene.config 
-                LenseConfigs.referenceSystemConfig 
+            |> action
+            |> ReferenceSystemApp.update
+                m.scene.config
+                LenseConfigs.referenceSystemConfig
                 m.scene.referenceSystem
-                                                 
-        { m with scene = { m.scene with referenceSystem = refSystem' }} 
+
+        { m with scene = { m.scene with referenceSystem = refSystem' }}
+
+    /// places the reference system at pos - moves the coordinate cross there
+    let private updateUpNorthForPosition (pos : V3d) (m : Model) =
+        updateReferenceSystemAt ReferenceSystemAction.UpdateUpNorth pos m
+
+    /// keeps up/north current for pos while leaving the coordinate cross where the user put it
+    let private refreshUpNorthForPosition (pos : V3d) (m : Model) =
+        updateReferenceSystemAt ReferenceSystemAction.RefreshUpNorth pos m
 
     let private createMultiSelectBox (startPoint: V2i) (viewPortSize: V2i) (currentPoint: V2i) =
         let clippingBox = Box2i.FromSize viewPortSize
@@ -504,7 +512,9 @@ module ViewerApp =
             |> logScreenOption 10000 feedback 
             |> Optic.set _navigation nav
             |> Optic.set _animationView nav.camera.view
-            |> updateUpNorthForPosition nav.camera.view.Location
+            // orientation only - navigating must not drag the reference system origin along,
+            // see https://github.com/pro3d-space/PRo3D/issues/662
+            |> refreshUpNorthForPosition nav.camera.view.Location
         | NavigationMessage msg, _ ->
             m // cases where navigation is blocked by other operations (e.g. animation)
         | AnimationMessage msg,_ -> // belongs to deprecated animation


### PR DESCRIPTION
Fixes #662 — the reference-system coordinate cross disappears as soon as you click or scroll in the render view.

### Cause

`Viewer.fs:507` refreshes the reference system at the camera position on every navigation message:

```fsharp
|> updateUpNorthForPosition nav.camera.view.Location
```

That dispatches `ReferenceSystemAction.UpdateUpNorth`, which lands in `updateCoordSystem` — and that sets **`origin`** along with the orientation (`ReferenceSystem.fs:97`, a coupling in place since `1e57216d4`, 2021). Since every marker of the cross is drawn at `model.origin` (`Sg.fs:178, 191, 256, 269, 282`), each navigation event teleports the cross onto the camera, inside the near plane. Every mouse down/up and every wheel event is a `NavigationMessage` (`Viewer.fs:2166-2179`), which is why a click that does not move the camera at all still loses it.

`origin` is not only the cross: the reference-system panel reports its lat/lon, it is persisted into scene files (`ReferenceSystem-Model.fs:211`) and into every sequenced bookmark (`SequencedBookmarks-Model.fs:158`), and `TransformationApp.fs:208` uses it for the surface trafo in the no-pivot fallback path. All of those drifted with the camera too.

Introduced by `a7262330` / `7d96a2ccf` on `features/OverViewController`; first shipped in `v6.0.0-prerelease5`. Not in `main`.

### Change

Split the two concerns that `UpdateUpNorth` had rolled into one:

* `updateCoordSystemAt (placeOrigin : bool) …` — recomputes up/north/northO, and moves `origin` only when asked. `updateCoordSystem` keeps its old signature and behaviour (`placeOrigin = true`).
* new action `RefreshUpNorth of V3d` — orientation only.
* `Viewer.fs` gets `refreshUpNorthForPosition` next to `updateUpNorthForPosition`, both built on one helper; the `NavigationMessage` handler uses the refreshing one.

Placing the coordinate system (`Interactions.PlaceCoordinateSystem`) and `InferCoordSystem` on import still move the origin exactly as before, so the only behaviour that changes is navigation.

### Kept deliberately

The up/north **refresh** on navigation stays. That was the point of the original commit: the OverView/MapView controller read `up`/`north` off the reference system, and on a curved body they change as the camera moves.

Worth a follow-up decision, though — the original motivation has since evaporated. `MapViewController.updateCameraForMapView` (`928161e0`) derives up/north itself from planet + camera position, and the `CameraView.withUp (smallConfig.north …)` lines in the MapView branch are commented out (`Navigation.fs:113-116`). The only live reader left is the FreeFly branch of `SetNavigationMode` (`Navigation.fs:173`, `bodyAwareSky`), which could compute up on the spot instead. The refresh could then be restricted to MapView mode or dropped entirely.

That matters because dip & strike are computed against `referenceSystem.up.value` / `northO` (`Drawing-Properties.fs:74`), so with the refresh in place those results depend on where the camera is standing, whereas before 6.0 they only changed when the user placed the coordinate system. Whether that is an improvement or a regression is a domain call — flagged in #662 rather than decided here, since fixing the reported bug does not require it.

### Verification

Full solution builds clean; no new incomplete-match warnings from the added action case.

I have **not** confirmed this visually in the running app — that needs an OPC surface loaded and I have no dataset here. If someone can point me at one (or just try the branch), the check is: place a coordinate system, then click and scroll — the cross should stay put, and the lat/lon in the reference-system panel should stop tracking the camera.
