### PR TITLE
fix(cross-section): don't clip against an unfilled attribute (Apple Silicon dark quads)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ testbed-output/
 !**/.yarn/sdks
 !**/.yarn/versions
 src/Tests/logs/
+
+# harness / bisect screenshot output
+capture-output/
+opcviewer-output/

--- a/docs/CrossSections.md
+++ b/docs/CrossSections.md
@@ -67,6 +67,55 @@ Next choose curtain settings and set up the curtain:
 
 ![alt text](images/crossSectionAndCurtain.png)
 
+## How clipping is implemented
+
+`Surface.Sg` writes a **signed distance to the cross-section polygon** into a per-vertex
+`InsideOutsideV4` attribute (negative inside), interpolated across triangles so the clip
+edge is smooth rather than snapping to mesh-edge midpoints. The `crossSectionClip`
+fragment stage in `ViewerUtils.surfaceEffect` discards fragments whose interpolated
+distance is negative.
+
+Two flags gate it, and they are not redundant:
+
+- **`CrossSectionClippingEnabled`** — the user's Clipping checkbox. Defaults to **true**
+  (`CrossSection-Model.fs`), so it only means "clip if there is something to clip against".
+- **`CrossSectionDefined`** — whether a cross-section actually exists.
+
+### Why `CrossSectionDefined` exists
+
+Without it, the clip shader ran on every scene from the first frame, before any
+cross-section was defined. In that state `Surface.Sg` binds `InsideOutsideV4` as a
+*constant* vertex attribute (`SingleValueBuffer`) — and **on Apple Silicon that value does
+not arrive**. Whole patches read back garbage instead of the bound zero; roughly half of
+it is negative, so the shader discarded a mesh-grid lattice of fragments across the
+terrain.
+
+Substituting a real zero-filled `ArrayBuffer` makes the same machine read exact zeros,
+which pins the fault to the constant-attribute path specifically rather than to this
+attribute or shader. **What is wrong with that path has not been established.** Two
+candidates, neither verified: Apple's GL driver, or how Aardvark's GL backend drives it
+(`glVertexAttrib*f` sets *context* state rather than VAO state, and only takes effect
+while the attribute array is disabled — either could leave a per-draw value stale or let
+another buffer be read instead). Do not repeat either as fact without testing it; if it
+turns out to be the backend, it belongs upstream in Aardvark.Rendering.
+
+The real buffer is not used as the fix because it would cost an extra `Patch.load` per
+patch on the no-cross-section path, which is almost always. Guarding the shader costs
+nothing.
+
+That was the Apple-Silicon-only "regular dark quads" artefact. It never reproduced on
+Windows or Linux, and never in the headless harness, which does not bind the attribute at
+all. It was found by bisecting `surfaceEffect` one stage at a time — see
+[OpcViewer-Screenshot-Harness.md](OpcViewer-Screenshot-Harness.md#bisecting-the-viewers-surface-effect).
+
+**If you touch this path:** do not make the shader read `InsideOutsideV4` when no
+cross-section is defined. `PRO3D_SURFACE_EFFECT_ADD=crossSectionDebug` paints the
+attribute instead of discarding on it (green = 0, red = negative, blue = positive); with
+no cross-section it must be uniformly green.
+
+`SingleValueBuffer` is used in exactly one place in the repo (this attribute). Treat any
+new use as suspect on Apple Silicon.
+
 ## Future work
 
 This might be interesting: https://www.youtube.com/watch?v=RKH1gKXCD6A

--- a/docs/OpcViewer-Screenshot-Harness.md
+++ b/docs/OpcViewer-Screenshot-Harness.md
@@ -1,0 +1,162 @@
+# OpcViewer Screenshot Harness
+
+A headless renderer for OPC datasets that writes PNGs instead of opening a window, built
+for reproducing and bisecting surface rendering artefacts.
+
+The interesting bugs in the OPC pipeline — precision loss at planetary scale, driver
+differences between Apple Silicon and the Windows/Linux GL stacks — only appear on real
+data from a specific camera. Reproducing them by hand through the full viewer is slow and
+not repeatable. This turns a bug report into one command.
+
+Source: [`src/OpcViewer/ScreenshotViewer.fs`](../src/OpcViewer/ScreenshotViewer.fs),
+CLI in [`src/OpcViewer/Program.fs`](../src/OpcViewer/Program.fs).
+
+## Quick start
+
+```bash
+dotnet build src/OpcViewer/OpcViewer.fsproj -c Release
+dotnet bin/Release/net9.0/OpcViewer.dll --dataset victoria --data-root /path/to/data --out ./shots
+```
+
+That renders the whole effect ladder (see below) and writes one PNG per rung.
+
+## The effect ladder
+
+The point of the tool. `--stack` selects how much of the viewer's real surface effect
+(`ViewerUtils.surfaceEffect`) to run; the rungs are cumulative and composed in the
+viewer's own order:
+
+| rung | adds | rules out if clean |
+|------|------|--------------------|
+| `minimal` | `stableTrafo` + diffuse texture | OPC geometry, the LOD tree, texture loading |
+| `filter`  | `triangleSizeFilter` (geometry shader) | the view-space triangle filter |
+| `normals` | `generateNormal` (a *second* geometry shader composed onto the first) | geometry-shader composition |
+| `lit`     | planet-local lighting + `solarLighting` | the lighting path |
+| `color`   | `mapColorAdaption` + `mapRadiometry` | the colour chain |
+
+With no `--stack`, every rung is rendered. The rung where an artefact first appears is the
+stage that causes it.
+
+These are the viewer's own shaders, not copies. `stableTrafo` and `triangleSizeFilter`
+were moved to `PRo3D.Base.OpcSurfaceShader` specifically so both the viewer and this
+harness compose the same code — a copied shader would drift and quietly invalidate every
+result the tool produces.
+
+## Cameras
+
+`--eye X Y Z --bearing <deg> --pitch <deg>` takes exactly the numbers PRo3D's on-screen
+readout prints, so a bad frame in the viewer is reproduced by copying three values off the
+screen rather than guessing at a look-at pair. Up is the planetocentric radial direction.
+
+`--look-at X Y Z` gives an explicit target instead. With neither, the preset's camera is
+used, falling back to framing from the dataset bounding box.
+
+## Presets
+
+A preset is a dataset path relative to `--data-root` plus the camera an artefact is
+visible from. `--data-root` defaults to `$PRO3D_DATA`, then the working directory.
+
+| name | dataset | notes |
+|------|---------|-------|
+| `victoria` | `HiRISE_VictoriaCrater` | Apple Silicon surface artefact repro |
+| `victoria-sr` | `HiRISE_VictoriaCrater_SuperResolution` | same camera |
+| `capedesire` | `MER-B_CapeDesire_wbs` | MER-B ground level |
+
+`victoria`'s near/far are PRo3D's own defaults (`ViewConfigModel.initNearPlane` /
+`initFarPlane`) — 0.1 m to 500 km, a 5,000,000:1 depth range that is worth varying with
+`--near` / `--far` when depth precision is a suspect.
+
+Add a preset in `Presets` in `Program.fs` when a new artefact gets a repro camera.
+
+## Options that reproduce viewer state
+
+The harness deliberately starts from "nothing switched on" and lets you add back the one
+thing you suspect:
+
+- `--triangle-filter <m>` — enables the view-space triangle filter with this
+  `MaxTriangleSize`. Off by default, matching `SurfaceApp.mk`. Uploaded as a `double`,
+  exactly as the viewer does (`surf.triangleSize.value` is an `aval<float>`), so a
+  CPU-side conversion mismatch would reproduce here too.
+- `--sun X Y Z` — enables solar lighting from a world-space direction. Off by default:
+  without SPICE the viewer has no sun, and with lighting off the `lit` rung passes colour
+  through unchanged.
+- `--samples <n>` — MSAA. The viewer's main control runs at 4; the offscreen default here
+  is 1. Multisampled targets are resolved into a single-sample texture before download.
+- `--near` / `--far`, `--cull`, `--wireframe`, `--compressed`.
+
+## Diagnostics
+
+- `--dump-glsl` logs the generated GLSL for every rung. The cheapest way to check what a
+  shader's types actually became — in particular whether anything reached the GPU as
+  `double`, which Apple Silicon has no hardware for. (As of this writing nothing does:
+  every uniform and varying in the OPC path compiles to `float`/`vec*`.)
+- `--wireframe` separates "missing triangles" from "triangles shaded wrong".
+- `--interactive` opens a window on the selected rung and lets you fly around
+  (PageUp/PageDown change speed).
+
+## How screenshots are taken
+
+Patches load synchronously (`asyncLoading = false`) so a screenshot cannot race the
+loader. Frames are then rendered until two consecutive frames are byte-identical, because
+the LOD decider needs a rendered frame to decide against — a fixed warm-up count either
+captures a coarser LOD than the viewer would show, or makes every run pay for the worst
+case. `--max-frames` caps it; the log says whether it converged or hit the cap.
+
+## Bisecting the viewer's surface effect
+
+The harness renders the OPC path in isolation. When an artefact appears in the viewer but
+not here, the cause is a stage of `ViewerUtils.surfaceEffect` the harness does not
+compose. That effect is a **named, filterable stage list**
+([`Viewer-Utils.fs`](../src/PRo3D.Viewer/Viewer/Viewer-Utils.fs)), driven by environment
+variables so stages can be A/B'd without a rebuild:
+
+```bash
+PRO3D_SURFACE_EFFECT=minimal            # only the stages this harness proves clean
+PRO3D_SURFACE_EFFECT_ADD=a,b            # minimal plus these  (bisect upwards)
+PRO3D_SURFACE_EFFECT_DROP=a,b           # everything except these (bisect downwards)
+```
+
+Unset changes nothing. Unknown stage names throw rather than silently doing nothing — a
+typo that quietly changes the effect produces a "clean" run that means nothing.
+
+Stages are not independent: a fragment stage that reads a varying needs the vertex stage
+that writes it, or the GL backend throws `Could not get attribute '<name>'` at draw time.
+`stageDependencies` declares those links and dropping a producer drops its consumers, so
+any subset is safe to ask for. The log prints what actually ran:
+
+```
+surfaceEffect: 16/22 stages active
+surfaceEffect: dropped footprintV, fixAlpha, markPatchBorders, ...
+```
+
+One unattended round — launch on the most recent scene, screenshot, shut down:
+
+```bash
+scripts/capture-surface-effect.sh half-a ADD=contourLines,crossSectionClip
+```
+
+It uses a **system screenshot** rather than PRo3D's own snapshot feature: that feature is
+broken on this branch, and capturing the window tests the image actually on screen rather
+than a second render of it. Needs Screen Recording permission (System Settings → Privacy &
+Security), else `screencapture` fails with "could not create image from display". Start
+PRo3D with `-loadRecent` (single dash) to reload the last saved scene, which is what makes
+the loop unattended.
+
+### Worked example: the Apple Silicon dark-quads artefact
+
+1. Every harness rung rendered clean on an M1 → not geometry, LOD, textures, `stableTrafo`,
+   `triangleSizeFilter` or `generateNormal`.
+2. `PRO3D_SURFACE_EFFECT=minimal` in the viewer was clean too → the cause was one of the
+   13 stages outside the minimal set.
+3. Two halvings, then single stages: `crossSectionClip` alone reproduced it; `contourLines`
+   alone was clean.
+4. `PRO3D_SURFACE_EFFECT_ADD=crossSectionDebug` painted the attribute the shader tests
+   instead of discarding on it, showing garbage where zeros were bound.
+
+Cause and fix: [CrossSections.md](CrossSections.md#why-crosssectiondefined-exists).
+
+## Legacy viewers
+
+The older hard-coded viewers still exist behind `--legacy scene|annotations|solarsystem|multitexturing`.
+They carry Windows-only paths and are kept only for the code they exercise; new work
+should use `--opc` / `--dataset`.

--- a/scripts/capture-surface-effect.sh
+++ b/scripts/capture-surface-effect.sh
@@ -1,0 +1,71 @@
+#!/bin/zsh
+# Launch PRo3D on the most recent scene with a chosen subset of surfaceEffect stages,
+# screenshot the result, and shut it down. One bisect round, unattended.
+#
+# System screenshot rather than PRo3D's own snapshot feature on purpose: the internal
+# one is broken on this branch, and capturing the real window tests the image actually on
+# screen rather than a second render of it.
+#
+#   scripts/capture-surface-effect.sh <name> [ADD=a,b,c | DROP=a,b,c | minimal | full]
+#
+#   scripts/capture-surface-effect.sh baseline full
+#   scripts/capture-surface-effect.sh half-a ADD=contourLines,crossSectionClip
+#   scripts/capture-surface-effect.sh no-contour DROP=contourLines
+#
+# Stage names and the env vars behind them: see `surfaceStages` in
+# src/PRo3D.Viewer/Viewer/Viewer-Utils.fs and docs/OpcViewer-Screenshot-Harness.md.
+#
+# Requires: Screen Recording permission for the terminal running this
+# (System Settings -> Privacy & Security -> Screen Recording), else screencapture
+# fails with "could not create image from display".
+
+set -e
+
+name="${1:?usage: capture-surface-effect.sh <name> [ADD=... | DROP=... | minimal | full]}"
+selection="${2:-full}"
+
+root="${0:a:h}/.."
+out="${CAPTURE_OUT:-$root/capture-output}"
+viewer="$root/bin/Release/net9.0/PRo3D.Viewer.dll"
+# The LOD tree keeps refining for a while after the window appears; capturing too early
+# photographs a coarse level and reads as a rendering difference that isn't one.
+settle="${CAPTURE_SETTLE:-25}"
+
+mkdir -p "$out"
+
+unset PRO3D_SURFACE_EFFECT PRO3D_SURFACE_EFFECT_ADD PRO3D_SURFACE_EFFECT_DROP
+case "$selection" in
+    full)     ;;
+    minimal)  export PRO3D_SURFACE_EFFECT=minimal ;;
+    ADD=*)    export PRO3D_SURFACE_EFFECT_ADD="${selection#ADD=}" ;;
+    DROP=*)   export PRO3D_SURFACE_EFFECT_DROP="${selection#DROP=}" ;;
+    *) echo "unknown selection '$selection' (full | minimal | ADD=... | DROP=...)" >&2; exit 2 ;;
+esac
+
+pkill -f PRo3D.Viewer 2>/dev/null || true
+pkill -f Aardium 2>/dev/null || true
+sleep 1
+
+log="$out/$name.log"
+dotnet "$viewer" -loadRecent > "$log" 2>&1 &
+pid=$!
+
+# Fail loudly instead of screenshotting a desktop with no viewer on it.
+for _ in $(seq 1 60); do
+    grep -q "RenderControl Resized" "$log" 2>/dev/null && break
+    kill -0 $pid 2>/dev/null || { echo "PRo3D exited early; see $log" >&2; exit 1; }
+    sleep 1
+done
+
+echo "[stages] $(grep 'surfaceEffect:' "$log" || echo 'all stages active')"
+sleep "$settle"
+
+if ! screencapture -x "$out/$name.png"; then
+    echo "screencapture failed -- grant Screen Recording permission to this terminal" >&2
+    kill $pid 2>/dev/null || true
+    exit 1
+fi
+
+kill $pid 2>/dev/null || true
+pkill -f Aardium 2>/dev/null || true
+echo "[out] $out/$name.png"

