### PR TITLE
fix(cross-section): only clip when a cross-section is defined

### DIFF
--- a/docs/CrossSections.md
+++ b/docs/CrossSections.md
@@ -67,6 +67,32 @@ Next choose curtain settings and set up the curtain:
 
 ![alt text](images/crossSectionAndCurtain.png)
 
+## How clipping is implemented
+
+`Surface.Sg` writes a signed distance to the cross-section polygon (negative inside) into
+a per-vertex `InsideOutsideV4` attribute, and the `crossSectionClip` fragment stage
+discards fragments whose interpolated distance is negative.
+
+Two flags gate it, and they are not redundant:
+
+- **`CrossSectionClippingEnabled`** — the user's Clipping checkbox. Defaults to **true**,
+  so it only means "clip if there is something to clip against".
+- **`CrossSectionDefined`** — whether a cross-section actually exists.
+
+Without the second, the clip shader ran on every scene from the first frame. In that
+state `InsideOutsideV4` holds no meaningful data: `Surface.Sg` binds it as a constant
+attribute (`SingleValueBuffer`), and on Apple Silicon that value does not arrive — whole
+patches read back garbage instead of the bound zero, roughly half of it negative, so the
+shader discarded a lattice of fragments across the terrain. Windows and Linux were
+unaffected.
+
+**Do not read `InsideOutsideV4` without checking `CrossSectionDefined`.**
+
+Whether the underlying fault is Apple's GL driver or how Aardvark's GL backend handles
+constant vertex attributes is not established; substituting a real zero-filled buffer for
+the same attribute reads back correctly on the same machine, which narrows it to that
+path but not to a cause.
+
 ## Future work
 
 This might be interesting: https://www.youtube.com/watch?v=RKH1gKXCD6A

--- a/src/PRo3D.Core/Surface/Surface.Sg.fs
+++ b/src/PRo3D.Core/Surface/Surface.Sg.fs
@@ -491,6 +491,11 @@ module Sg =
                                     //Log.stop()
                                     AVal.constant (ArrayBuffer(arr) :> IBuffer)
                                 | None ->
+                                    // Placeholder only. This constant attribute does not
+                                    // arrive as the bound zero on Apple Silicon -- whole
+                                    // patches read back garbage. Do not read
+                                    // InsideOutsideV4 unless a cross-section is defined;
+                                    // crossSectionClip guards on CrossSectionDefined.
                                     SingleValueBuffer(AVal.constant V4f.Zero) :> aval<IBuffer>
                             )
 

--- a/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
@@ -839,10 +839,22 @@ module ViewerUtils =
 
         type UniformScope with
             member x.CrossSectionClippingEnabled : bool = x?CrossSectionClippingEnabled
+            member x.CrossSectionDefined : bool = x?CrossSectionDefined
 
+        /// Discards surface fragments outside the cross-section polygon, using the signed
+        /// distance Surface.Sg writes into the per-vertex InsideOutsideV4 attribute.
+        ///
+        /// CrossSectionDefined is not redundant with CrossSectionClippingEnabled: clipping
+        /// is enabled by default and only means "clip if there is something to clip
+        /// against". Without the guard this ran on every scene from the first frame, and
+        /// with no cross-section defined InsideOutsideV4 holds no meaningful data --
+        /// Surface.Sg binds it as a constant attribute (SingleValueBuffer) whose value does
+        /// not arrive on Apple Silicon, so roughly half the surface read negative and was
+        /// discarded, producing a lattice of holes across the terrain.
         let crossSectionClip (v : CrossSectionVertex) =
             fragment {
-                if uniform.CrossSectionClippingEnabled && v.insideOutside.X < 0.0f then
+                if uniform.CrossSectionClippingEnabled && uniform.CrossSectionDefined
+                   && v.insideOutside.X < 0.0f then
                     discard()
                 return v
             }
@@ -1234,6 +1246,8 @@ module ViewerUtils =
                 |> ASet.map snd
                 |> Sg.set
                 |> Sg.uniform "CrossSectionClippingEnabled" m.scene.crossSectionModel.clippingEnabled
+                // Whether there is a cross-section at all. See crossSectionClip.
+                |> Sg.uniform "CrossSectionDefined" (crossSectionData |> AVal.map Option.isSome)
                 |> Sg.applyCrossSection crossSectionData
                 |> Sg.noEvents
 


### PR DESCRIPTION
Fixes the Apple-Silicon-only rendering artefact: a regular lattice of black holes across OPC terrain. Windows and Linux were unaffected.

## Cause

`crossSectionClip` discards fragments based on the signed distance in the per-vertex `InsideOutsideV4` attribute.

`clippingEnabled` defaults to `true` and only means *"clip if there is something to clip against"* — but nothing checked whether a cross-section actually existed. So the clip shader ran from the first frame of every scene, reading an attribute that holds no meaningful data in that state: with no cross-section, `Surface.Sg` binds it as a constant attribute (`SingleValueBuffer`), and on Apple Silicon that value does not arrive. Whole patches read back garbage instead of the bound zero, roughly half of it negative — and negative means `discard()`.

## Fix

A `CrossSectionDefined` uniform, so the attribute is only read once it holds real data.

## Verification

Bisected to this single stage by composing `surfaceEffect` one shader at a time; `contourLines` alone was rendered as a matched control and was clean. The value the shader tests was then painted directly instead of discarded on, showing garbage where zeros were bound. After the fix: same scene, same camera, unmodified surface effect — clean.

## What is not established

Whether the underlying fault is Apple's GL driver or how Aardvark's GL backend handles constant vertex attributes. Substituting a real zero-filled buffer for the same attribute reads back correctly on the same machine, which narrows it to that path but not to a cause. A standalone repro outside the OPC path has **not** been found — a scene of many draw calls, with a pass-through geometry shader, thousands of vertices per draw, and several other attributes bound alongside, all read the constant attribute correctly. Tracked upstream at aardvark-platform/aardvark.rendering#135, which needs a better repro before it is actionable.

The guard is correct regardless of which it turns out to be: reading an attribute that was never filled was always wrong.

## Scope

3 files, +47/-2. The diagnostic tooling used to find this is deliberately **not** included — it needs its own design and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)