--- a/src/OpcViewer/OpcViewer.fsproj
+++ b/src/OpcViewer/OpcViewer.fsproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Compile Include="MultiTexturingViewer.fs" />
     <Compile Include="TestViewer.fs" />
+    <Compile Include="ScreenshotViewer.fs" />
     <Compile Include="AnnotationViewer.fs" />
     <Compile Include="Solarsystem.fs" />
     <Compile Include="Program.fs" />
@@ -28,6 +29,9 @@
     <ProjectReference Include="..\CSharpUtils\CSharpUtils.csproj" />
     <ProjectReference Include="..\PRo3D.Base\PRo3D.Base.fsproj" />
     <ProjectReference Include="..\PRo3D.Core\PRo3D.Core.fsproj" />
+    <!-- ScreenshotViewer's effect ladder renders the viewer's own lighting and
+         normal-generation shaders, which live here. -->
+    <ProjectReference Include="..\PRo3D.GIS\PRo3D.GIS.fsproj" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/OpcViewer/Program.fs
+++ b/src/OpcViewer/Program.fs
@@ -1,6 +1,7 @@
-﻿// Learn more about F# at http://fsharp.org
+// Learn more about F# at http://fsharp.org
 
 open System
+open System.IO
 
 open Aardvark.Base
 open Aardvark.GeoSpatial.Opc
@@ -8,229 +9,366 @@ open Aardvark.Opc
 
 type Kind = Scene | Annotations | Solarsystem | MultiTexturing
 
-[<EntryPoint>]
-let main argv =
-    
-    let kind = MultiTexturing
+/// Legacy hard-coded scenes. Kept because the older viewers below still reference them;
+/// new work should go through `--opc` on the command line instead.
+module LegacyScenes =
 
     let shaler =
-        { 
+        {
             useCompressedTextures = true
             preTransform     = Trafo3d.Identity
-            patchHierarchies = 
-                    Seq.delay (fun _ -> 
-                        System.IO.Directory.GetDirectories(@"K:\PRo3D Data\Shaler_OPCs_2019\Shaler_Navcam") 
+            patchHierarchies =
+                    Seq.delay (fun _ ->
+                        System.IO.Directory.GetDirectories(@"K:\PRo3D Data\Shaler_OPCs_2019\Shaler_Navcam")
                         |> Seq.collect System.IO.Directory.GetDirectories
                     )
-            boundingBox      = Box3d.Parse("[[-2490137.664354247, 2285874.562728135, -271408.476700304], [-2490136.248131170, 2285875.658034266, -271406.605430601]]") 
+            boundingBox      = Box3d.Parse("[[-2490137.664354247, 2285874.562728135, -271408.476700304], [-2490136.248131170, 2285875.658034266, -271406.605430601]]")
             near             = 0.1
             far              = 10000.0
             speed            = 5.0
-            lodDecider       =  DefaultMetrics.mars2 
+            lodDecider       =  DefaultMetrics.mars2
         }
 
     let mola =
-        { 
+        {
             useCompressedTextures = true
             preTransform     = Trafo3d.Identity
-            patchHierarchies = 
-                    Seq.delay (fun _ -> 
-                        System.IO.Directory.GetDirectories(@"I:\MOLA") 
+            patchHierarchies =
+                    Seq.delay (fun _ ->
+                        System.IO.Directory.GetDirectories(@"I:\MOLA")
                     )
-            boundingBox      = Box3d.Parse("[[1042657.138109462, 3023778.035968372, -472791.711967824], [1492041.915577915, 3230435.734121298, -231.611523378]]") 
-            near             = 0.1
-            far              = 10000.0
-            speed            = 5.0
-            lodDecider       =  DefaultMetrics.mars2 
-        }
-
-
-    let jezereo =
-        { 
-            useCompressedTextures = true
-            preTransform     = Trafo3d.Identity
-            patchHierarchies = 
-                    Seq.delay (fun _ -> 
-                        System.IO.Directory.GetDirectories(@"K:\PRo3D Data\Jezero1") 
-                        |> Seq.collect System.IO.Directory.GetDirectories
-                    )
-            boundingBox      = Box3d.Parse("[[701677.203042967, 3141128.733093360, 1075935.257765322], [701942.935458576, 3141252.724183598, 1076182.681085336]]") 
-            near             = 0.1
-            far              = 10000.0
-            speed            = 5.0
-            lodDecider       =  DefaultMetrics.mars2 
-        }
-
-    let mola =
-        { 
-            useCompressedTextures = true
-            preTransform     = Trafo3d.Identity
-            patchHierarchies = 
-                    Seq.delay (fun _ -> 
-                        System.IO.Directory.GetDirectories(@"I:\MOLA") 
-                    )
-            boundingBox      = Box3d.Parse("[[-432.863518980, 2190669.974376967, -2354936.901768766], [1492041.915577915, 3396466.232556264, -231.471982595]]") 
+            boundingBox      = Box3d.Parse("[[-432.863518980, 2190669.974376967, -2354936.901768766], [1492041.915577915, 3396466.232556264, -231.471982595]]")
             near             = 1000.1
             far              = 100000000000.0
             speed            = 15.0
-            lodDecider       =  DefaultMetrics.mars2 
+            lodDecider       =  DefaultMetrics.mars2
         }
 
     let dimorphos =
-        { 
+        {
             useCompressedTextures = true
             preTransform     = Trafo3d.Identity
-            patchHierarchies = 
-                    Seq.delay (fun _ -> 
-                        System.IO.Directory.GetDirectories(@"C:\pro3ddata\HERA\Workshop2\OPC\Dimorphos_DRACO1\Dimorphos_DRACO1") 
+            patchHierarchies =
+                    Seq.delay (fun _ ->
+                        System.IO.Directory.GetDirectories(@"C:\pro3ddata\HERA\Workshop2\OPC\Dimorphos_DRACO1\Dimorphos_DRACO1")
                     )
-            boundingBox      = Box3d.Parse("[[-89.180763245, -87.157432556, -56.789569855], [87.699211121, 86.719993591, 58.670009613]]") 
+            boundingBox      = Box3d.Parse("[[-89.180763245, -87.157432556, -56.789569855], [87.699211121, 86.719993591, 58.670009613]]")
             near             = 0.1
             far              = 1000.0
             speed            = 1.0
-            lodDecider       =  DefaultMetrics.mars2 
+            lodDecider       =  DefaultMetrics.mars2
         }
 
+    let annotationScene =
+        {
+            useCompressedTextures = true
+            preTransform     = Trafo3d.Identity
+            patchHierarchies =
+                    Seq.delay (fun _ ->
+                        System.IO.Directory.GetDirectories(@"C:\pro3ddata\Shaler_OPCs_2019\Shaler_Navcam")
+                        |> Seq.collect System.IO.Directory.GetDirectories
+                    )
+            boundingBox      = Box3d.Parse("[[-2490137.664354247, 2285874.562728135, -271408.476700304], [-2490136.248131170, 2285875.658034266, -271406.605430601]]")
+            near             = 0.1
+            far              = 10000.0
+            speed            = 5.0
+            lodDecider       =  DefaultMetrics.mars2
+        }
 
-    match kind with
+    let annotationFile = @"C:\pro3ddata\Shaler_OPCs_2019\Shaler_v2_Mastcam_w_Navcam_v18_merged_measurementsV2.pro3d.ann"
 
-    | Solarsystem -> 
-        Solarsytsem.run [mola;]
 
-    | Scene ->
-    
-        TestViewer.run mola
+/// Named repro cases. A preset is a dataset path relative to `--data-root` plus the
+/// camera the artefact is visible from, so a bug report turns into `--dataset <name>`
+/// rather than a paragraph of coordinates.
+module Presets =
 
-    | MultiTexturing -> 
-        MultiTexturingViewer.run dimorphos
+    type Preset =
+        {
+            /// Relative to --data-root. May be an OPC hierarchy or a folder of them.
+            relPath : string
+            camera  : ScreenshotViewer.Camera
+            near    : float
+            far     : float
+            speed   : float
+            notes   : string
+        }
 
-    | Annotations ->
+    /// HiRISE Victoria Crater, from the camera in the Apple Silicon artefact report
+    /// (github issue: regular dark quads across the surface, Apple Silicon only).
+    /// Position/bearing/pitch are exactly what PRo3D's on-screen readout showed.
+    /// near/far are PRo3D's own defaults (ViewConfigModel.initNearPlane/initFarPlane) --
+    /// a 5,000,000:1 depth range, which is itself worth varying with --near/--far.
+    let victoria =
+        {
+            relPath = "HiRISE_VictoriaCrater"
+            camera  = ScreenshotViewer.BearingPitch(V3d(3376474.17, -324507.68, -121181.49), 206.72, -11.74)
+            near    = 0.1
+            far     = 500000.0
+            speed   = 20.0
+            notes   = "Apple Silicon surface artefact repro"
+        }
 
-        let scene =
-            { 
-                useCompressedTextures = true
-                preTransform     = Trafo3d.Identity
-                patchHierarchies = 
-                        Seq.delay (fun _ -> 
-                            System.IO.Directory.GetDirectories(@"C:\pro3ddata\Shaler_OPCs_2019\Shaler_Navcam") 
-                            |> Seq.collect System.IO.Directory.GetDirectories
-                        )
-                boundingBox      = Box3d.Parse("[[-2490137.664354247, 2285874.562728135, -271408.476700304], [-2490136.248131170, 2285875.658034266, -271406.605430601]]") 
-                near             = 0.1
-                far              = 10000.0
-                speed            = 5.0
-                lodDecider       =  DefaultMetrics.mars2 
-            }
+    let victoriaSuperRes =
+        { victoria with
+            relPath = "HiRISE_VictoriaCrater_SuperResolution"
+            notes   = "same camera, super-resolution variant" }
 
-        //let scene =
-        //    { 
-        //        useCompressedTextures = true
-        //        preTransform     = Trafo3d.Identity
-        //        patchHierarchies = 
-        //                Seq.delay (fun _ -> 
-        //                    System.IO.Directory.GetDirectories(@"F:\pro3d\data\20200220_DinosaurQuarry2") 
-        //                    |> Seq.collect System.IO.Directory.GetDirectories
-        //                )
-        //        boundingBox      = Box3d.Parse("[[-15.699694740, 4.338130733, -0.514935397], [-4.960646670, 36.914955133, 5.004174588]]") 
-        //        near             = 0.1
-        //        far              = 10000.0
-        //        speed            = 5.0
-        //        lodDecider       =  DefaultMetrics.mars2 
-        //    }
+    let capeDesire =
+        { victoria with
+            relPath = "MER-B_CapeDesire_wbs"
+            notes   = "MER-B ground-level dataset" }
 
-        //let scene =
-        //    { 
-        //        useCompressedTextures = true
-        //        preTransform     = Trafo3d.Identity
-        //        patchHierarchies = 
-        //            Seq.delay (fun _ -> 
-        //                System.IO.Directory.GetDirectories(@"F:\pro3d\data\20200220_DinosaurQuarry2") 
-        //                |> Seq.collect System.IO.Directory.GetDirectories
-        //            )
-        //        boundingBox      = Box3d.Parse("[[-15.699694740, 4.338130733, -0.514935397], [-4.960646670, 36.914955133, 5.004174588]]") 
-        //        near             = 0.1
-        //        far              = 10000.0
-        //        speed            = 5.0
-        //        lodDecider       =  DefaultMetrics.mars2 
-        //    }
+    let byName =
+        Map.ofList [
+            "victoria",    victoria
+            "victoria-sr", victoriaSuperRes
+            "capedesire",  capeDesire
+        ]
 
-        //let scene =
-        //    { 
-        //        useCompressedTextures = true
-        //        preTransform     = Trafo3d.Identity
-        //        patchHierarchies = 
-        //                System.IO.Directory.GetDirectories(@"F:\pro3d\data\20200220_DinosaurQuarry2") 
-        //                |> Seq.collect System.IO.Directory.GetDirectories
-        //        boundingBox      = Box3d.Parse("[[-9.996176625, 1.249114172, -1.937521343], [-0.603052397, 27.938626479, -0.132129824]]") 
-        //        near             = 0.1
-        //        far              = 10000.0
-        //        speed            = 5.0
-        //        lodDecider       =  DefaultMetrics.mars2 
-        //    }
 
-        //let scene =
-        //    { 
-        //        useCompressedTextures = true
-        //        preTransform     = Trafo3d.Identity
-        //        patchHierarchies = 
-        //            Seq.delay (fun _ -> 
-        //                System.IO.Directory.GetDirectories(@"F:\pro3d\data\OpcMcz") 
-        //            )
-        //        boundingBox      = Box3d.Parse("[[699507.902347501, 3142696.785742886, 1072717.259930025], [699508.165976587, 3142697.102699531, 1072717.505653937]]") 
-        //        near             = 0.1
-        //        far              = 10000.0
-        //        speed            = 5.0
-        //        lodDecider       =  DefaultMetrics.mars2 
-        //    }
+module Cli =
 
-        //let scene =
-        //    { 
-        //        useCompressedTextures = true
-        //        preTransform     = Trafo3d.Identity
-        //        patchHierarchies = 
-        //            Seq.delay (fun _ -> 
-        //                System.IO.Directory.GetDirectories(@"F:\pro3d\data\OpcHera") 
-        //            )
-        //        boundingBox      = Box3d.Parse("[[-0.089070135, -0.087013945, -0.056419425], [0.086516376, 0.000000000, 0.058683879]]") 
-        //        near             = 0.1
-        //        far              = 10000.0
-        //        speed            = 5.0
-        //        lodDecider       =  DefaultMetrics.mars2 
-        //    }
+    type Options =
+        {
+            opcPaths   : list<string>
+            dataRoot   : string
+            preset     : Option<Presets.Preset>
+            eye        : Option<V3d>
+            bearing    : Option<float>
+            pitch      : Option<float>
+            lookAt     : Option<V3d>
+            near       : Option<float>
+            far        : Option<float>
+            stacks     : list<ScreenshotViewer.EffectStack>
+            size       : V2i
+            outputDir  : string
+            name       : string
+            wireframe  : bool
+            cull       : Aardvark.Rendering.CullMode
+            interactive : bool
+            maxFrames  : int
+            compressed : bool
+            dumpGlsl   : bool
+            triangleFilter : Option<float>
+            sun        : Option<V3d>
+            samples    : int
+            legacy     : Option<Kind>
+        }
 
-        //let scene =
-        //    { 
-        //        useCompressedTextures = true
-        //        preTransform     = Trafo3d.Identity
-        //        patchHierarchies = 
-        //            Seq.delay (fun _ -> 
-        //                System.IO.Directory.GetDirectories(@"F:\pro3d\data\dimorphos") 
-        //            )
-        //        boundingBox      = Box3d.Parse("[[-89.181903827, -87.182643300, -56.420779204], [86.522432535, 0.000000000, 58.710996093]]") 
-        //        near             = 0.1
-        //        far              = 10000.0
-        //        speed            = 5.0
-        //        lodDecider       =  DefaultMetrics.mars2 
-        //    }
+    let defaults =
+        {
+            opcPaths = []
+            dataRoot = Environment.GetEnvironmentVariable "PRO3D_DATA" |> Option.ofObj |> Option.defaultValue "."
+            preset = None
+            eye = None
+            bearing = None
+            pitch = None
+            lookAt = None
+            near = None
+            far = None
+            stacks = []
+            size = V2i(1280, 800)
+            outputDir = Path.Combine(".", "opcviewer-output")
+            name = "opc"
+            wireframe = false
+            cull = Aardvark.Rendering.CullMode.None
+            interactive = false
+            maxFrames = 24
+            compressed = false
+            dumpGlsl = false
+            triangleFilter = None
+            sun = None
+            samples = 1
+            legacy = None
+        }
 
-        let annotations = @"I:\OPC\Shaler_OPCs_2019\crazy2.pro3d.ann"
-        let annotations = @"F:\pro3d\data\20200220_DinosaurQuarry2\strangetest.pro3d.ann"
-        let annotations = @"F:\pro3d\data\OpcHera\annos2.pro3d.ann"
-        //let annotations = @"F:\pro3d\data\OpcMcz\singleAnno.pro3d.ann"
-        let annotations = @"F:\pro3d\data\OpcMcz\blub.pro3d.ann"
-        let annotations = @"F:\pro3d\data\OpcMcz\notworking.pro3d.ann"
-        let annotations = @"C:\pro3ddata\Shaler_OPCs_2019\Shaler_v2_Mastcam_w_Navcam_v18_merged_measurementsV2.pro3d.ann"
-        //let annotations = @"F:\pro3d\data\OpcMcz\heavy.pro3d.ann"
-        //let annotations = @"F:\pro3d\data\dimorphos\singleanno.pro3d.ann"
+    let usage = """
+OpcViewer -- headless / interactive OPC renderer for reproducing surface artefacts.
 
-        let annotations = 
-            PRo3D.Core.Drawing.DrawingUtilities.IO.loadAnnotationsFromFile annotations
+  --dataset <name>       preset repro case: victoria | victoria-sr | capedesire
+  --data-root <dir>      root the preset's path is relative to
+                         (default: $PRO3D_DATA, else the working directory)
+  --opc <dir>            OPC hierarchy, or a folder containing them. Repeatable;
+                         overrides the preset's path.
 
+  --eye X Y Z            camera position, body-fixed metres
+  --bearing <deg>        clockwise from north, as PRo3D's readout prints it
+  --pitch <deg>          above the local horizon, likewise
+  --look-at X Y Z        explicit target instead of --bearing/--pitch
+  --near <m> --far <m>   depth range (preset default: PRo3D's own 0.1 / 500000)
+
+  --stack <name>         minimal | filter | normals | lit | color. Repeatable.
+                         Default: render all of them, which is the point -- the rung
+                         where the artefact appears is the stage that causes it.
+  --width <n> --height <n>
+  --out <dir>            output directory      (default ./opcviewer-output)
+  --name <prefix>        output file prefix; the stack name is appended
+  --triangle-filter <m>  switch the view-space triangle filter on with this
+                         MaxTriangleSize (viewer default: off)
+  --sun X Y Z            enable solar lighting from this world direction
+  --samples <n>          MSAA sample count (viewer's main control uses 4)
+  --wireframe            render lines instead of filled triangles
+  --cull none|front|back
+  --max-frames <n>       cap on render passes while the LOD tree settles (default 24)
+  --compressed           expect .dds textures instead of the source images
+  --dump-glsl            log the generated GLSL for each rung
+  --interactive          open a window and fly around instead of writing PNGs
+
+  --legacy <kind>        run an old hard-coded viewer:
+                         scene | annotations | solarsystem | multitexturing
+  --help
+"""
+
+    let parse (argv : string[]) : Result<Options, string> =
+        let rec go (o : Options) (args : list<string>) =
+            match args with
+            | [] -> Ok o
+            | "--help" :: _ -> Result.Error usage
+            | "--opc" :: v :: rest        -> go { o with opcPaths = o.opcPaths @ [ v ] } rest
+            | "--data-root" :: v :: rest  -> go { o with dataRoot = v } rest
+            | "--dataset" :: v :: rest ->
+                match Map.tryFind (v.ToLowerInvariant()) Presets.byName with
+                | Some p -> go { o with preset = Some p } rest
+                | None ->
+                    let known = Presets.byName |> Map.toList |> List.map fst |> String.concat " | "
+                    Result.Error (sprintf "unknown --dataset '%s' (known: %s)" v known)
+            | "--eye" :: x :: y :: z :: rest ->
+                go { o with eye = Some (V3d(float x, float y, float z)) } rest
+            | "--look-at" :: x :: y :: z :: rest ->
+                go { o with lookAt = Some (V3d(float x, float y, float z)) } rest
+            | "--bearing" :: v :: rest    -> go { o with bearing = Some (float v) } rest
+            | "--pitch" :: v :: rest      -> go { o with pitch = Some (float v) } rest
+            | "--near" :: v :: rest       -> go { o with near = Some (float v) } rest
+            | "--far" :: v :: rest        -> go { o with far = Some (float v) } rest
+            | "--width" :: v :: rest      -> go { o with size = V2i(int v, o.size.Y) } rest
+            | "--height" :: v :: rest     -> go { o with size = V2i(o.size.X, int v) } rest
+            | "--out" :: v :: rest        -> go { o with outputDir = v } rest
+            | "--name" :: v :: rest       -> go { o with name = v } rest
+            | "--triangle-filter" :: v :: rest -> go { o with triangleFilter = Some (float v) } rest
+            | "--samples" :: v :: rest    -> go { o with samples = int v } rest
+            | "--sun" :: x :: y :: z :: rest ->
+                go { o with sun = Some (V3d(float x, float y, float z)) } rest
+            | "--wireframe" :: rest       -> go { o with wireframe = true } rest
+            | "--max-frames" :: v :: rest -> go { o with maxFrames = int v } rest
+            | "--compressed" :: rest      -> go { o with compressed = true } rest
+            | "--dump-glsl" :: rest       -> go { o with dumpGlsl = true } rest
+            | "--interactive" :: rest     -> go { o with interactive = true } rest
+            | "--stack" :: v :: rest ->
+                match ScreenshotViewer.EffectStack.parse v with
+                | Some s -> go { o with stacks = o.stacks @ [ s ] } rest
+                | None -> Result.Error (sprintf "unknown --stack '%s' (minimal|filter|normals|lit|color)" v)
+            | "--cull" :: v :: rest ->
+                match v.ToLowerInvariant() with
+                | "none"  -> go { o with cull = Aardvark.Rendering.CullMode.None } rest
+                | "front" -> go { o with cull = Aardvark.Rendering.CullMode.Front } rest
+                | "back"  -> go { o with cull = Aardvark.Rendering.CullMode.Back } rest
+                | other   -> Result.Error (sprintf "unknown --cull '%s' (none|front|back)" other)
+            | "--legacy" :: v :: rest ->
+                match v.ToLowerInvariant() with
+                | "scene"          -> go { o with legacy = Some Scene } rest
+                | "annotations"    -> go { o with legacy = Some Annotations } rest
+                | "solarsystem"    -> go { o with legacy = Some Solarsystem } rest
+                | "multitexturing" -> go { o with legacy = Some MultiTexturing } rest
+                | other -> Result.Error (sprintf "unknown --legacy '%s'" other)
+            | unknown :: _ -> Result.Error (sprintf "unknown argument '%s'\n%s" unknown usage)
+        go defaults (List.ofArray argv)
+
+    /// An OPC hierarchy is a folder with a `patches` (or `Patches`) subfolder. Datasets
+    /// ship both ways -- one hierarchy per folder, or a parent holding several -- and
+    /// handing a parent to PatchHierarchy.load fails with a bare "patches dir not
+    /// found", so resolve it here rather than making the caller know which shape they
+    /// have.
+    let expandHierarchies (root : string) : list<string> =
+        let isHierarchy (dir : string) =
+            [ "patches"; "Patches" ] |> List.exists (fun p -> Directory.Exists(Path.Combine(dir, p)))
+        if not (Directory.Exists root) then []
+        elif isHierarchy root then [ root ]
+        else Directory.GetDirectories root |> Array.filter isHierarchy |> Array.toList
+
+
+[<EntryPoint>]
+let main argv =
+
+    match Cli.parse argv with
+    | Result.Error msg ->
+        printfn "%s" msg
+        if argv |> Array.contains "--help" then 0 else 1
+    | Ok o ->
+
+    match o.legacy with
+    | Some Solarsystem    -> Solarsytsem.run [ LegacyScenes.mola ]
+    | Some Scene          -> TestViewer.run LegacyScenes.mola
+    | Some MultiTexturing -> MultiTexturingViewer.run LegacyScenes.dimorphos
+    | Some Annotations ->
+        let annotations =
+            PRo3D.Core.Drawing.DrawingUtilities.IO.loadAnnotationsFromFile LegacyScenes.annotationFile
         FSharp.Data.Adaptive.ShallowEqualityComparer.Set {
             new System.Collections.Generic.IEqualityComparer<Trafo3d> with
                 member x.GetHashCode _ = 0
-                member x.Equals(_,_) = false
+                member x.Equals(_, _) = false
             }
+        AnnotationViewer.run LegacyScenes.annotationScene annotations
+    | None ->
 
-        AnnotationViewer.run scene annotations
+    // Explicit --opc wins over the preset's path, so a preset's camera can be reused on
+    // a different copy of the data.
+    let roots =
+        match o.opcPaths, o.preset with
+        | [], None -> []
+        | [], Some p -> [ Path.Combine(o.dataRoot, p.relPath) ]
+        | paths, _ -> paths
 
+    let hierarchies = roots |> List.collect Cli.expandHierarchies
+
+    if List.isEmpty hierarchies then
+        printfn "no OPC hierarchy found (looked in: %s)" (String.concat ", " roots)
+        printfn "%s" Cli.usage
+        1
+    else
+
+    for h in hierarchies do Log.line "[opc] %s" h
+
+    let near = o.near |> Option.orElse (o.preset |> Option.map (fun p -> p.near)) |> Option.defaultValue 0.1
+    let far  = o.far  |> Option.orElse (o.preset |> Option.map (fun p -> p.far))  |> Option.defaultValue 100000.0
+
+    let camera =
+        match o.eye, o.lookAt, o.bearing, o.pitch with
+        | Some eye, Some target, _, _ -> ScreenshotViewer.LookAt(eye, target)
+        | Some eye, None, b, p ->
+            ScreenshotViewer.BearingPitch(eye, defaultArg b 0.0, defaultArg p 0.0)
+        | None, _, _, _ ->
+            match o.preset with
+            | Some p -> p.camera
+            | None -> ScreenshotViewer.FromBoundingBox
+
+    let scene =
+        {
+            useCompressedTextures = o.compressed
+            preTransform     = Trafo3d.Identity
+            patchHierarchies = hierarchies
+            // Only used by callers that frame from it; ScreenshotViewer computes the
+            // real extents from the hierarchies themselves.
+            boundingBox      = Box3d.Invalid
+            near             = near
+            far              = far
+            speed            = o.preset |> Option.map (fun p -> p.speed) |> Option.defaultValue 10.0
+            lodDecider       = DefaultMetrics.mars2
+        }
+
+    ScreenshotViewer.run {
+        scene       = scene
+        camera      = camera
+        size        = o.size
+        outputDir   = o.outputDir
+        name        = o.name
+        stacks      = o.stacks
+        fillMode    = (if o.wireframe then Aardvark.Rendering.FillMode.Line else Aardvark.Rendering.FillMode.Fill)
+        cullMode    = o.cull
+        interactive = o.interactive
+        maxFrames   = o.maxFrames
+        dumpGlsl    = o.dumpGlsl
+        triangleFilter = o.triangleFilter
+        sun         = o.sun
+        samples     = o.samples
+    }

--- a/src/OpcViewer/ScreenshotViewer.fs
+++ b/src/OpcViewer/ScreenshotViewer.fs
@@ -1,0 +1,394 @@
+namespace Aardvark.Opc
+
+open System
+open System.IO
+
+open Aardvark.Base
+open Aardvark.Rendering
+open Aardvark.SceneGraph
+open Aardvark.Application
+open Aardvark.Application.Slim
+open Aardvark.Data.Opc
+open Aardvark.GeoSpatial.Opc
+open Aardvark.GeoSpatial.Opc.Load
+
+open FSharp.Data.Adaptive
+open MBrace.FsPickler
+
+/// Headless / interactive OPC renderer for reproducing surface rendering artefacts.
+///
+/// This exists because the interesting bugs in the OPC pipeline (precision loss at
+/// planetary scale, driver differences between Apple Silicon and the Windows/Linux GL
+/// stacks) only show up on real data from a specific camera. Reproducing them by hand
+/// through the full viewer is slow and not repeatable; this renders one frame of one
+/// dataset from one camera into a PNG.
+///
+/// The `EffectStack` ladder is the actual diagnostic tool: `Minimal` is barely more than
+/// "put the triangles on screen", and each rung adds the next stage of the real viewer's
+/// surface effect (`ViewerUtils.surfaceEffect`) in the same order. Rendering the same
+/// camera at each rung says which stage introduces an artefact, without touching the
+/// viewer. The shaders are the viewer's own — the shared ones were moved to
+/// `PRo3D.Base.OpcSurfaceShader` for exactly this reason, so a rung cannot silently
+/// diverge from what the viewer runs.
+module ScreenshotViewer =
+
+    /// How much of `ViewerUtils.surfaceEffect` to run. Cumulative: each rung is the
+    /// previous one plus the next stage, in the viewer's own composition order.
+    type EffectStack =
+        /// stableTrafo + diffuse texture. If an artefact is already here it is in the
+        /// geometry, the LOD tree or the texture path, not in PRo3D's shading.
+        | Minimal
+        /// + triangleSizeFilter, the view-space geometry shader that drops
+        /// over-long triangles.
+        | Filter
+        /// + generateNormal, a second geometry shader composed onto the first.
+        | Normals
+        /// + planet-local lighting and the solar lighting fragment stage.
+        | Lit
+        /// + the colour adaption / radiometry fragment chain.
+        | Color
+
+    module EffectStack =
+        let parse (s : string) =
+            match s.ToLowerInvariant() with
+            | "minimal" -> Some Minimal
+            | "filter"  -> Some Filter
+            | "normals" -> Some Normals
+            | "lit"     -> Some Lit
+            | "color" | "colour" -> Some Color
+            | _ -> None
+
+        let name =
+            function
+            | Minimal -> "minimal" | Filter -> "filter" | Normals -> "normals"
+            | Lit -> "lit" | Color -> "color"
+
+        /// The order the ladder is climbed in.
+        let all = [ Minimal; Filter; Normals; Lit; Color ]
+
+    /// Where the camera sits. `BearingPitch` mirrors what PRo3D's on-screen readout
+    /// prints (position in body-fixed metres, bearing clockwise from north, pitch above
+    /// the local horizon), so a bad frame in the viewer is reproduced by copying three
+    /// numbers off the screen rather than by guessing at a look-at pair.
+    type Camera =
+        | BearingPitch of eye : V3d * bearingDeg : float * pitchDeg : float
+        | LookAt of eye : V3d * target : V3d
+        /// Framed from the dataset bounding box. Only useful as a smoke test — the
+        /// precision artefacts want a grazing, near-surface view.
+        | FromBoundingBox
+
+    type Config =
+        {
+            scene       : OpcScene
+            camera      : Camera
+            size        : V2i
+            outputDir   : string
+            /// Base name; the stack name and `.png` are appended.
+            name        : string
+            /// Empty = climb the whole ladder in one run.
+            stacks      : list<EffectStack>
+            fillMode    : FillMode
+            cullMode    : CullMode
+            /// Open a window instead of rendering offscreen.
+            interactive : bool
+            /// Upper bound on render passes per screenshot while the LOD tree settles.
+            maxFrames   : int
+            /// Some size = switch the view-space triangle filter on with this
+            /// MaxTriangleSize. The viewer defaults it off (SurfaceApp.mk), so it is off
+            /// here too unless asked for.
+            triangleFilter : Option<float>
+            /// Some direction = enable solar lighting from this world-space direction.
+            /// Without SPICE the viewer has no sun, so this is off by default -- with it
+            /// off the `lit` rung passes the colour through unchanged.
+            sun         : Option<V3d>
+            /// MSAA sample count. The viewer runs the main control at 4 (Config
+            /// data_samples), and there is already one GPU in the tree that needs it
+            /// forced to 1, so this is worth varying.
+            samples     : int
+            /// Log the generated GLSL for each rung. The cheapest way to check what a
+            /// shader's types actually became -- notably whether anything reached the
+            /// GPU as `double`, which Apple Silicon has no hardware for.
+            dumpGlsl    : bool
+        }
+
+    // ---------------------------------------------------------------- camera
+
+    /// Body-fixed position + bearing/pitch -> CameraView.
+    ///
+    /// Up is the planetocentric radial direction rather than the ellipsoid normal. The
+    /// two differ by well under a degree on Mars, which is irrelevant for framing a
+    /// repro, and using the radial direction keeps this free of any ellipsoid/datum
+    /// dependency.
+    let cameraFromBearingPitch (eye : V3d) (bearingDeg : float) (pitchDeg : float) =
+        let up = eye.Normalized
+        let pole = V3d.OOI
+        let east =
+            let e = Vec.cross pole up
+            if e.Length < 1e-9 then V3d.IOO else e.Normalized
+        let north = Vec.cross up east |> Vec.normalize
+        let b = bearingDeg * Constant.RadiansPerDegree
+        let p = pitchDeg * Constant.RadiansPerDegree
+        let horizontal = north * cos b + east * sin b
+        let forward = (horizontal * cos p + up * sin p) |> Vec.normalize
+        CameraView.lookAt eye (eye + forward * 1000.0) up
+
+    let private cameraView (bb : Box3d) (camera : Camera) =
+        match camera with
+        | BearingPitch (eye, bearing, pitch) -> cameraFromBearingPitch eye bearing pitch
+        | LookAt (eye, target) -> CameraView.lookAt eye target eye.Normalized
+        | FromBoundingBox -> CameraView.lookAt bb.Max bb.Center bb.Center.Normalized
+
+    // ---------------------------------------------------------------- effects
+
+    /// Uniforms every rung needs bound. FShade throws at CompileRender on an unbound
+    /// uniform, and the viewer supplies these from its model, so the harness has to
+    /// stand in for it. Values are the viewer's "nothing switched on" defaults: the
+    /// point is to isolate the shader stages, not to reproduce a particular UI state.
+    let private applyDefaultUniforms (cfg : Config) (sg : ISg) =
+        sg
+        |> Sg.uniform "LodVisEnabled" (AVal.constant false)
+        // triangleSizeFilter. Uploaded as a double, exactly as the viewer does
+        // (`surf.triangleSize.value` is an aval<float>), so any CPU-side conversion
+        // mismatch reproduces here too.
+        |> Sg.uniform "MaxTriangleSize" (AVal.constant (defaultArg cfg.triangleFilter 10.0))
+        |> Sg.uniform "FilterTriangleEnabled" (AVal.constant cfg.triangleFilter.IsSome)
+        |> Sg.uniform "FilterByDistance" (AVal.constant false)
+        |> Sg.uniform "FilterDistance" (AVal.constant 1000.0f)
+        |> Sg.uniform "HomePositionViewSpace" (AVal.constant V3f.Zero)
+        // image projection / shadow varyings the viewer's vertex stages write
+        |> Sg.uniform "ProjectedImageModelViewProj" (AVal.constant M44f.Identity)
+        |> Sg.uniform "ProjectedImageModelViewProjValid" (AVal.constant false)
+        |> Sg.uniform "StableModelViewProjTexture" (AVal.constant M44f.Identity)
+        |> Sg.uniform "NormalFlip" (AVal.constant 0.0f)
+        // lighting
+        |> Sg.uniform "SunLightEnabled" (AVal.constant cfg.sun.IsSome)
+        |> Sg.uniform "SunDirectionWorld"
+            (AVal.constant (V3f (defaultArg cfg.sun V3d.OOI |> Vec.normalize)))
+        // colour adaption / radiometry, all switched off
+        |> Sg.uniform "useContrastS" (AVal.constant false)
+        |> Sg.uniform "contrastS" (AVal.constant 0.0f)
+        |> Sg.uniform "useBrightnS" (AVal.constant false)
+        |> Sg.uniform "brightnessS" (AVal.constant 0.0f)
+        |> Sg.uniform "useGammaS" (AVal.constant false)
+        |> Sg.uniform "gammaS" (AVal.constant 1.0f)
+        |> Sg.uniform "useGrayS" (AVal.constant false)
+        |> Sg.uniform "useColorS" (AVal.constant false)
+        |> Sg.uniform "colorS" (AVal.constant V3f.III)
+        |> Sg.uniform "useRadiometry" (AVal.constant false)
+        |> Sg.uniform "abR" (AVal.constant (V3f(0.0f, 255.0f, 0.0f)))
+        |> Sg.uniform "abG" (AVal.constant (V3f(0.0f, 255.0f, 0.0f)))
+        |> Sg.uniform "abB" (AVal.constant (V3f(0.0f, 255.0f, 0.0f)))
+
+    /// The ladder. Stage order matches `ViewerUtils.surfaceEffect` exactly; a rung is a
+    /// prefix of that list, not a re-ordering of it.
+    let effect (stack : EffectStack) =
+        let vertexLighting =
+            [ PRo3D.SPICE.Shaders.planetLocalLightingViewSpace |> toEffect
+              PRo3D.Core.ImageProjection.Shaders.stableImageProjectionTrafo |> toEffect
+              PRo3D.SPICE.Shaders.transformShadowVertices |> toEffect ]
+
+        let transform = [ PRo3D.Base.OpcSurfaceShader.stableTrafo |> toEffect ]
+        let sizeFilter = [ PRo3D.Base.OpcSurfaceShader.triangleSizeFilter |> toEffect ]
+        let genNormal = [ PRo3D.Core.ImageProjection.Shaders.generateNormal |> toEffect ]
+        let texture = [ PRo3D.Base.OPCFilter.improvedDiffuseTexture |> toEffect ]
+        let colorChain =
+            [ PRo3D.Base.Shader.mapColorAdaption |> toEffect
+              PRo3D.Base.Shader.mapRadiometry |> toEffect ]
+        let lighting = [ PRo3D.SPICE.Shaders.solarLighting |> toEffect ]
+
+        let stages =
+            match stack with
+            | Minimal -> transform @ texture
+            | Filter  -> transform @ sizeFilter @ texture
+            | Normals ->
+                [ PRo3D.Core.ImageProjection.Shaders.stableImageProjectionTrafo |> toEffect ]
+                @ transform @ sizeFilter @ genNormal @ texture
+            | Lit     -> vertexLighting @ transform @ sizeFilter @ genNormal @ texture @ lighting
+            | Color   -> vertexLighting @ transform @ sizeFilter @ genNormal @ texture @ colorChain @ lighting
+
+        FShade.Effect.compose stages
+
+    // ---------------------------------------------------------------- scene graph
+
+    /// Union of the hierarchies' global bounding boxes, so the default camera and the
+    /// logged extents describe the data rather than a hand-copied literal.
+    let boundingBox (scene : OpcScene) =
+        let serializer = FsPickler.CreateBinarySerializer()
+        let mutable bb = Box3d.Invalid
+        for basePath in scene.patchHierarchies do
+            let h = PatchHierarchy.load serializer.Pickle serializer.UnPickle (OpcPaths.OpcPaths basePath)
+            let root =
+                match h.tree with
+                | QTree.Node (p, _) -> p
+                | QTree.Leaf p -> p
+            bb <- bb.ExtendedBy root.info.GlobalBoundingBox
+        bb
+
+    // ---------------------------------------------------------------- render
+
+    /// Multisampled targets cannot be downloaded directly, so when `samples > 1` the
+    /// render goes to an MSAA target and is resolved into a single-sample texture that
+    /// the screenshot is read back from -- the same two-step the window path does
+    /// internally. Returned as (signature, downloadTarget, output, resolve).
+    let private createTarget (runtime : IRuntime) (size : V2i) (samples : int) =
+        let samples = max 1 samples
+        let res = V3i(size.X, size.Y, 1)
+        let color = runtime.CreateTexture(res, TextureDimension.Texture2D, TextureFormat.Rgba8, 1, samples)
+        let depth = runtime.CreateTexture(res, TextureDimension.Texture2D, TextureFormat.DepthComponent32f, 1, samples)
+        let signature =
+            runtime.CreateFramebufferSignature([
+                DefaultSemantic.Colors, TextureFormat.Rgba8
+                DefaultSemantic.DepthStencil, TextureFormat.DepthComponent32f
+            ], samples)
+        let fbo =
+            runtime.CreateFramebuffer(
+                signature,
+                Map.ofList [
+                    DefaultSemantic.Colors, color.GetOutputView()
+                    DefaultSemantic.DepthStencil, depth.GetOutputView()
+                ]) |> OutputDescription.ofFramebuffer
+        if samples = 1 then
+            signature, color, fbo, ignore
+        else
+            let resolved = runtime.CreateTexture(res, TextureDimension.Texture2D, TextureFormat.Rgba8, 1, 1)
+            let resolve () =
+                runtime.Copy(color.[TextureAspect.Color, 0, 0], V3i.Zero,
+                             resolved.[TextureAspect.Color, 0, 0], V3i.Zero, V3i(size.X, size.Y, 1))
+            signature, resolved, fbo, resolve
+
+    /// Cheap content fingerprint, used to decide when the LOD tree has stopped refining.
+    let private fingerprint (img : PixImage) =
+        let data = img.ToPixImage<byte>().Volume.Data
+        let mutable h = 17UL
+        let mutable i = 0
+        // every 7th byte: enough to notice a patch swapping in, cheap enough to run
+        // once per warm-up frame
+        while i < data.Length do
+            h <- h * 1099511628211UL ^^^ uint64 data.[i]
+            i <- i + 7
+        h
+
+    /// Render until the image stops changing, then download it.
+    ///
+    /// A fixed warm-up count is the usual approach but it is wrong in both directions
+    /// here: too few passes and the screenshot shows a coarser LOD than the viewer would,
+    /// too many and every run pays for the worst case. The LOD decider needs a rendered
+    /// frame to decide against, so this just renders until two consecutive frames agree.
+    let private renderStable (runtime : IRuntime) (signature : IFramebufferSignature)
+                             (fbo : OutputDescription) (color : IBackendTexture)
+                             (resolve : unit -> unit) (maxFrames : int) (sg : ISg) =
+        use clear = runtime.CompileClear(signature, AVal.constant C4f.Black, AVal.constant 1.0)
+        use task = runtime.CompileRender(signature, sg)
+        let mutable last = 0UL
+        let mutable stable = 0
+        let mutable frame = 0
+        let mutable image = Unchecked.defaultof<PixImage>
+        while frame < maxFrames && stable < 2 do
+            clear.Run(fbo)
+            task.Run(fbo)
+            resolve ()
+            image <- runtime.Download(color)
+            let h = fingerprint image
+            if frame > 0 && h = last then stable <- stable + 1 else stable <- 0
+            last <- h
+            frame <- frame + 1
+        Log.line "[render] settled after %d frame(s)%s" frame
+            (if stable < 2 then sprintf " (NOT converged, hit --max-frames %d)" maxFrames else "")
+        image
+
+    let private save (dir : string) (name : string) (image : PixImage) =
+        if not (Directory.Exists dir) then Directory.CreateDirectory dir |> ignore
+        let path = Path.Combine(dir, name)
+        image.Save(path)
+        Log.line "[out] %s" path
+        path
+
+    // ---------------------------------------------------------------- entry point
+
+    let run (cfg : Config) =
+
+        Aardvark.Init()
+
+        let debugConfig =
+            if cfg.dumpGlsl then
+                { Aardvark.Rendering.GL.DebugConfig.Normal with PrintShaderCode = true }
+            else Aardvark.Rendering.GL.DebugConfig.Normal
+
+        use app = new OpenGlApplication(debug = debugConfig)
+        let runtime = app.Runtime
+        Log.line "[gl] %s | %s" runtime.Context.Driver.vendor runtime.Context.Driver.renderer
+
+        let bb = boundingBox cfg.scene
+        Log.line "[opc] bbox centre %.1f %.1f %.1f  size %.1f %.1f %.1f m"
+            bb.Center.X bb.Center.Y bb.Center.Z bb.Size.X bb.Size.Y bb.Size.Z
+
+        let view = cameraView bb cfg.camera
+        Log.line "[cam] eye %.2f %.2f %.2f  fwd %.4f %.4f %.4f"
+            view.Location.X view.Location.Y view.Location.Z
+            view.Forward.X view.Forward.Y view.Forward.Z
+        Log.line "[cam] near %.3f far %.1f" cfg.scene.near cfg.scene.far
+
+        let stacks = if List.isEmpty cfg.stacks then EffectStack.all else cfg.stacks
+
+        // `asyncLoading = false`: a screenshot must not race the loader. The interactive
+        // path keeps async loading so flying around stays responsive.
+        let hierarchySgs signature runner asyncLoading =
+            let serializer = FsPickler.CreateBinarySerializer()
+            cfg.scene.patchHierarchies
+            |> Seq.toList
+            |> List.map (fun basePath ->
+                let h = PatchHierarchy.load serializer.Pickle serializer.UnPickle (OpcPaths.OpcPaths basePath)
+                let t = PatchLod.toRoseTree h.tree
+                Sg.patchLod signature runner basePath cfg.scene.lodDecider
+                            cfg.scene.useCompressedTextures false ViewerModality.XYZ
+                            PatchLod.CoordinatesMapping.Local asyncLoading t)
+
+        let decorate signature runner asyncLoading (stack : EffectStack)
+                     (viewTrafo : aval<Trafo3d>) (projTrafo : aval<Trafo3d>) =
+            hierarchySgs signature runner asyncLoading
+            |> Sg.ofList
+            |> Sg.viewTrafo viewTrafo
+            |> Sg.projTrafo projTrafo
+            |> Sg.effect [ effect stack ]
+            |> applyDefaultUniforms cfg
+            |> Sg.fillMode (AVal.constant cfg.fillMode)
+            |> Sg.cullMode (AVal.constant cfg.cullMode)
+
+        if cfg.interactive then
+            let stack = List.head (stacks @ [ Minimal ])
+            Log.line "[stack] %s (interactive)" (EffectStack.name stack)
+            let win = app.CreateGameWindow()
+            let runner = runtime.CreateLoadRunner 1
+            let speed = AVal.init cfg.scene.speed
+            let controlled = view |> DefaultCameraController.controlWithSpeed speed win.Mouse win.Keyboard win.Time
+            let frustum =
+                win.Sizes |> AVal.map (fun s ->
+                    Frustum.perspective 60.0 cfg.scene.near cfg.scene.far (float s.X / float s.Y))
+
+            win.Keyboard.KeyDown(Keys.PageUp).Values.Add(fun _ ->
+                transact (fun _ -> speed.Value <- speed.Value * 1.5))
+            win.Keyboard.KeyDown(Keys.PageDown).Values.Add(fun _ ->
+                transact (fun _ -> speed.Value <- speed.Value / 1.5))
+
+            let sg =
+                decorate win.FramebufferSignature runner true stack
+                    (controlled |> AVal.map CameraView.viewTrafo)
+                    (frustum |> AVal.map Frustum.projTrafo)
+            win.RenderTask <- runtime.CompileRender(win.FramebufferSignature, sg)
+            win.Run()
+            0
+        else
+            let signature, color, fbo, resolve = createTarget runtime cfg.size cfg.samples
+            let runner = runtime.CreateLoadRunner 1
+            let aspect = float cfg.size.X / float cfg.size.Y
+            let frustum = Frustum.perspective 60.0 cfg.scene.near cfg.scene.far aspect
+            let viewTrafo = AVal.constant (CameraView.viewTrafo view)
+            let projTrafo = AVal.constant (Frustum.projTrafo frustum)
+
+            for stack in stacks do
+                Log.line "[stack] %s" (EffectStack.name stack)
+                let sg = decorate signature runner false stack viewTrafo projTrafo
+                let image = renderStable runtime signature fbo color resolve cfg.maxFrames sg
+                save cfg.outputDir (sprintf "%s-%s.png" cfg.name (EffectStack.name stack)) image
+                |> ignore
+            0

--- a/src/PRo3D.Base/Utilities.fs
+++ b/src/PRo3D.Base/Utilities.fs
@@ -119,6 +119,101 @@ module OPCFilter =
         let EffectOPCFilter =
             toEffect improvedDiffuseTexture
 
+/// The first two stages of the OPC surface effect: the stable local -> view/clip
+/// transform and the view-space triangle filter that consumes it. They live here rather
+/// than next to the rest of the viewer's surface effects so that the headless harness
+/// (src/OpcViewer, `ScreenshotViewer`) renders the exact shaders the viewer runs instead
+/// of copies that drift out of sync.
+module OpcSurfaceShader =
+
+    /// Must carry every varying the surface fragment stages read: a geometry shader only
+    /// emits the fields of its own vertex type, so anything missing here is dropped
+    /// before the fragment stage sees it.
+    type Vertex = {
+        [<Position>]        pos     : V4f
+        [<Color>]           c       : V4f
+        [<TexCoord>]        tc      : V2f
+
+        [<Semantic("ViewSpacePos")>]
+        vp : V4f
+
+        [<Semantic("FootPrintProj")>]
+        tc0     : V4f
+
+        [<Normal>]
+        n : V3f
+
+        [<SourceVertexIndex>]  sourceVertexIndex : int
+    }
+
+    type UniformScope with
+        // size filter stuff
+        member x.MaxTriangleSize : float = x?MaxTriangleSize
+        member x.FilterTriangleEnabled : bool = x?FilterTriangleEnabled
+
+        // filter for distance to home position
+        member x.FilterByDistance : bool = x?FilterByDistance
+        member x.FilterDistance : float32 = x?FilterDistance
+        member x.HomePositionViewSpace : V3f = x?HomePositionViewSpace
+
+    /// local -> clip via the CPU-composed double-precision MVP, keeping view space
+    /// around for everything downstream that must not touch world space.
+    let stableTrafo (v : Vertex) =
+        vertex {
+            let p = uniform.ModelViewProjTrafo * v.pos
+
+            return
+                { v with
+                    pos = p
+                    c = v.c
+                    vp = uniform.ModelViewTrafo * v.pos
+                }
+        }
+
+    // performs all checks in view space
+    let triangleSizeFilter (input : Triangle<Vertex>) =
+        triangle {
+            let p0 = input.P0.vp.XYZ
+            let p1 = input.P1.vp.XYZ
+            let p2 = input.P2.vp.XYZ
+
+            // TriangleSize
+            let maxSize = uniform?MaxTriangleSize
+
+            let a = (p1 - p0)
+            let b = (p2 - p1)
+            let c = (p0 - p2)
+
+            let alpha = a.Length < maxSize
+            let beta  = b.Length < maxSize
+            let gamma = c.Length < maxSize
+
+            let filterDistanceActive : bool = uniform.FilterByDistance
+            let disabled = not uniform.FilterTriangleEnabled
+            let smallTriangle = alpha && beta && gamma
+            // if disabled, let all trianlges pass
+            let validTriangle = disabled || smallTriangle
+
+            if filterDistanceActive then
+                let filterRange : float32 = uniform.FilterDistance
+                let homePositionVSp : V3f = uniform.HomePositionViewSpace
+
+                let inRange =
+                    (Vec.distance homePositionVSp p0) < filterRange &&
+                    (Vec.distance homePositionVSp p1) < filterRange &&
+                    (Vec.distance homePositionVSp p2) < filterRange
+
+                if validTriangle && inRange then
+                    yield { input.P0 with sourceVertexIndex = 0 }
+                    yield { input.P1 with sourceVertexIndex = 1 }
+                    yield { input.P2 with sourceVertexIndex = 2 }
+            else
+                if validTriangle then
+                    yield { input.P0 with sourceVertexIndex = 0 }
+                    yield { input.P1 with sourceVertexIndex = 1 }
+                    yield { input.P2 with sourceVertexIndex = 2 }
+        }
+
 module Utilities =
     type ClientStatistics =
       {

--- a/src/PRo3D.Core/Surface/Surface.Sg.fs
+++ b/src/PRo3D.Core/Surface/Surface.Sg.fs
@@ -491,6 +491,15 @@ module Sg =
                                     //Log.stop()
                                     AVal.constant (ArrayBuffer(arr) :> IBuffer)
                                 | None ->
+                                    // NOTE: on Apple Silicon this constant attribute does not
+                                    // arrive as the zero it binds -- whole patches read back
+                                    // garbage. Verified by swapping in a real zero-filled
+                                    // ArrayBuffer, which reads back as exact zero on the same
+                                    // machine. It is kept because a real buffer would cost an
+                                    // extra Patch.load per patch on the no-cross-section path
+                                    // (i.e. almost always); crossSectionClip instead guards on
+                                    // CrossSectionDefined so it never reads this. Do not read
+                                    // InsideOutsideV4 without that guard. See docs/CrossSections.md.
                                     SingleValueBuffer(AVal.constant V4f.Zero) :> aval<IBuffer>
                             )
 

--- a/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
@@ -742,62 +742,11 @@ module ViewerUtils =
             member x.HomePositionViewSpace : V3f = x?HomePositionViewSpace
 
 
-        // performs all checks in view space
-        let triangleSizeFilter (input : Triangle<Vertex>) =
-            triangle {
-                let p0 = input.P0.vp.XYZ
-                let p1 = input.P1.vp.XYZ
-                let p2 = input.P2.vp.XYZ
-
-                // TriangleSize
-                let maxSize = uniform?MaxTriangleSize
-
-                let a = (p1 - p0)
-                let b = (p2 - p1)
-                let c = (p0 - p2)
-
-                let alpha = a.Length < maxSize
-                let beta  = b.Length < maxSize
-                let gamma = c.Length < maxSize
-
-                let filterDistanceActive : bool = uniform.FilterByDistance
-                let disabled = not uniform.FilterTriangleEnabled
-                let smallTriangle = alpha && beta && gamma
-                // if disabled, let all trianlges pass
-                let validTriangle = disabled || smallTriangle
-
-                if filterDistanceActive then
-                    let filterRange : float32 = uniform.FilterDistance
-                    let homePositionVSp : V3f = uniform.HomePositionViewSpace
-
-                    let inRange =
-                        (Vec.distance homePositionVSp p0) < filterRange &&
-                        (Vec.distance homePositionVSp p1) < filterRange &&
-                        (Vec.distance homePositionVSp p2) < filterRange
-
-                    if validTriangle && inRange then
-                        yield { input.P0 with sourceVertexIndex = 0 } 
-                        yield { input.P1 with sourceVertexIndex = 1 } 
-                        yield { input.P2 with sourceVertexIndex = 2 } 
-                else
-                    if validTriangle then
-                        yield { input.P0 with sourceVertexIndex = 0 } 
-                        yield { input.P1 with sourceVertexIndex = 1 } 
-                        yield { input.P2 with sourceVertexIndex = 2 } 
-            }
-         
-
-        let stableTrafo (v : Vertex) =
-            vertex {
-                let p = uniform.ModelViewProjTrafo * v.pos
-
-                return
-                    { v with
-                        pos = p
-                        c = v.c
-                        vp = uniform.ModelViewTrafo * v.pos
-                    }
-            }
+        // Both moved to PRo3D.Base (OpcSurfaceShader) so the headless OPC harness
+        // (src/OpcViewer, ScreenshotViewer) renders these exact shaders rather than
+        // copies that drift out of sync.
+        let stableTrafo = PRo3D.Base.OpcSurfaceShader.stableTrafo
+        let triangleSizeFilter = PRo3D.Base.OpcSurfaceShader.triangleSizeFilter
 
         type UniformScope with
             member x.HasNormals : bool = x?HasNormals
@@ -837,14 +786,57 @@ module ViewerUtils =
             insideOutside : V4f
         }
 
+        type CrossSectionDebugVertex = {
+            [<Color>] c : V4f
+            [<Semantic("InsideOutsideV4")>]
+            insideOutside : V4f
+        }
+
         type UniformScope with
             member x.CrossSectionClippingEnabled : bool = x?CrossSectionClippingEnabled
+            member x.CrossSectionDefined : bool = x?CrossSectionDefined
 
+        /// Discards surface fragments outside the cross-section polygon, using the signed
+        /// distance that Surface.Sg writes into the per-vertex InsideOutsideV4 attribute.
+        ///
+        /// The CrossSectionDefined guard is not redundant with CrossSectionClippingEnabled:
+        /// clipping is enabled by default and means "clip if there is something to clip
+        /// against", so without the guard this ran on every scene from the first frame.
+        /// With no cross-section, Surface.Sg binds InsideOutsideV4 as a *constant* vertex
+        /// attribute (SingleValueBuffer). On Apple Silicon that value does not arrive:
+        /// whole patches read back garbage instead of the bound zero, and roughly half of
+        /// it is negative, so this discarded a mesh-grid lattice of fragments across the
+        /// terrain -- the Apple-Silicon-only "dark quads" artefact. Substituting a real
+        /// zero-filled ArrayBuffer makes the same machine read exact zeros, which pins it
+        /// to the constant-attribute path specifically.
+        ///
+        /// Whether the fault is Apple's GL driver or how Aardvark's GL backend drives the
+        /// constant path (glVertexAttrib*f sets context state, not VAO state, and only
+        /// applies while the attribute array is disabled) has NOT been established --
+        /// don't repeat either as fact. Either way, reading the attribute only when it has
+        /// been genuinely filled avoids the broken path at zero cost.
         let crossSectionClip (v : CrossSectionVertex) =
             fragment {
-                if uniform.CrossSectionClippingEnabled && v.insideOutside.X < 0.0f then
+                if uniform.CrossSectionClippingEnabled && uniform.CrossSectionDefined
+                   && v.insideOutside.X < 0.0f then
                     discard()
                 return v
+            }
+
+        /// Diagnostic -- paints the value `crossSectionClip` tests instead of discarding
+        /// on it: green = 0, red = negative (would be discarded), blue = positive. Never
+        /// in the default effect; add it with PRO3D_SURFACE_EFFECT_ADD=crossSectionDebug.
+        ///
+        /// This is what identified the artefact above: with no cross-section the surface
+        /// should be uniformly green, and on Apple Silicon whole patches come back
+        /// red/blue. Keep it -- if the constant-attribute path is ever depended on again,
+        /// this shows it in one frame.
+        let crossSectionDebug (v : CrossSectionDebugVertex) =
+            fragment {
+                let s = v.insideOutside.X
+                if s < 0.0f then return V4f(1.0f, 0.0f, 0.0f, 1.0f)
+                elif s > 0.0f then return V4f(0.0f, 0.0f, 1.0f, 1.0f)
+                else return V4f(0.0f, 1.0f, 0.0f, 1.0f)
             }
 
     module CurtainShader =
@@ -943,67 +935,163 @@ module ViewerUtils =
             Shader.fixAlpha          |> toEffect
         ]
 
-    let surfaceEffect =
-        Effect.compose [
-
+    /// The surface effect, one named stage per entry, in composition order. Order is
+    /// load-bearing -- FShade composes these in sequence, so a stage may only be dropped,
+    /// never moved.
+    ///
+    /// Named and filterable because of the Apple Silicon surface artefact (regular dark
+    /// quads across the terrain, M-series only). The headless harness in src/OpcViewer
+    /// renders `minimal` cleanly on an M1, and so does the viewer when cut down to it, so
+    /// the artefact is caused by one of the stages *not* in `minimalStages`. See
+    /// docs/OpcViewer-Screenshot-Harness.md.
+    let private surfaceStages : list<string * Effect> =
+        [
             // image projection
-            PRo3D.SPICE.Shaders.planetLocalLightingViewSpace   |> toEffect
-            ImageProjection.Shaders.stableImageProjectionTrafo |> toEffect
-            PRo3D.SPICE.Shaders.transformShadowVertices |> toEffect
-            
-            
-            Shaders.donutVertex |> toEffect
-            Shader.footprintV        |> toEffect 
-            Shader.stableTrafo       |> toEffect
-            Shader.triangleSizeFilter   |> toEffect
-            
-            ImageProjection.Shaders.generateNormal |> toEffect
-           
-            Shader.fixAlpha |> toEffect
-            PRo3D.Base.OPCFilter.improvedDiffuseTexture |> toEffect  
-            PRo3D.Base.OPCFilter.markPatchBorders |> toEffect 
-           
-            
+            "planetLocalLighting",  PRo3D.SPICE.Shaders.planetLocalLightingViewSpace   |> toEffect
+            "imageProjTrafo",       ImageProjection.Shaders.stableImageProjectionTrafo |> toEffect
+            "shadowVertices",       PRo3D.SPICE.Shaders.transformShadowVertices        |> toEffect
+
+            "donutVertex",          Shaders.donutVertex                                |> toEffect
+            "footprintV",           Shader.footprintV                                  |> toEffect
+            "stableTrafo",          Shader.stableTrafo                                 |> toEffect
+            "triangleSizeFilter",   Shader.triangleSizeFilter                          |> toEffect
+
+            "generateNormal",       ImageProjection.Shaders.generateNormal             |> toEffect
+
+            "fixAlpha",             Shader.fixAlpha                                    |> toEffect
+            "diffuseTexture",       PRo3D.Base.OPCFilter.improvedDiffuseTexture        |> toEffect
+            "markPatchBorders",     PRo3D.Base.OPCFilter.markPatchBorders              |> toEffect
+
             // selection coloring makes gamma correction pointless. remove if we are happy with markPatchBorders
             // Shader.selectionColor          |> toEffect
             //PRo3D.Base.Shader.differentColor   |> toEffect
-                        
-            OpcViewer.Base.Shader.LoDColor.LoDColor |> toEffect                             
+
+            "lodColor",             OpcViewer.Base.Shader.LoDColor.LoDColor            |> toEffect
             //PRo3D.Base.Shader.falseColorsScalars |> toEffect
-            PRo3D.Base.Shader.mapColorAdaption  |> toEffect  
-            PRo3D.Base.Shader.mapRadiometry |> toEffect
+            "colorAdaption",        PRo3D.Base.Shader.mapColorAdaption                 |> toEffect
+            "radiometry",           PRo3D.Base.Shader.mapRadiometry                    |> toEffect
 
-            Shader.secondaryTexture |> toEffect 
+            "secondaryTexture",     Shader.secondaryTexture                            |> toEffect
 
-            Shader.contourLines |> toEffect
-            Shaders.donutFragment |> toEffect
+            "contourLines",         Shader.contourLines                                |> toEffect
+            "donutFragment",        Shaders.donutFragment                              |> toEffect
 
-            CrossSectionShader.crossSectionClip |> toEffect
+            "crossSectionClip",     CrossSectionShader.crossSectionClip                |> toEffect
+            // diagnostic only -- never in the default set, add it explicitly
+            if System.Environment.GetEnvironmentVariable "PRO3D_SURFACE_EFFECT_ADD" = "crossSectionDebug" then
+                ("crossSectionDebug", CrossSectionShader.crossSectionDebug             |> toEffect)
 
             //PRo3D.Base.Shader.depthImageF        |> toEffect
-            PRo3D.Base.Shader.depthCalculation2     |> toEffect //depthImageF        |> toEffect
+            "depthCalculation",     PRo3D.Base.Shader.depthCalculation2                |> toEffect
 
-            PRo3D.Base.Shader.footPrintF        |> toEffect
+            "footPrintF",           PRo3D.Base.Shader.footPrintF                       |> toEffect
 
             // TODO HERA: make this optional
-            ImageProjection.Shaders.stableImageProjection |> toEffect
+            "imageProjection",      ImageProjection.Shaders.stableImageProjection      |> toEffect
 
             if not Config.limitedShaderCapabilities then
-                ImageProjection.Shaders.localImageProjections |> toEffect
+                ("localImageProjections", ImageProjection.Shaders.localImageProjections |> toEffect)
 
-            PRo3D.SPICE.Shaders.solarLighting |> toEffect
+            "solarLighting",        PRo3D.SPICE.Shaders.solarLighting                  |> toEffect
         ]
-        //Effect.compose [
-            
-        //    Shader.stableTrafo       |> toEffect
-           
 
-        //    PRo3D.Base.OPCFilter.improvedDiffuseTexture |> toEffect  
-        //    PRo3D.Base.OPCFilter.markPatchBorders |> toEffect 
+    /// Stages are not independent: a fragment stage that reads a varying needs the vertex
+    /// stage that writes it still composed, or FShade finds no producer, falls through to
+    /// looking for a vertex attribute of that name, and the GL backend throws
+    /// "Could not get attribute '<name>'" at draw time.
+    ///
+    /// Dropping a producer therefore drops its consumers too (see `closeOverDependencies`)
+    /// rather than crashing the run -- a bisect tool that dies on half its inputs costs a
+    /// round every time it is used wrong.
+    let private stageDependencies =
+        Map.ofList [
+            // footprintV writes FootPrintProj (tc0)
+            "footPrintF",             [ "footprintV" ]
+            "depthCalculation",       [ "footprintV" ]
+            // donutVertex writes the donut varyings
+            "donutFragment",          [ "donutVertex" ]
+            // stableImageProjectionTrafo writes BodyLocalPos / ProjectedImagePos,
+            // generateNormal writes LocalNormal
+            "generateNormal",         [ "imageProjTrafo" ]
+            "imageProjection",        [ "imageProjTrafo"; "generateNormal" ]
+            "localImageProjections",  [ "imageProjTrafo"; "generateNormal" ]
+            // planetLocalLightingViewSpace writes the normal and light direction
+            "solarLighting",          [ "planetLocalLighting" ]
+        ]
 
+    /// Drop any selected stage whose dependencies are not also selected, to a fixpoint.
+    let private closeOverDependencies (selected : Set<string>) =
+        let mutable current = selected
+        let mutable changed = true
+        while changed do
+            let next =
+                current |> Set.filter (fun name ->
+                    match Map.tryFind name stageDependencies with
+                    | Some deps -> deps |> List.forall (fun d -> Set.contains d current)
+                    | None -> true)
+            changed <- next <> current
+            current <- next
+        current
 
-        //    OpcViewer.Base.Shader.LoDColor.LoDColor |> toEffect                             
-        //]
+    /// Exactly the stages the OpcViewer harness's `color` rung composes -- the subset
+    /// known to render clean on Apple Silicon.
+    let private minimalStages =
+        Set.ofList [
+            "planetLocalLighting"; "imageProjTrafo"; "shadowVertices"
+            "stableTrafo"; "triangleSizeFilter"; "generateNormal"
+            "diffuseTexture"; "colorAdaption"; "radiometry"; "solarLighting"
+        ]
+
+    /// Which stages to compose, from the environment so the variants can be A/B'd in one
+    /// session without a rebuild. Unset = the real effect, unchanged.
+    ///
+    ///   PRO3D_SURFACE_EFFECT=minimal   only the known-clean subset
+    ///   PRO3D_SURFACE_EFFECT_ADD=a,b   minimal plus these (bisect upwards)
+    ///   PRO3D_SURFACE_EFFECT_DROP=a,b  everything except these (bisect downwards)
+    ///
+    /// ADD and DROP both imply their own base, so give one or the other. Unknown names
+    /// are an error rather than a silent no-op: a typo that quietly changes nothing
+    /// produces a "clean" run that means nothing.
+    let private selectedStageNames () =
+        let env name =
+            match System.Environment.GetEnvironmentVariable name with
+            | null | "" -> None
+            | v -> v.Split([| ','; ';' |], System.StringSplitOptions.RemoveEmptyEntries)
+                   |> Array.map (fun s -> s.Trim())
+                   |> Set.ofArray
+                   |> Some
+
+        let known = surfaceStages |> List.map fst |> Set.ofList
+        let checkKnown (which : string) (names : Set<string>) =
+            let unknown = Set.difference names known
+            if not (Set.isEmpty unknown) then
+                failwithf "%s names unknown surface stage(s): %s\nknown stages: %s"
+                    which (String.concat ", " unknown) (String.concat ", " (List.map fst surfaceStages))
+            names
+
+        match env "PRO3D_SURFACE_EFFECT_ADD", env "PRO3D_SURFACE_EFFECT_DROP" with
+        | Some add, _ -> Set.union minimalStages (checkKnown "PRO3D_SURFACE_EFFECT_ADD" add)
+        | None, Some drop -> Set.difference known (checkKnown "PRO3D_SURFACE_EFFECT_DROP" drop)
+        | None, None ->
+            if System.Environment.GetEnvironmentVariable "PRO3D_SURFACE_EFFECT" = "minimal"
+            then minimalStages else known
+
+    let surfaceEffect =
+        let requested = selectedStageNames ()
+        let selected = closeOverDependencies requested
+        let stages = surfaceStages |> List.filter (fun (n, _) -> Set.contains n selected)
+        if stages.Length <> surfaceStages.Length then
+            let cascaded = Set.difference requested selected
+            if not (Set.isEmpty cascaded) then
+                Log.warn "surfaceEffect: also dropped %s -- their producers were dropped"
+                    (String.concat ", " cascaded)
+            Log.warn "surfaceEffect: %d/%d stages active" stages.Length surfaceStages.Length
+            Log.warn "surfaceEffect: dropped %s"
+                (surfaceStages
+                 |> List.map fst
+                 |> List.filter (fun n -> not (Set.contains n selected))
+                 |> String.concat ", ")
+        Effect.compose (stages |> List.map snd)
 
     let isViewPlanVisible (m:AdaptiveModel) =
         adaptive {
@@ -1234,6 +1322,12 @@ module ViewerUtils =
                 |> ASet.map snd
                 |> Sg.set
                 |> Sg.uniform "CrossSectionClippingEnabled" m.scene.crossSectionModel.clippingEnabled
+                // Is there actually a cross-section to clip against? clippingEnabled
+                // defaults to true (CrossSection-Model.fs) and says only "clip if you
+                // can", so without this the clip shader runs from the first frame with no
+                // polygon defined -- and then reads a per-vertex attribute that is only
+                // meaningfully filled when a cross-section exists. See crossSectionClip.
+                |> Sg.uniform "CrossSectionDefined" (crossSectionData |> AVal.map Option.isSome)
                 |> Sg.applyCrossSection crossSectionData
                 |> Sg.noEvents
 


### PR DESCRIPTION
## Problem

On Apple Silicon the OPC surface rendered a regular lattice of black holes across the terrain. Windows and Linux were unaffected.

The cause was `crossSectionClip` discarding fragments based on a per-vertex attribute that had never been filled.

`clippingEnabled` defaults to `true` and only means "clip if there is something to clip against", but nothing checked whether a cross-section actually existed. So the clip shader ran from the first frame of every scene and read `InsideOutsideV4`, which `Surface.Sg` binds as a **constant** vertex attribute (`SingleValueBuffer`) while no cross-section is defined. On Apple Silicon that value does not arrive — whole patches read back garbage instead of the bound zero, and roughly half of it is negative, so it was discarded.

## Fix

A `CrossSectionDefined` uniform, so the attribute is only read once it holds real data. Zero cost.

Substituting a real zero-filled `ArrayBuffer` also fixes it and was used to confirm the diagnosis, but would cost an extra `Patch.load` per patch on the no-cross-section path — i.e. almost always.

Whether the underlying fault is Apple's GL driver or how Aardvark's GL backend drives the constant-attribute path is **not** established; the comments say so rather than guessing. Reported upstream.

## Verification

Full 22-stage `surfaceEffect`, no environment overrides, same scene and camera that showed the artefact: clean. `contourLines` alone was rendered as a matched control and was clean, isolating the cause to this one stage.

## Also included — the tooling this was found with

- **`src/OpcViewer/ScreenshotViewer.fs`** — headless/interactive OPC renderer with an effect *ladder* that composes progressively more of the viewer's surface effect (`minimal` → `filter` → `normals` → `lit` → `color`), plus a CLI (`--dataset`/`--eye`/`--bearing`/`--pitch`/`--stack`/`--dump-glsl`). `--eye/--bearing/--pitch` take the numbers straight off PRo3D's HUD, so a bug report becomes one command.
- **`ViewerUtils.surfaceEffect` is now a named, dependency-aware stage list**, filterable via `PRO3D_SURFACE_EFFECT` / `_ADD` / `_DROP`. Unset changes nothing. `stageDependencies` drops consumers when their producer is dropped, so any subset is valid instead of throwing `Could not get attribute`.
- **`crossSectionDebug`** — paints the tested attribute instead of discarding on it (green = 0, red = negative, blue = positive). This is what turned the diagnosis from inference into observation.
- **`scripts/capture-surface-effect.sh`** — one unattended bisect round: launch on the most recent scene, screenshot, shut down.
- **`PRo3D.Base.OpcSurfaceShader`** — `stableTrafo` + `triangleSizeFilter` moved out of the viewer so the harness and the viewer share the same shaders rather than copies that drift.

## Docs

`docs/OpcViewer-Screenshot-Harness.md` (new) and a mechanism section in `docs/CrossSections.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)