### PR TITLE
Read OPC attribute layers from per-vertex aara data, show them under the 3D cursor

### DIFF
--- a/ai/RENDERING.md
+++ b/ai/RENDERING.md
@@ -28,6 +28,7 @@ OPC is the patch-based, hierarchical terrain format PRo3D is built around. An OP
 - **Loading**: `Aardvark.Data.Opc` parses the hierarchy and patch files; PRo3D discovers/validates dataset folders in `src/PRo3D.Core/Surface/` (folder discovery, `isOpcFolder`/`isSurfaceFolder`).
 - **LoD rendering**: `Aardvark.GeoSpatial.Opc` provides `Sg.patchLod` (and friends), which builds an adaptive scene-graph node that streams and swaps patch levels based on screen-space error / distance metrics.
 - **`opc-tool`** (`src/opc-tool/`) is the offline companion CLI: validate a dataset, resize/convert patch textures (to `.dds`), and **pre-build KdTrees** for picking.
+- **Attribute layers** (elevation, slope, gravity, …) come in two forms. Every OPC has them as *texture layers* under `Images/<Layer>/`, declared in the dataset's `*.opcx`. Newer exports additionally ship them as *per-vertex* `.aara` grids inside each patch directory, listed in `patch.xml`'s `<Attributes>`. Reading values at a picked point prefers the per-vertex form (three small random-access reads per layer) and falls back to decoding the texture. **Beware two traps**: the per-vertex grid is *smaller* than the position grid (a centred skirt, `off = (posSize − attrSize) / 2`), and texture layers store values *normalised into the layer's `ChannelsDefinedRange`* while per-vertex layers hold physical values. See [docs/VertexAttributes.md](../docs/VertexAttributes.md) and `src/PRo3D.Core/VertexAttributes.fs`.
 
 ---
 

--- a/docs/VertexAttributes.md
+++ b/docs/VertexAttributes.md
@@ -1,0 +1,201 @@
+﻿# Per-Vertex Attribute Layers
+
+Newer OPC exports store their attribute layers twice: as **texture layers** under
+`Images/<Layer>/` and, additionally, as **per-vertex `*.aara` grids** inside each patch
+directory. PRo3D reads the per-vertex form wherever it exists — it is far cheaper than
+decoding an image per layer per sample — and falls back to texture sampling otherwise.
+
+Two features use this:
+
+* **Profile extraction** — attribute values along an annotation, exported to CSV.
+* **The 3D cursor readout** — the *Under Cursor* section of the **Config** panel, which
+  shows the values under the mouse pointer live. This is also the testbed for the
+  extraction itself.
+
+## What the data looks like
+
+A patch directory of such an OPC (HERA Dimorphos, `AARA_Textures` export):
+
+```
+Patches/0_0_2/
+  XYZ_Local.aara              positions (V3f, 1032 x 1032)
+  Earth8K_Coordinates.aara    texture coordinates (V2f, 1032 x 1032)
+  Earth8K_Weights.aara        texture blend weights (float, 1032 x 1032)
+  LonLatRad.aara              V3f, 1024 x 1024   <-- attribute layers
+  Normal.aara                 V3f, 1024 x 1024
+  Gravity.aara                V3f, 1024 x 1024
+  Magnitude.aara              float, 1024 x 1024
+  Potential.aara              float, 1024 x 1024
+  Elevation.aara              float, 1024 x 1024
+  Slope.aara                  float, 1024 x 1024
+  patch.xml
+```
+
+`patch.xml` lists them in its `<Attributes>` element; the layer name is the file's base
+name. Only layers whose resolution matches the geometry can be exported this way, so an
+OPC may well ship a subset — or none at all.
+
+### The attribute grid is smaller than the position grid
+
+The position grid carries a skirt around the attribute grid, and its width shrinks with
+the hierarchy level because it is a constant number of *source DEM* pixels:
+
+| level | positions | attributes | offset |
+|-------|-----------|------------|--------|
+| 0     | 1032²     | 1024²      | 4      |
+| 1     | 1028²     | 1024²      | 2      |
+| 2     | 1026²     | 1024²      | 1      |
+
+So a vertex at position grid `(x, y)` maps to attribute index
+
+```
+attributeIndex = (y - off) * attrWidth + (x - off),   off = (posSize - attrSize) / 2
+```
+
+This was established empirically, by comparing the third `LonLatRad` channel (the vertex
+radius, in metres) against `|Local2Global · XYZ_Local|` for every patch of
+`g_01960mm_spc_dtm_dimo_0000n00000_v003`. The centred offset agrees to float32 round-off
+(median error 2·10⁻⁶ m); every other offset is off by at least 0.19 m. The same invariant
+guards the code — see `per-vertex layers are physically consistent` in
+`src/Tests/ProfileAttributeExtractionTest.fs`.
+
+## How a value is sampled
+
+1. Pick a surface: the KdTree hit gives a triangle index into the patch's triangle set.
+2. `PatchTriangleGrid` maps that triangle back to its three position grid indices.
+3. Barycentric weights of the hit point within the triangle.
+4. For each attribute layer, read the three corner values and blend them.
+
+Only three small random-access reads per layer are needed, so nothing has to be held in
+memory. ZIP-backed OPCs (`*.opcz`) cannot seek, so their payloads are cached instead,
+bounded at 512 MB.
+
+Interpolation is component-wise. A layer that wraps — the longitude channel of
+`LonLatRad` — is therefore interpolated *across* the 0/360 seam rather than around it, so
+values near the seam can be misleading.
+
+Vertices in the skirt have no attribute values. A hit whose triangle touches the skirt
+yields no per-vertex value for that layer, and the texture fallback takes over.
+
+## Texture sampling fallback
+
+Layers the per-vertex data does not cover are read from the patch's attribute textures.
+This costs a full image decode per layer per sample, so it is used for profile extraction
+but **never** for the 3D cursor — a surface without per-vertex layers shows nothing in the
+*Under Cursor* readout and says so.
+
+Attribute textures store each layer **normalised into the layer's `ChannelsDefinedRange`**
+from the `*.opcx` (EXR layers hold `[0,1]` floats; 8/16 bit images are normalised on read).
+Per-vertex layers hold physical values. Texture samples are therefore mapped back onto the
+layer's range so both sources are in the same units:
+
+```
+physical = definedRange.Min + sample * definedRange.Size
+```
+
+Without a declared range the raw sample is returned unchanged. Samples carrying the
+export's nodata sentinel (values `<= -9999`) are dropped rather than reported.
+
+Because texture sampling is nearest-texel while the per-vertex path interpolates, the two
+agree to a few percent of a layer's range for smooth layers (elevation, potential,
+gravity magnitude) and can differ substantially for a gradient layer such as slope.
+
+## The Under Cursor readout
+
+`Config → Show Preview Cursor` drives both the 3D pointer and this readout; it is **on by
+default**. The readout is the *Under Cursor* accordion in the **Config** panel, below
+*Screenshots*, and shows the surface, the patch and every per-vertex layer under the mouse.
+
+The readout only updates while surface picking is active — hold `CTRL` and move the mouse
+over a surface. Picking and attribute extraction run on the background picking thread, so
+neither blocks the UI.
+
+Per-patch data (attribute layer headers, triangle-to-grid mappings) is cached by path.
+Triangle mappings dominate — about 4 MB per patch — so that cache is bounded to 32
+patches, and all caches are dropped when a surface is removed.
+
+## Multi-channel `*.opcx` attribute layers
+
+For a multi-channel `Map` layer, ExportGpc writes one range per channel:
+
+```xml
+<AttributeLayer version="0" num="12">
+  <Type>Map</Type>
+  <Label>Gravity</Label>
+  <ChannelsDefinedRange>[[-0.000039896, 0.000040985], [-0.000046144, 0.000046183], [-0.000050788, 0.000050736]]</ChannelsDefinedRange>
+  ...
+```
+
+PRo3D parsed this with `Range1d.Parse`, which only understands `[min, max]`, so such OPCs
+failed to import until the `*.opcx` was hand-patched. Both forms are now accepted.
+
+The scalar layer model carries exactly one range, and it keeps the **first channel's**.
+That is the right choice because both consumers look at channel 0 — the false-colour legend
+and the de-normalisation of texture samples, which are read through
+`ChannelReference.ChannelWithIndex 0`. Unioning the channels would widen the range (by 25%
+for Dimorphos's `Gravity` layer) and skew every de-normalised value. `parseChannelRanges`
+still returns all channels for callers that need them.
+
+An unparsable range logs a warning and falls back to `[0, 1]` instead of failing the import.
+
+The parser is PRo3D's own copy, `SurfaceUtils.SurfaceAttributes` in
+`src/PRo3D.Core/Surface/SurfaceApp.fs` — reached from `SceneLoader.addSurfaceAttributes`.
+`OPCViewer.Base` ships a near-identical copy that PRo3D's import path does not use, so no
+package update is involved.
+
+## `*.opc.json` sidecar
+
+ExportGpc writes a `*.opc.json` next to the `*.opcx`. PRo3D parses it at surface import and
+logs a summary — it is not persisted into the scene:
+
+* `product_information` — product type/state, creator, creation time
+* `input_products` — the `*.gpc.json` the OPC was exported from
+* `DemModel` — the DEM reference model. **Its shape depends on `ModelType`:**
+  * `DemSphere` (Deimos BDS export) declares `Center` and a single rotation `Axis`.
+  * `DemEllipsoid` (Dimorphos export) declares `Center`, a full frame
+    `AxisX`/`AxisY`/`AxisZ`, and the three semi-axis lengths `Radii`
+    (`[89.5, 84.5, 57.5]` m for Dimorphos) — and *no* `Axis`.
+
+  Both are read; fields absent for a given model type stay `None`. A key that is present
+  but not a numeric triple logs a warning rather than being reported as missing.
+* `DskBrief` — only present for OPCs derived from a SPICE DSK (`*.bds`) shape model; the
+  Dimorphos export has none. Kept verbatim in `dskBrief`, and parsed into `dskSummary`:
+  body, reference frame, coordinate system, longitude/latitude/radius ranges and
+  vertex/plate counts. Every field is optional — DSKBRIEF output is free text.
+
+Example output for the Deimos BDS export:
+
+```
+[OpcMetadata] Deimos: deimos_k005_tho_v02.opc.json
+[OpcMetadata]   product: opc (initial), created 2026-08-04T08:10:14.619015+0000 by ExportGpc
+[OpcMetadata]   input: ...\4_ModifyGpc\Deimos\deimos_k005_tho_v02.gpc.json
+[OpcMetadata]   DEM model: DemSphere center=[39.2324, -75.5169, 339.0206] axis=[0.0301, 0.9982, -0.0526]
+[OpcMetadata]   DSK body: 402 (DEIMOS), frame IAU_DEIMOS, Planetocentric Latitudinal
+[OpcMetadata]   DSK radius 3.58220 .. 8.70680 km, longitude -180.0 .. 180.0 deg, latitude -90.0 .. 90.0 deg
+[OpcMetadata]   DSK plates: 5040, vertices: 2522
+```
+
+## Code map
+
+| File | Contents |
+|------|----------|
+| `src/PRo3D.Core/VertexAttributes.fs` | `*.aara` header reading, layer discovery, grid offset, barycentric sampling |
+| `src/PRo3D.Core/ProfileAttributeExtraction.fs` | triangle-to-grid mapping, texture fallback, profile walk, CSV export |
+| `src/PRo3D.Core/TriangleSet.fs` | `computeValidQuadStarts` — the compact triangle-to-grid form |
+| `src/PRo3D.Core/OpcMetadata.fs` | `*.opc.json` / DSKBRIEF parsing |
+| `src/PRo3D.Core/Surface/SurfaceApp.fs` | `SurfaceUtils.SurfaceAttributes` — `*.opcx` attribute layer parsing |
+| `src/PRo3D.Viewer/Viewer/ViewerGUI.fs` | `Gui.Config.underCursor` — the *Under Cursor* readout |
+| `src/PRo3D.Viewer/Viewer/Picking.fs` | `pickRayInfo`, which keeps the hit info the extraction needs |
+
+## Tests
+
+`src/Tests/ProfileAttributeExtractionTest.fs` and `src/Tests/OpcSidecarTests.fs`. The
+data-backed cases self-skip; point them at OPCs with:
+
+* `PRO3D_AARA_OPC` — an OPC with per-vertex attribute layers
+* `PRO3D_BDS_OPC` — an OPC with a `*.opc.json` carrying a `DskBrief`
+
+```
+dotnet run --project src/Tests -- --testdatasource C:\pro3ddata \
+    --filter "all.profile tests.ProfileAttributeExtraction"
+```

--- a/src/PRo3D.Core/OpcMetadata.fs
+++ b/src/PRo3D.Core/OpcMetadata.fs
@@ -1,0 +1,248 @@
+namespace PRo3D.Core
+
+open System
+open System.IO
+open System.Globalization
+open System.Text.RegularExpressions
+
+open Aardvark.Base
+open Aardvark.Data.Opc
+
+open FSharp.Data
+
+/// The DEM reference model an OPC was exported against, as recorded in the `DemModel`
+/// block of the OPC's `*.opc.json` sidecar.
+///
+/// The block's shape depends on `ModelType`:
+///   * `DemSphere` declares `Center` and a single rotation `Axis`.
+///   * `DemEllipsoid` declares `Center`, a full frame `AxisX`/`AxisY`/`AxisZ`, and the
+///     three semi-axis lengths `Radii`.
+/// Fields absent for a given model type stay None.
+type DemModel =
+    {
+        /// e.g. "DemSphere" or "DemEllipsoid"
+        modelType : string
+        /// centre of the reference body in the OPC's coordinate system
+        center    : Option<V3d>
+        /// `DemSphere`: the rotation axis
+        axis      : Option<V3d>
+        /// `DemEllipsoid`: the reference frame's axes (X, Y, Z)
+        frame     : Option<V3d * V3d * V3d>
+        /// `DemEllipsoid`: semi-axis lengths, in the OPC's unit
+        radii     : Option<V3d>
+    }
+
+/// Key facts lifted out of the DSKBRIEF summary of the `*.bds` (SPICE DSK) shape
+/// model an OPC was derived from. Everything is optional - DSKBRIEF output is free
+/// text and its layout is not contractual.
+type DskSummary =
+    {
+        /// e.g. "402 (DEIMOS)"
+        body             : Option<string>
+        /// e.g. "IAU_DEIMOS" - the frame the shape model's vertices are given in
+        referenceFrame   : Option<string>
+        /// e.g. "Planetocentric Latitudinal"
+        coordinateSystem : Option<string>
+        longitudeRange   : Option<Range1d>
+        latitudeRange    : Option<Range1d>
+        /// radius range in kilometres, as reported by DSKBRIEF
+        radiusRangeKm    : Option<Range1d>
+        vertexCount      : Option<int>
+        plateCount       : Option<int>
+    }
+
+/// Contents of an OPC's `*.opc.json` sidecar, written next to the `*.opcx`.
+type OpcMetadata =
+    {
+        path             : string
+        productType      : Option<string>
+        productState     : Option<string>
+        creatorId        : Option<string>
+        creationDateTime : Option<string>
+        /// `metadata_file` entries of `input_products`
+        inputProducts    : list<string>
+        demModel         : Option<DemModel>
+        /// verbatim DSKBRIEF text, kept as-is because it carries more than is parsed below
+        dskBrief         : Option<string>
+        dskSummary       : Option<DskSummary>
+    }
+
+/// Reads the `*.opc.json` sidecar that JOANNEUM's ExportGpc writes next to an OPC.
+/// For OPCs derived from a SPICE DSK (`*.bds`) shape model it carries the DEM
+/// reference model and the DSKBRIEF summary of the source shape - body, reference
+/// frame, radius range, vertex/plate counts.
+module OpcMetadata =
+
+    let private invariant = CultureInfo.InvariantCulture
+
+    let private tryFloat (s : string) =
+        match Double.TryParse(s, NumberStyles.Float, invariant) with
+        | true, v -> Some v
+        | _       -> None
+
+    let private tryInt (s : string) =
+        match Int32.TryParse(s, NumberStyles.Integer, invariant) with
+        | true, v -> Some v
+        | _       -> None
+
+    let private tryString (json : JsonValue) (name : string) =
+        match json.TryGetProperty name with
+        | Some v -> try Some (v.AsString()) with _ -> None
+        | None   -> None
+
+    /// A three element numeric array. A present but unreadable value is reported rather than
+    /// silently treated like an absent one - otherwise a schema change looks like missing data.
+    let private tryV3d (json : JsonValue) (name : string) =
+        match json.TryGetProperty name with
+        | None -> None
+        | Some (JsonValue.Array values) when values.Length >= 3 ->
+            try Some (V3d(values.[0].AsFloat(), values.[1].AsFloat(), values.[2].AsFloat()))
+            with e ->
+                Log.warn "[OpcMetadata] %s is not a numeric triple: %s" name e.Message
+                None
+        | Some value ->
+            Log.warn "[OpcMetadata] %s is not a three element array: %s" name (value.ToString())
+            None
+
+    let private tryMatch (pattern : string) (text : string) =
+        let m = Regex.Match(text, pattern, RegexOptions.IgnoreCase)
+        if m.Success then Some m else None
+
+    let private tryGroup (pattern : string) (text : string) =
+        text |> tryMatch pattern |> Option.map (fun m -> m.Groups.[1].Value.Trim())
+
+    let private tryRange (label : string) (text : string) =
+        // e.g. "Min, max radius      (km):          3.58220     8.70680"
+        text
+        |> tryMatch (sprintf @"Min,\s*max\s+%s\s*\([^)]*\)\s*:\s*(\S+)\s+(\S+)" label)
+        |> Option.bind (fun m ->
+            match tryFloat m.Groups.[1].Value, tryFloat m.Groups.[2].Value with
+            | Some a, Some b -> Some (Range1d(min a b, max a b))
+            | _ -> None
+        )
+
+    /// Pulls the interesting fields out of a DSKBRIEF summary. Returns None when the
+    /// text does not look like DSKBRIEF output at all.
+    let parseDskBrief (text : string) =
+        if String.IsNullOrWhiteSpace text || not (text.Contains "DSKBRIEF") then None
+        else
+            Some {
+                body             = text |> tryGroup @"Body:\s*(.+)"
+                referenceFrame   = text |> tryGroup @"Reference frame:\s*(\S+)"
+                coordinateSystem = text |> tryGroup @"Coordinate system:\s*(.+)"
+                longitudeRange   = text |> tryRange "longitude"
+                latitudeRange    = text |> tryRange "latitude"
+                radiusRangeKm    = text |> tryRange "radius"
+                vertexCount      = text |> tryGroup @"Number of vertices:\s*(\d+)" |> Option.bind tryInt
+                plateCount       = text |> tryGroup @"Number of plates:\s*(\d+)" |> Option.bind tryInt
+            }
+
+    let private parseDemModel (json : JsonValue) =
+        match json.TryGetProperty "DemModel" with
+        | None -> None
+        | Some dem ->
+            let frame =
+                match tryV3d dem "AxisX", tryV3d dem "AxisY", tryV3d dem "AxisZ" with
+                | Some x, Some y, Some z -> Some (x, y, z)
+                | _ -> None
+
+            Some {
+                modelType = tryString dem "ModelType" |> Option.defaultValue "unknown"
+                center    = tryV3d dem "Center"
+                axis      = tryV3d dem "Axis"
+                frame     = frame
+                radii     = tryV3d dem "Radii"
+            }
+
+    let ofJsonString (path : string) (content : string) =
+        let json = JsonValue.Parse content
+        let productInfo = json.TryGetProperty "product_information"
+
+        let inputProducts =
+            match json.TryGetProperty "input_products" with
+            | Some (JsonValue.Array entries) ->
+                entries |> Array.toList |> List.choose (fun e -> tryString e "metadata_file")
+            | _ -> []
+
+        let dskBrief = tryString json "DskBrief"
+
+        {
+            path             = path
+            productType      = productInfo |> Option.bind (fun p -> tryString p "product_type")
+            productState     = productInfo |> Option.bind (fun p -> tryString p "product_state")
+            creatorId        = productInfo |> Option.bind (fun p -> tryString p "creator_id")
+            creationDateTime = productInfo |> Option.bind (fun p -> tryString p "creation_datetime")
+            inputProducts    = inputProducts
+            demModel         = parseDemModel json
+            dskBrief         = dskBrief
+            dskSummary       = dskBrief |> Option.bind parseDskBrief
+        }
+
+    /// The `*.opc.json` sidecar belonging to an `*.opcx` file, if present.
+    let sidecarPath (opcxPath : string) =
+        let dir = Path.GetDirectoryName opcxPath
+        let name = Path.GetFileNameWithoutExtension opcxPath
+        if String.IsNullOrEmpty dir then name + ".opc.json"
+        else dir +/ (name + ".opc.json")
+
+    let tryRead (path : string) =
+        if not (Prinziple.fileExists path) then None
+        else
+            try
+                use stream = Prinziple.openRead path
+                use reader = new StreamReader(stream)
+                Some (ofJsonString path (reader.ReadToEnd()))
+            with e ->
+                Log.warn "[OpcMetadata] could not read %s: %s" path e.Message
+                None
+
+    /// Reads the sidecar belonging to an `*.opcx` file.
+    let tryReadForOpcx (opcxPath : string) =
+        tryRead (sidecarPath opcxPath)
+
+    let private formatRange (unit : string) (r : Option<Range1d>) =
+        match r with
+        | Some r -> sprintf "%.5f .. %.5f %s" r.Min r.Max unit
+        | None   -> "n/a"
+
+    /// Logs what was found. The sidecar is not persisted into the scene, so this is
+    /// currently the only place the BDS provenance shows up.
+    let log (surfaceName : string) (metadata : OpcMetadata) =
+        Log.line "[OpcMetadata] %s: %s" surfaceName (Path.GetFileName metadata.path)
+        Log.line "[OpcMetadata]   product: %s (%s), created %s by %s"
+            (metadata.productType      |> Option.defaultValue "?")
+            (metadata.productState     |> Option.defaultValue "?")
+            (metadata.creationDateTime |> Option.defaultValue "?")
+            (metadata.creatorId        |> Option.defaultValue "?")
+
+        for input in metadata.inputProducts do
+            Log.line "[OpcMetadata]   input: %s" input
+
+        match metadata.demModel with
+        | Some dem ->
+            Log.line "[OpcMetadata]   DEM model: %s center=%s"
+                dem.modelType
+                (dem.center |> Option.map (fun c -> c.ToString()) |> Option.defaultValue "n/a")
+
+            dem.axis  |> Option.iter (fun a -> Log.line "[OpcMetadata]     axis: %s" (a.ToString()))
+            dem.radii |> Option.iter (fun r -> Log.line "[OpcMetadata]     semi-axes: %s" (r.ToString()))
+            dem.frame |> Option.iter (fun (x, y, z) ->
+                Log.line "[OpcMetadata]     frame: x=%s y=%s z=%s" (x.ToString()) (y.ToString()) (z.ToString()))
+        | None -> ()
+
+        match metadata.dskSummary with
+        | Some dsk ->
+            Log.line "[OpcMetadata]   DSK body: %s, frame %s, %s"
+                (dsk.body             |> Option.defaultValue "?")
+                (dsk.referenceFrame   |> Option.defaultValue "?")
+                (dsk.coordinateSystem |> Option.defaultValue "?")
+            Log.line "[OpcMetadata]   DSK radius %s, longitude %s, latitude %s"
+                (formatRange "km"  dsk.radiusRangeKm)
+                (formatRange "deg" dsk.longitudeRange)
+                (formatRange "deg" dsk.latitudeRange)
+            Log.line "[OpcMetadata]   DSK plates: %s, vertices: %s"
+                (dsk.plateCount  |> Option.map string |> Option.defaultValue "?")
+                (dsk.vertexCount |> Option.map string |> Option.defaultValue "?")
+        | None ->
+            if metadata.dskBrief.IsSome then
+                Log.line "[OpcMetadata]   DskBrief present but not recognised as DSKBRIEF output"

--- a/src/PRo3D.Core/PRo3D.Core.fsproj
+++ b/src/PRo3D.Core/PRo3D.Core.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="TransformationApp.fs" />
     <Compile Include="TriangleSet.fs" />
     <Compile Include="Surface.fs" />
+    <Compile Include="VertexAttributes.fs" />
     <Compile Include="ProfileAttributeExtraction.fs" />
     <Compile Include="GroupsApp.fs" />
     <Compile Include="OrientationCube.fs" />
@@ -81,6 +82,7 @@
     <Compile Include="Drawing\EllipseAnnotation.fs" />
     <Compile Include="Drawing\Drawing-App.fs" />
     <Compile Include="InstrumentMetadata.fs" />
+    <Compile Include="OpcMetadata.fs" />
     <Compile Include="ProjectedImageList-Model.fs" />
 	<Compile Include="ProjectedImageList-Model.g.fs" />
     <Compile Include="GisApp-Model.fs" />

--- a/src/PRo3D.Core/ProfileAttributeExtraction.fs
+++ b/src/PRo3D.Core/ProfileAttributeExtraction.fs
@@ -25,29 +25,34 @@ open PRo3DCompability
 
 open System.Globalization
 
-/// Compact triangle-to-position-grid mapping of one patch. `TriangleSet.computeGridIndices`
-/// emits two triangles per valid quad, so storing each valid quad's top-left grid index is
-/// enough to recover any triangle's three grid indices.
+/// Compact triangle-to-position-grid mapping of one patch: two triangles per quad, so each
+/// quad's top-left grid index is enough to recover any triangle's three grid indices.
+/// Built by `TriangleSet.computeTriangleQuadStarts`, which documents how the numbering
+/// follows the KdTree's object set.
 type PatchTriangleGrid =
     {
         /// size of the patch's position grid (index = y * gridSize.X + x)
         gridSize  : V2i
-        /// top-left grid index of each valid quad, in triangle emission order
+        /// top-left grid index of each quad in triangle order, -1 where the triangles are
+        /// degenerate fillers with no grid position
         quadStart : int[]
     }
 
     member x.TriangleCount = x.quadStart.Length * 2
 
     /// The three position grid indices of triangle `triangleIndex`, matching the winding
-    /// `TriangleSet.computeGridIndices` produces (a,b,c then c,b,d).
+    /// `TriangleSet.computeGridIndices` produces (a,b,c then c,b,d). None for a filler
+    /// triangle or an index outside the patch.
     member x.TryGetTriangleIndices (triangleIndex : int) =
         let quad = triangleIndex / 2
         if triangleIndex < 0 || quad >= x.quadStart.Length then None
         else
             let a = x.quadStart.[quad]
-            let b = a + x.gridSize.X
-            if triangleIndex % 2 = 0 then Some [| a; b; a + 1 |]
-            else Some [| a + 1; b; b + 1 |]
+            if a < 0 then None
+            else
+                let b = a + x.gridSize.X
+                if triangleIndex % 2 = 0 then Some [| a; b; a + 1 |]
+                else Some [| a + 1; b; b + 1 |]
 
 /// What to do for layers the per-vertex `*.aara` data does not cover.
 [<RequireQualifiedAccess>]
@@ -103,8 +108,8 @@ module ProfileAttributeExtraction =
     let private triGridMappingCache = Dictionary<string, PatchTriangleGrid>()
 
     /// Maps triangles of a patch's KdTree TriangleSet back onto the position grid it was
-    /// built from. Relies on `TriangleSet.computeGridIndices` emitting triangles in the
-    /// same order (and with the same NaN-quad skipping) as the KdTree construction did.
+    /// built from. `TriangleSet.computeTriangleQuadStarts` documents how the numbering has to
+    /// follow the object set the KdTree was built from.
     let buildTriangleToGridMapping (affine: Trafo3d) (objectSetPath: string) =
         lock triGridMappingCache (fun () ->
             match triGridMappingCache.TryGetValue(objectSetPath) with
@@ -115,7 +120,7 @@ module ProfileAttributeExtraction =
                 let mapping =
                     {
                         gridSize  = size
-                        quadStart = TriangleSet.computeValidQuadStarts size positions.Data
+                        quadStart = TriangleSet.computeTriangleQuadStarts size positions.Data
                     }
 
                 if triGridMappingCache.Count >= maxCachedTriangleGrids then
@@ -128,10 +133,6 @@ module ProfileAttributeExtraction =
                 mapping
         )
 
-    /// Drops cached per-patch data. Called when surfaces are removed.
-    let clearCaches () =
-        lock triGridMappingCache (fun () -> triGridMappingCache.Clear())
-        VertexAttributes.clearCache ()
 
     /// Interpolated texture coordinate at a hit. Only the three corner texels are read
     /// from the coordinates *.aara instead of loading the whole grid.
@@ -265,6 +266,9 @@ module ProfileAttributeExtraction =
     /// `objectSetPath` persisted in a kd-tree does. A case-sensitive lookup silently misses
     /// every patch of such a surface.
     let buildPatchInfoLookup (sgSurface : SgSurface) =
+        // reached from the background picking thread and from profile export on the update
+        // thread, so the shared Dictionary needs the same lock as the mapping cache
+        lock patchInfoLookupCache (fun () ->
         match patchInfoLookupCache.TryGetValue(sgSurface.surface) with
         | true, lookup -> lookup
         | _ ->
@@ -283,6 +287,13 @@ module ProfileAttributeExtraction =
             patchInfoLookupCache.[sgSurface.surface] <- dict
             Log.line "[Extraction] built patch info lookup for surface %A with %d entries" sgSurface.surface dict.Count
             dict
+        )
+
+    /// Drops all cached per-patch data. Called when surfaces are removed.
+    let clearCaches () =
+        lock triGridMappingCache (fun () -> triGridMappingCache.Clear())
+        lock patchInfoLookupCache (fun () -> patchInfoLookupCache.Clear())
+        VertexAttributes.clearCache ()
 
     /// Extract attributes at a KdTree hit point.
     ///
@@ -318,7 +329,14 @@ module ProfileAttributeExtraction =
                             let layers = VertexAttributes.getLayers patchDir patchInfo
                             VertexAttributes.sample layers positionsGridSize gridIndices weights
 
-                        let covered = fromVertices |> List.map (fun a -> a.name) |> Set.ofList
+                        // texture layer names come from the Images/<Layer> folder, per-vertex
+                        // ones from the *.aara base name - compared case-insensitively so a
+                        // spelling difference cannot let the less accurate texture value
+                        // through and override the per-vertex one
+                        let covered =
+                            // System's HashSet - FSharp.Data.Adaptive.HashSet has no comparer
+                            System.Collections.Generic.HashSet<string>(
+                                fromVertices |> List.map (fun a -> a.name), StringComparer.OrdinalIgnoreCase)
 
                         let fromTextures =
                             // Only pay for image decoding when the per-vertex layers are

--- a/src/PRo3D.Core/ProfileAttributeExtraction.fs
+++ b/src/PRo3D.Core/ProfileAttributeExtraction.fs
@@ -25,6 +25,50 @@ open PRo3DCompability
 
 open System.Globalization
 
+/// Compact triangle-to-position-grid mapping of one patch. `TriangleSet.computeGridIndices`
+/// emits two triangles per valid quad, so storing each valid quad's top-left grid index is
+/// enough to recover any triangle's three grid indices.
+type PatchTriangleGrid =
+    {
+        /// size of the patch's position grid (index = y * gridSize.X + x)
+        gridSize  : V2i
+        /// top-left grid index of each valid quad, in triangle emission order
+        quadStart : int[]
+    }
+
+    member x.TriangleCount = x.quadStart.Length * 2
+
+    /// The three position grid indices of triangle `triangleIndex`, matching the winding
+    /// `TriangleSet.computeGridIndices` produces (a,b,c then c,b,d).
+    member x.TryGetTriangleIndices (triangleIndex : int) =
+        let quad = triangleIndex / 2
+        if triangleIndex < 0 || quad >= x.quadStart.Length then None
+        else
+            let a = x.quadStart.[quad]
+            let b = a + x.gridSize.X
+            if triangleIndex % 2 = 0 then Some [| a; b; a + 1 |]
+            else Some [| a + 1; b; b + 1 |]
+
+/// What to do for layers the per-vertex `*.aara` data does not cover.
+[<RequireQualifiedAccess>]
+type TextureFallback =
+    /// Never decode textures. Required for interactive per-frame use such as the 3D
+    /// cursor, where one image decode per layer per mouse move is not affordable.
+    | Disabled
+    /// Decode and point sample the patch's attribute textures. `scalarLayers` are the
+    /// surface's `*.opcx` attribute layers as stored on `Surface.scalarLayers`; they carry
+    /// the range the texture values are normalised into, which is needed to recover
+    /// physical values.
+    | Enabled of scalarLayers : HashMap<int, ScalarLayer>
+
+/// Attributes sampled at a single picked surface point.
+type AttributeHit = {
+    position   : V3d
+    /// name of the patch the hit landed in, e.g. "0_0_2"
+    patchName  : string
+    attributes : list<SampledAttribute>
+}
+
 /// Result of attribute extraction at a single sample point.
 type ProfileSample = {
     position   : V3d
@@ -51,33 +95,56 @@ module ProfileAttributeExtraction =
             let u = 1.0 - v - w
             V3d(u, v, w)
 
-    // Cache for triangle-to-grid index mappings (keyed by objectSetPath)
-    let private triGridMappingCache = Dictionary<string, int[][]>()
+    // Cached triangle-to-grid mappings, keyed by objectSetPath. Building one reads the
+    // patch's whole position grid, so it is worth keeping - but each entry costs ~4 MB for
+    // a 1032^2 patch, and the 3D cursor pulls in a new patch whenever it crosses a patch
+    // boundary. Bounded so a long session cannot grow without limit.
+    let private maxCachedTriangleGrids = 32
+    let private triGridMappingCache = Dictionary<string, PatchTriangleGrid>()
 
+    /// Maps triangles of a patch's KdTree TriangleSet back onto the position grid it was
+    /// built from. Relies on `TriangleSet.computeGridIndices` emitting triangles in the
+    /// same order (and with the same NaN-quad skipping) as the KdTree construction did.
     let buildTriangleToGridMapping (affine: Trafo3d) (objectSetPath: string) =
-        match triGridMappingCache.TryGetValue(objectSetPath) with
-        | true, mapping -> mapping
-        | _ ->
-            let positions = objectSetPath |> Aara.fromFile<V3f>
-            let size = positions.Size.XY.ToV2i()
-            let indices = TriangleSet.computeGridIndices size positions.Data
-            let mapping = indices |> Array.chunkBySize 3
-            triGridMappingCache.[objectSetPath] <- mapping
-            Log.line "[Extraction] built triangle mapping for %s (%d triangles)" (Path.GetFileName(Path.GetDirectoryName(objectSetPath))) mapping.Length
-            mapping
+        lock triGridMappingCache (fun () ->
+            match triGridMappingCache.TryGetValue(objectSetPath) with
+            | true, mapping -> mapping
+            | _ ->
+                let positions = objectSetPath |> Aara.fromFile<V3f>
+                let size = positions.Size.XY.ToV2i()
+                let mapping =
+                    {
+                        gridSize  = size
+                        quadStart = TriangleSet.computeValidQuadStarts size positions.Data
+                    }
 
-    let getUVAtHit (coordinatesPath: string) (gridMapping: int[][]) (triIdx: int) (triangle: Triangle3d) (hitPoint: V3d) =
-        let texCoords = coordinatesPath |> Aara.fromFile<V2f>
-        // V-flip to match Patch.load convention
-        let texCoordData = texCoords.Data |> Array.map (fun v -> V2f(v.X, 1.0f - v.Y))
-        let gridIndices = gridMapping.[triIdx]
-        let uv0 = texCoordData.[gridIndices.[0]]
-        let uv1 = texCoordData.[gridIndices.[1]]
-        let uv2 = texCoordData.[gridIndices.[2]]
-        let bary = computeBarycentric triangle hitPoint
-        let u = float32 bary.X * uv0.X + float32 bary.Y * uv1.X + float32 bary.Z * uv2.X
-        let v = float32 bary.X * uv0.Y + float32 bary.Y * uv1.Y + float32 bary.Z * uv2.Y
-        V2f(u, v)
+                if triGridMappingCache.Count >= maxCachedTriangleGrids then
+                    Log.line "[Extraction] triangle mapping cache full (%d patches) - dropping" triGridMappingCache.Count
+                    triGridMappingCache.Clear()
+
+                triGridMappingCache.[objectSetPath] <- mapping
+                Log.line "[Extraction] built triangle mapping for %s (%d triangles, %dx%d grid)"
+                    (Path.GetFileName(Path.GetDirectoryName(objectSetPath))) mapping.TriangleCount size.X size.Y
+                mapping
+        )
+
+    /// Drops cached per-patch data. Called when surfaces are removed.
+    let clearCaches () =
+        lock triGridMappingCache (fun () -> triGridMappingCache.Clear())
+        VertexAttributes.clearCache ()
+
+    /// Interpolated texture coordinate at a hit. Only the three corner texels are read
+    /// from the coordinates *.aara instead of loading the whole grid.
+    let getUVAtHit (coordinatesPath: string) (positionsGridSize: V2i) (gridIndices: int[]) (weights: V3d) =
+        match VertexAttributes.tryGetLayer coordinatesPath with
+        | None -> None
+        | Some layer ->
+            match VertexAttributes.sampleOne layer positionsGridSize gridIndices weights with
+            | Some sample when sample.values.Length >= 2 ->
+                // V-flip to match Patch.load convention. Interpolation and the flip
+                // commute because barycentric weights sum to 1.
+                Some (V2f(float32 sample.values.[0], 1.0f - float32 sample.values.[1]))
+            | _ -> None
 
     let private readPixelValue (img: PixImage) (px: int) (py: int) =
         match img with
@@ -101,54 +168,107 @@ module ProfileAttributeExtraction =
         let py = clamp 0 (h - 1) (int (uv.Y * float32 h))
         readPixelValue img px py
 
-    let extractAttributesAtUV (uv: V2f) (patchInfo: PatchFileInfo) (opcPaths: OpcPaths) =
-        let numTextures = patchInfo.Textures.Length / 2 // first half = textures, second half = weights
-        let results = Dictionary<string, float[]>()
-        for i in 1 .. numTextures - 1 do
-            let texturePath = Patch.tryExtractTexturePath opcPaths patchInfo i
-            match texturePath with
-            | None -> ()
-            | Some (texturePath, texName) ->
-                let isExr = Path.GetExtension(texturePath).ToLower() = ".exr"
-                let extension =
-                    match Path.GetExtension(texturePath).ToLower() with
-                    | ".dds" -> Some TextureLoading.DDS
-                    | ".tiff" | ".tif" -> Some TextureLoading.TIFF
-                    | ".exr" -> Some TextureLoading.TextureFormat.OpenEXR
-                    | _ -> None
+    /// Indices into `patchInfo.Textures` that denote actual attribute textures.
+    /// `PatchFileInfo.Textures` interleaves DiffuseColorNTexture with DiffuseColorNWeights
+    /// entries; the weights are *.aara files and are dropped here. The first remaining
+    /// entry is the patch's base colour texture and carries no attribute meaning.
+    let private attributeTextureIndices (patchInfo: PatchFileInfo) =
+        let textures =
+            patchInfo.Textures
+            |> List.indexed
+            |> List.filter (fun (_, t) -> not (t.fileName.EndsWith(".aara", StringComparison.OrdinalIgnoreCase)))
+            |> List.map fst
+        match textures with
+        | _ :: rest -> rest
+        | []        -> []
 
-                if isExr then
-                    use stream = Prinziple.openRead texturePath
-                    let mipMap = TextureLoading.loadImageFromStream stream (ChannelReference.ChannelWithIndex 0) extension
-                    match mipMap.ImageArray |> Seq.tryHead with
-                    | Some img ->
-                        match sampleImageAtUV uv img with
-                        | Some values -> results.[texName] <- values
-                        | None -> ()
-                    | None ->
-                        Log.warn "[Extraction] no image in EXR mipmap for texture %d" i
-                else
-                    use stream = Prinziple.openRead texturePath
-                    let mipMap = TextureLoading.loadImageFromStream stream ChannelReference.NoChannelSelection extension
-                    match mipMap.ImageArray |> Seq.tryHead with
-                    | Some img ->
-                        match sampleImageAtUV uv img with
-                        | Some values -> results.[texName] <- values
-                        | None -> ()
-                    | None ->
-                        Log.warn "[Extraction] no image in mipmap for texture %d" i
+    /// Sentinel the exports write into attribute textures where a layer has no value.
+    /// Normalised samples live in [0, 1], so anything this negative is nodata.
+    let private textureNoData = -9999.0
 
-        results
+    /// Attribute textures store each layer normalised into the layer's
+    /// `ChannelsDefinedRange` from the `*.opcx` - EXR layers hold [0,1] floats, and 8/16
+    /// bit images are normalised by `readPixelValue`. The per-vertex `*.aara` layers hold
+    /// physical values instead, so texture samples are mapped back onto the layer's range
+    /// to make the two sources comparable. Without a known range the raw sample is
+    /// returned unchanged, which is what this code did before the ranges were consulted.
+    let private toPhysical (range : Option<Range1d>) (values : float[]) =
+        match range with
+        | None   -> values
+        | Some r -> values |> Array.map (fun v -> r.Min + v * r.Size)
+
+    /// Looks up the range a texture layer's values are normalised into, by layer label.
+    /// `Surface.scalarLayers` is keyed by layer index, so it is re-keyed here.
+    let rangeLookup (scalarLayers : HashMap<int, ScalarLayer>) =
+        let byLabel =
+            scalarLayers
+            |> HashMap.toValueList
+            |> List.map (fun l -> l.label, l.definedRange)
+            |> Map.ofList
+        fun (label : string) -> byLabel |> Map.tryFind label
+
+    let private sampleTexture (opcPaths: OpcPaths) (patchInfo: PatchFileInfo) (rangeOf: string -> Option<Range1d>) (uv: V2f) (index: int) =
+        match Patch.tryExtractTexturePath opcPaths patchInfo index with
+        | None -> None
+        | Some (texturePath, texName) ->
+            let ext = Path.GetExtension(texturePath).ToLowerInvariant()
+            let format =
+                match ext with
+                | ".dds"          -> Some TextureLoading.DDS
+                | ".tiff" | ".tif" -> Some TextureLoading.TIFF
+                | ".exr"          -> Some TextureLoading.TextureFormat.OpenEXR
+                | _               -> None
+
+            // EXR layers are single channel scalar maps written into channel 0
+            let channel =
+                if ext = ".exr" then ChannelReference.ChannelWithIndex 0
+                else ChannelReference.NoChannelSelection
+
+            use stream = Prinziple.openRead texturePath
+            let mipMap = TextureLoading.loadImageFromStream stream channel format
+            match mipMap.ImageArray |> Seq.tryHead with
+            | None ->
+                Log.warn "[Extraction] no image in mipmap for texture %d (%s)" index texName
+                None
+            | Some img ->
+                sampleImageAtUV uv img
+                |> Option.bind (fun values ->
+                    if values |> Array.exists (fun v -> v <= textureNoData) then None
+                    else
+                        Some { name = texName; values = toPhysical (rangeOf texName) values; source = AttributeSource.TextureSampling }
+                )
+
+    /// Samples the patch's attribute textures at `uv`, skipping layers already covered by
+    /// per-vertex data. Decoding an image per layer is what makes this the slow path.
+    let extractAttributesAtUV (uv: V2f) (patchInfo: PatchFileInfo) (opcPaths: OpcPaths) (rangeOf: string -> Option<Range1d>) (alreadyCovered: string -> bool) =
+        attributeTextureIndices patchInfo
+        |> List.choose (fun index ->
+            match Patch.tryExtractTexturePath opcPaths patchInfo index with
+            | Some (_, texName) when alreadyCovered texName -> None
+            | Some _ -> sampleTexture opcPaths patchInfo rangeOf uv index
+            | None   -> None
+        )
+
+    /// Paths persisted in kd-trees and paths derived from `OpcPaths` can use different
+    /// directory separators, so they are normalised before being matched against each other.
+    let private normalizeSeparators (path : string) =
+        path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
 
     // Cache for PatchFileInfo lookups, keyed by surface guid
     let private patchInfoLookupCache = Dictionary<Guid, Dictionary<string, PatchFileInfo * OpcPaths>>()
 
     /// Build (or retrieve from cache) the patchInfoLookup for a given SgSurface.
-    let buildPatchInfoLookup (sgSurface: SgSurface) =
+    ///
+    /// Keys are compared case-insensitively on purpose: `OpcPaths.Patches_DirAbsPath` probes
+    /// `"patches"` before `"Patches"` and `Directory.Exists` is case-insensitive on Windows,
+    /// so the keys built here can spell the patches directory differently than the
+    /// `objectSetPath` persisted in a kd-tree does. A case-sensitive lookup silently misses
+    /// every patch of such a surface.
+    let buildPatchInfoLookup (sgSurface : SgSurface) =
         match patchInfoLookupCache.TryGetValue(sgSurface.surface) with
         | true, lookup -> lookup
         | _ ->
-            let dict = Dictionary<string, PatchFileInfo * OpcPaths>()
+            let dict = Dictionary<string, PatchFileInfo * OpcPaths>(StringComparer.OrdinalIgnoreCase)
             match sgSurface.dataSource with
             | DataSource.OpcHierarchy hierarchies ->
                 for h in hierarchies do
@@ -157,7 +277,7 @@ module ProfileAttributeExtraction =
                         let info = leaf.info
                         let dir = h.opcPaths.Patches_DirAbsPath +/ info.Name
                         let objectSetPath = dir +/ info.Positions
-                        dict.[objectSetPath] <- (info, OpcPaths h.opcPaths.Opc_DirAbsPath)
+                        dict.[normalizeSeparators objectSetPath] <- (info, OpcPaths h.opcPaths.Opc_DirAbsPath)
             | DataSource.Mesh ->
                 Log.warn "[Extraction] mesh data source not supported for attribute extraction"
             patchInfoLookupCache.[sgSurface.surface] <- dict
@@ -165,8 +285,10 @@ module ProfileAttributeExtraction =
             dict
 
     /// Extract attributes at a KdTree hit point.
-    /// Returns the attributes dictionary, or None if extraction fails.
-    let extractAttributesFromHit (hitInfo: KdTreeHitInfo) (ray: FastRay3d) =
+    ///
+    /// Per-vertex `*.aara` layers are read first - three small random-access reads per
+    /// layer. Layers the vertex data does not cover fall back to `textureFallback`.
+    let extractAttributesFromHit (textureFallback : TextureFallback) (hitInfo : KdTreeHitInfo) (ray : FastRay3d) =
         let sgSurf = hitInfo.sgSurface
 
         // find the Level0KdTree for the hit bounding box
@@ -175,18 +297,47 @@ module ProfileAttributeExtraction =
             match kdMap |> HashMap.tryFind hitInfo.hitBBox with
             | Some (Level0KdTree.LazyKdTree kd) ->
                 try
-                    let gridMapping = buildTriangleToGridMapping kd.affine kd.objectSetPath
+                    let mapping = buildTriangleToGridMapping kd.affine kd.objectSetPath
+                    let positionsGridSize = mapping.gridSize
                     let triIdx = hitInfo.hit.SetObject.Index
                     let triangleSet = hitInfo.hit.SetObject.Set :?> TriangleSet
                     let triangle = DebugKdTreesX.getTriangle triangleSet triIdx
                     let hitPoint = ray.Ray.GetPointOnRay(hitInfo.hit.RayHit.T)
-                    let uv = getUVAtHit kd.coordinatesPath gridMapping triIdx triangle hitPoint
+                    let weights = computeBarycentric triangle hitPoint
 
+                    let patchDir = Path.GetDirectoryName kd.objectSetPath
                     let patchInfoLookup = buildPatchInfoLookup sgSurf
-                    match patchInfoLookup.TryGetValue(kd.objectSetPath) with
-                    | true, (patchInfo, opcPaths) ->
-                        let attributes = extractAttributesAtUV uv patchInfo opcPaths
-                        Some (hitPoint, attributes)
+                    match mapping.TryGetTriangleIndices triIdx,
+                          patchInfoLookup.TryGetValue(normalizeSeparators kd.objectSetPath) with
+                    | None, _ ->
+                        Log.warn "[Extraction] triangle %d outside the grid mapping of %s (%d triangles)"
+                            triIdx patchDir mapping.TriangleCount
+                        None
+                    | Some gridIndices, (true, (patchInfo, opcPaths)) ->
+                        let fromVertices =
+                            let layers = VertexAttributes.getLayers patchDir patchInfo
+                            VertexAttributes.sample layers positionsGridSize gridIndices weights
+
+                        let covered = fromVertices |> List.map (fun a -> a.name) |> Set.ofList
+
+                        let fromTextures =
+                            // Only pay for image decoding when the per-vertex layers are
+                            // missing or do not cover a layer.
+                            match textureFallback with
+                            | TextureFallback.Disabled -> []
+                            | TextureFallback.Enabled _ when attributeTextureIndices patchInfo |> List.isEmpty -> []
+                            | TextureFallback.Enabled scalarLayers ->
+                                match getUVAtHit kd.coordinatesPath positionsGridSize gridIndices weights with
+                                | Some uv -> extractAttributesAtUV uv patchInfo opcPaths (rangeLookup scalarLayers) covered.Contains
+                                | None ->
+                                    Log.warn "[Extraction] no texture coordinates for %s" patchDir
+                                    []
+
+                        Some {
+                            position   = hitPoint
+                            patchName  = patchInfo.Name
+                            attributes = fromVertices @ fromTextures
+                        }
                     | _ ->
                         Log.warn "[Extraction] no patch info found for %s" kd.objectSetPath
                         None
@@ -218,13 +369,17 @@ module ProfileAttributeExtraction =
         let surfaceFilter = fun (_id : Guid) (l : Leaf) (_s : SgSurface) -> l.visible && l.active
         let mutable cache = cache
         let mutable allAttributeNames = Set.empty<string>
-        let mutable samples = []
+        let samples = List<ProfileSample>(points.Length)
         let mutable accDistance = 0.0
+        let mutable vertexSourced = 0
+        let mutable textureSourced = 0
 
-        for i in 0 .. points.Length - 1 do
-            let p = points.[i]
+        let pointArray = points |> List.toArray
+
+        for i in 0 .. pointArray.Length - 1 do
+            let p = pointArray.[i]
             if i > 0 then
-                accDistance <- accDistance + Vec.distance points.[i-1] p
+                accDistance <- accDistance + Vec.distance pointArray.[i-1] p
 
             let rayOrigin = p + up * 10.0
             let ray = FastRay3d(Ray3d(rayOrigin, -up))
@@ -232,18 +387,32 @@ module ProfileAttributeExtraction =
             match SurfaceIntersection.doKdTreeIntersection surfacesModel refSys observedSystem observerSystem ray surfaceFilter cache false with
             | Some hitInfo, c ->
                 cache <- c
-                match extractAttributesFromHit hitInfo ray with
-                | Some (hitPoint, attributes) ->
-                    for kvp in attributes do
-                        allAttributeNames <- allAttributeNames |> Set.add kvp.Key
-                    samples <- samples @ [{ position = hitPoint; distance = accDistance; attributes = attributes }]
+                // the *.opcx attribute layer ranges of the surface that was hit - needed to
+                // turn normalised texture samples back into physical values
+                let scalarLayers =
+                    match SurfaceModel.getSurface surfacesModel hitInfo.sgSurface.surface with
+                    | Some leaf -> (Leaf.toSurface leaf).scalarLayers
+                    | None      -> HashMap.empty
+                match extractAttributesFromHit (TextureFallback.Enabled scalarLayers) hitInfo ray with
+                | Some hit ->
+                    let attributes = Dictionary<string, float[]>()
+                    for a in hit.attributes do
+                        attributes.[a.name] <- a.values
+                        allAttributeNames <- allAttributeNames |> Set.add a.name
+                        match a.source with
+                        | AttributeSource.VertexData      -> vertexSourced <- vertexSourced + 1
+                        | AttributeSource.TextureSampling -> textureSourced <- textureSourced + 1
+                    samples.Add { position = hit.position; distance = accDistance; attributes = attributes }
                 | None ->
                     Log.warn $"[MultiAttrProfile] point {i}: attribute extraction failed"
             | None, c ->
                 cache <- c
                 Log.warn $"[MultiAttrProfile] point {i}: no surface hit"
 
-        samples, allAttributeNames, cache
+        Log.line "[MultiAttrProfile] %d values from per-vertex layers, %d from texture sampling"
+            vertexSourced textureSourced
+
+        samples |> List.ofSeq, allAttributeNames, cache
 
     let private formatFloat (v : float) =
         v.ToString("G", CultureInfo.InvariantCulture)

--- a/src/PRo3D.Core/Surface/SurfaceApp.fs
+++ b/src/PRo3D.Core/Surface/SurfaceApp.fs
@@ -687,23 +687,65 @@ module SurfaceUtils =
 
                 sgObjects
 
-    module SurfaceAttributes = 
+    module SurfaceAttributes =
         open System.Xml
-            
+        open System.Globalization
+        open System.Text.RegularExpressions
+
         let get (name : string) (node : XmlNode)=
             node.SelectSingleNode(name).InnerText.Trim()
-        
-        let parseMap (index : int)(node : XmlNode) : ScalarLayer = 
-            let definedRange = node |> get "ChannelsDefinedRange" |> Range1d.Parse
-            { 
+
+        let tryGet (name : string) (node : XmlNode) =
+            match node.SelectSingleNode(name) with
+            | null -> None
+            | n    -> Some (n.InnerText.Trim())
+
+        let private rangePattern = Regex(@"\[\s*([^\[\],]+?)\s*,\s*([^\[\],]+?)\s*\]", RegexOptions.Compiled)
+
+        /// ChannelsDefinedRange / ChannelsActualRange holds a single range "[min, max]" for
+        /// single channel maps, but a per-channel list "[[min,max], [min,max], [min,max]]"
+        /// for multi-channel ones - normals, gravity vectors, lon/lat/radius.
+        /// Range1d.Parse only understands the former, which made such OPCs fail to import
+        /// until the *.opcx was hand-patched.
+        let parseChannelRanges (text : string) =
+            rangePattern.Matches(text)
+            |> Seq.choose (fun m ->
+                match Double.TryParse(m.Groups.[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture),
+                      Double.TryParse(m.Groups.[2].Value, NumberStyles.Float, CultureInfo.InvariantCulture) with
+                | (true, min), (true, max) -> Some (Range1d(min, max))
+                | _ -> None
+            )
+            |> Seq.toList
+
+        /// The range carried by a scalar layer. The model has room for exactly one, and the
+        /// consumers - the false-colour legend and the de-normalisation of texture samples -
+        /// both look at the layer's *first* channel (attribute textures are read through
+        /// `ChannelReference.ChannelWithIndex 0`). So the first channel's range is the right
+        /// one; unioning the channels would widen it, e.g. by 25% for Dimorphos's Gravity
+        /// layer, and skew every de-normalised value.
+        let parseChannelRange (text : string) =
+            parseChannelRanges text |> List.tryHead
+
+        let parseMap (index : int)(node : XmlNode) : ScalarLayer =
+            let label = node |> get "Label"
+
+            let range (name : string) (fallback : Range1d) =
+                match node |> tryGet name |> Option.bind parseChannelRange with
+                | Some r -> r
+                | None ->
+                    Log.warn "[SurfaceAttributes] could not parse %s of layer %s - using %A" name label fallback
+                    fallback
+
+            let definedRange = range "ChannelsDefinedRange" (Range1d(0.0, 1.0))
+            {
                 version      = ScalarLayer.current
-                label        = node |> get "Label" 
-                actualRange  = node |> get "ChannelsActualRange"  |> Range1d.Parse
-                definedRange = definedRange //node |> get "ChannelsDefinedRange" |> Range1d.Parse
+                label        = label
+                actualRange  = range "ChannelsActualRange" definedRange
+                definedRange = definedRange
                 index        = index
                 colorLegend  = (FalseColorsModel.initDefinedScalarsLegend definedRange)
             }
-        
+
         let parseTexture (index : int)(node : XmlNode) : TextureLayer =
             { 
                 version = TextureLayer.current
@@ -865,7 +907,10 @@ module SurfaceApp =
         | RemoveSurface (id,path) -> //model
             let groups = GroupsApp.removeLeaf model.surfaces id path true
             let sg' = model.sgSurfaces |> HashMap.remove id
-            { model with surfaces = groups; sgSurfaces = sg'} |> SurfaceModel.triggerSgGrouping              
+            // per-patch attribute layers and triangle mappings are keyed by path, so drop
+            // them rather than let them outlive the surface they belong to
+            ProfileAttributeExtraction.clearCaches ()
+            { model with surfaces = groups; sgSurfaces = sg'} |> SurfaceModel.triggerSgGrouping
         | RebuildKdTrees id ->                
             let surf = id |> SurfaceModel.getSurface model
             match surf with

--- a/src/PRo3D.Core/TriangleSet.fs
+++ b/src/PRo3D.Core/TriangleSet.fs
@@ -30,6 +30,30 @@ module TriangleSet =
 
         result.ToArray()
 
+    /// Top-left grid index of every quad `computeGridIndices` emits triangles for, in the
+    /// same order - so triangle `i` belongs to quad `i / 2`.
+    ///
+    /// This is the compact form of the triangle-to-grid mapping needed to look up
+    /// per-vertex data at a picked triangle: one int per quad instead of six, and no
+    /// jagged per-triangle arrays. For a 1032x1032 patch that is 4 MB rather than the
+    /// ~100 MB a `int[3]` per triangle costs, which matters because the mapping is cached
+    /// per patch and rebuilt whenever the 3D cursor moves onto a new patch.
+    let computeValidQuadStarts (size : V2i) (positions : V3f[]) =
+        let w = size.X
+        let h = size.Y
+        let result = List<int>((w - 1) * (h - 1))
+
+        for y in 0 .. h - 2 do
+            for x in 0 .. w - 2 do
+                let a = y * w + x
+                let b = a + w
+
+                if not (positions.[a].AnyNaN || positions.[b].AnyNaN ||
+                        positions.[a + 1].AnyNaN || positions.[b + 1].AnyNaN) then
+                    result.Add a
+
+        result.ToArray()
+
 
     let getInvalidIndices3f (positions : V3f[]) =
         let result = System.Collections.Generic.List<int>(64)

--- a/src/PRo3D.Core/TriangleSet.fs
+++ b/src/PRo3D.Core/TriangleSet.fs
@@ -30,18 +30,35 @@ module TriangleSet =
 
         result.ToArray()
 
-    /// Top-left grid index of every quad `computeGridIndices` emits triangles for, in the
-    /// same order - so triangle `i` belongs to quad `i / 2`.
+    /// Top-left grid index of the quad each *picked* triangle belongs to - triangle `i`
+    /// belongs to entry `i / 2` - or -1 where a triangle carries no grid position.
     ///
-    /// This is the compact form of the triangle-to-grid mapping needed to look up
-    /// per-vertex data at a picked triangle: one int per quad instead of six, and no
-    /// jagged per-triangle arrays. For a 1032x1032 patch that is 4 MB rather than the
-    /// ~100 MB a `int[3]` per triangle costs, which matters because the mapping is cached
-    /// per patch and rebuilt whenever the 3D cursor moves onto a new patch.
-    let computeValidQuadStarts (size : V2i) (positions : V3f[]) =
+    /// This is the compact form of the triangle-to-grid mapping needed to look up per-vertex
+    /// data at a picked triangle: one int per quad instead of six, and no jagged
+    /// per-triangle arrays. For a 1032x1032 patch that is 4 MB rather than the ~100 MB an
+    /// `int[3]` per triangle costs, which matters because the mapping is cached per patch and
+    /// rebuilt whenever the 3D cursor moves onto a new patch.
+    ///
+    /// The order must match the object set the KdTree was built from, which is produced by
+    /// `DebugKdTreesX.loadTriangles'` = `PRo3DCSharp.ComputeIndexArray` followed by
+    /// `getTriangleSet`. That path does **not** compact: an invalid quad leaves six zero
+    /// indices, so it degenerates to `(positions[0], positions[0], positions[0])` and is only
+    /// dropped by the NaN filter when `positions[0]` is itself NaN. So:
+    ///
+    ///   * `positions[0]` NaN  - the fillers are dropped, only valid quads are numbered.
+    ///   * `positions[0]` valid - the fillers survive and occupy triangle slots, so every quad
+    ///     is numbered and invalid ones are marked -1.
+    ///
+    /// Getting this wrong does not fail loudly: it displaces every lookup by the number of
+    /// invalid quads before the hit and returns plausible values from the wrong vertices.
+    let computeTriangleQuadStarts (size : V2i) (positions : V3f[]) =
         let w = size.X
         let h = size.Y
-        let result = List<int>((w - 1) * (h - 1))
+        let quadCount = max 0 ((w - 1) * (h - 1))
+        let result = List<int>(quadCount)
+
+        // does a degenerate filler triangle survive getTriangleSet's NaN filter?
+        let fillersSurvive = positions.Length > 0 && not positions.[0].AnyNaN
 
         for y in 0 .. h - 2 do
             for x in 0 .. w - 2 do
@@ -51,6 +68,8 @@ module TriangleSet =
                 if not (positions.[a].AnyNaN || positions.[b].AnyNaN ||
                         positions.[a + 1].AnyNaN || positions.[b + 1].AnyNaN) then
                     result.Add a
+                elif fillersSurvive then
+                    result.Add -1
 
         result.ToArray()
 

--- a/src/PRo3D.Core/VertexAttributes.fs
+++ b/src/PRo3D.Core/VertexAttributes.fs
@@ -1,0 +1,327 @@
+namespace PRo3D.Core.Surface
+
+open System
+open System.IO
+open System.Text
+open System.Collections.Generic
+
+open Aardvark.Base
+open Aardvark.Data.Opc
+open Aardvark.SceneGraph.Opc
+
+/// Where an attribute value under the cursor / along a profile came from.
+[<RequireQualifiedAccess>]
+type AttributeSource =
+    /// interpolated from a per-vertex *.aara layer stored next to the patch geometry
+    | VertexData
+    /// point sampled from the patch's texture layer image
+    | TextureSampling
+
+/// A single attribute value sampled at a picked surface point. `values` holds one
+/// entry per channel (e.g. 3 for LonLatRad or Normal, 1 for Elevation or Slope).
+type SampledAttribute =
+    {
+        name   : string
+        values : float[]
+        source : AttributeSource
+    }
+
+/// The scalar element type of an *.aara file.
+[<RequireQualifiedAccess>]
+type AaraScalar =
+    | Float32
+    | Float64
+    | Int32
+
+    member x.ByteSize =
+        match x with
+        | AaraScalar.Float32 -> 4
+        | AaraScalar.Float64 -> 8
+        | AaraScalar.Int32   -> 4
+
+/// Header of an *.aara file: a length-prefixed type name, the dimension count and
+/// one int32 size per dimension, followed by the tightly packed payload.
+type AaraHeader =
+    {
+        typeName   : string
+        /// grid size; x is the fastest varying index (index = y * size.X + x)
+        size       : V2i
+        /// scalar components per grid element (1 for float/double, 2 for V2f, 3 for V3f, ...)
+        components : int
+        scalar     : AaraScalar
+        /// byte offset of the payload within the file
+        dataOffset : int64
+    }
+
+    member x.ElementSize = x.components * x.scalar.ByteSize
+
+/// How a layer's payload is reached. Plain files are read with random access - a
+/// pick only needs a few bytes per layer. ZIP entries inflate sequentially and
+/// cannot seek, so their payload is held in memory instead.
+[<RequireQualifiedAccess>]
+type AaraPayload =
+    | OnDisk   of path : string
+    | InMemory of payload : byte[]
+
+/// One per-vertex attribute layer of a patch.
+type VertexAttributeLayer =
+    {
+        /// layer name as used by the *.opcx attribute layers, e.g. "Elevation"
+        name    : string
+        path    : string
+        header  : AaraHeader
+        payload : AaraPayload
+    }
+
+/// Reads OPC per-vertex attribute layers - the `*.aara` files listed in a patch's
+/// `<Attributes>` element - and samples them at a picked surface point. This is the
+/// fast path for attribute extraction; the alternative is decoding the patch's
+/// texture layer images and sampling them at the hit's UV, which costs a full image
+/// decode per layer per sample.
+///
+/// **Grid layout.** Attribute layers do *not* share the position grid's size: the
+/// positions carry a symmetric skirt whose width shrinks with the hierarchy level
+/// (1032 / 1028 / 1026 against a constant 1024 attribute grid for the HERA Dimorphos
+/// exports). The attribute grid is centred in the position grid:
+///
+///     attributeIndex(x, y) = positionIndex(x + off, y + off)
+///     off = (positionGridSize - attributeGridSize) / 2
+///
+/// Verified for every patch of `g_01960mm_spc_dtm_dimo_0000n00000_v003` by comparing
+/// `LonLatRad.z` against `|Local2Global * XYZ_Local|` - median error 2e-6 m, i.e.
+/// float32 round-off. Every other offset is off by at least 0.19 m.
+module VertexAttributes =
+
+    /// Payload bytes held in memory for ZIP-backed layers before the cache is dropped.
+    /// Irrelevant for plain directories, which are read with random access.
+    let private inMemoryCacheLimit = 512L * 1024L * 1024L
+
+    /// Cached layers keyed by absolute file path, and cached layer *sets* keyed by
+    /// absolute patch directory. Attribute layers are immutable on disk, so a patch is
+    /// discovered once and reused for every pick.
+    let private fileCache = Dictionary<string, Option<VertexAttributeLayer>>()
+    let private layerCache = Dictionary<string, VertexAttributeLayer[]>()
+    let mutable private inMemoryBytes = 0L
+
+    let private tryParseTypeName (typeName : string) =
+        match typeName with
+        | "float"  -> Some (1, AaraScalar.Float32)
+        | "V2f"    -> Some (2, AaraScalar.Float32)
+        | "V3f"    -> Some (3, AaraScalar.Float32)
+        | "V4f"    -> Some (4, AaraScalar.Float32)
+        | "double" -> Some (1, AaraScalar.Float64)
+        | "V2d"    -> Some (2, AaraScalar.Float64)
+        | "V3d"    -> Some (3, AaraScalar.Float64)
+        | "V4d"    -> Some (4, AaraScalar.Float64)
+        | "int"    -> Some (1, AaraScalar.Int32)
+        | "V2i"    -> Some (2, AaraScalar.Int32)
+        | "V3i"    -> Some (3, AaraScalar.Int32)
+        | _        -> None
+
+    /// Reads the header of an already opened *.aara stream, leaving the stream
+    /// positioned at the start of the payload.
+    let tryReadHeader (stream : Stream) =
+        let typeName = Aara.readString Encoding.ASCII stream
+        let dimensions = stream.ReadByte()
+        if dimensions <= 0 || dimensions > 3 then None
+        else
+            let reader = new BinaryReader(stream, Encoding.ASCII, true)
+            let sizes = Array.init dimensions (fun _ -> reader.ReadInt32())
+            let size =
+                match sizes with
+                | [| x |]       -> V2i(x, 1)
+                | [| x; y |]    -> V2i(x, y)
+                | [| x; y; _ |] -> V2i(x, y)
+                | _             -> V2i.Zero
+
+            match tryParseTypeName typeName with
+            | Some (components, scalar) when size.X > 0 && size.Y > 0 ->
+                Some {
+                    typeName   = typeName
+                    size       = size
+                    components = components
+                    scalar     = scalar
+                    // name length byte + name + dimension count byte + one int32 per dimension
+                    dataOffset = int64 (1 + typeName.Length + 1 + 4 * dimensions)
+                }
+            | _ -> None
+
+    let private loadPayload (path : string) (header : AaraHeader) (stream : Stream) =
+        if stream.CanSeek then
+            AaraPayload.OnDisk path
+        else
+            let byteCount = int64 header.size.X * int64 header.size.Y * int64 header.ElementSize
+            if inMemoryBytes + byteCount > inMemoryCacheLimit then
+                Log.warn "[VertexAttributes] in-memory layer cache above %d MB - dropping cached layers" (inMemoryCacheLimit / 1048576L)
+                fileCache.Clear()
+                layerCache.Clear()
+                inMemoryBytes <- 0L
+
+            use ms = new MemoryStream()
+            stream.CopyTo ms
+            inMemoryBytes <- inMemoryBytes + ms.Length
+            AaraPayload.InMemory (ms.ToArray())
+
+    let private loadLayer (path : string) =
+        if not (Prinziple.fileExists path) then None
+        else
+            try
+                use stream = Prinziple.openRead path
+                match tryReadHeader stream with
+                | None ->
+                    Log.warn "[VertexAttributes] unsupported aara layout in %s" path
+                    None
+                | Some header ->
+                    Some {
+                        name    = Path.GetFileNameWithoutExtension path
+                        path    = path
+                        header  = header
+                        payload = loadPayload path header stream
+                    }
+            with e ->
+                Log.warn "[VertexAttributes] could not read %s: %s" path e.Message
+                None
+
+    /// Reads a single *.aara file as a sampleable layer, cached by path. Used for grids
+    /// that are not attribute layers, e.g. the patch's texture coordinates.
+    let tryGetLayer (path : string) =
+        lock fileCache (fun () ->
+            match fileCache.TryGetValue path with
+            | true, layer -> layer
+            | _ ->
+                let layer = loadLayer path
+                fileCache.[path] <- layer
+                layer
+        )
+
+    /// The per-vertex attribute layers of a patch, cached by patch directory. Empty
+    /// for patches that ship no `<Attributes>` (older OPCs), which is the caller's
+    /// signal to fall back to texture sampling.
+    let getLayers (patchDir : string) (patchInfo : PatchFileInfo) =
+        lock layerCache (fun () ->
+            match layerCache.TryGetValue patchDir with
+            | true, layers -> layers
+            | _ ->
+                let layers =
+                    patchInfo.Attributes
+                    // Positions2d.aara is synthesised by PatchFileInfo.load' for the 2D
+                    // modality and is not an attribute layer.
+                    |> List.filter (fun f -> Path.GetFileNameWithoutExtension(f) <> "Positions2d")
+                    |> List.choose (fun fileName -> tryGetLayer (patchDir +/ fileName))
+                    |> List.toArray
+
+                layerCache.[patchDir] <- layers
+                if layers.Length > 0 then
+                    Log.line "[VertexAttributes] %s: %d per-vertex layers (%s)"
+                        (Path.GetFileName patchDir) layers.Length
+                        (layers |> Array.map (fun l -> l.name) |> String.concat ", ")
+                layers
+        )
+
+    /// Decodes one grid element out of `buffer` into `target`.
+    let private decodeElement (header : AaraHeader) (buffer : byte[]) (offset : int) (target : float[]) =
+        for c in 0 .. header.components - 1 do
+            let o = offset + c * header.scalar.ByteSize
+            target.[c] <-
+                match header.scalar with
+                | AaraScalar.Float32 -> float (BitConverter.ToSingle(buffer, o))
+                | AaraScalar.Float64 -> BitConverter.ToDouble(buffer, o)
+                | AaraScalar.Int32   -> float (BitConverter.ToInt32(buffer, o))
+
+    /// Reads a full element from a seekable stream. Returns false on a short read.
+    let private tryReadElement (stream : Stream) (header : AaraHeader) (buffer : byte[]) (elementIndex : int) =
+        let elementSize = header.ElementSize
+        stream.Seek(header.dataOffset + int64 elementIndex * int64 elementSize, SeekOrigin.Begin) |> ignore
+        let mutable read = 0
+        let mutable eof = false
+        while not eof && read < elementSize do
+            let n = stream.Read(buffer, read, elementSize - read)
+            if n <= 0 then eof <- true else read <- read + n
+        read = elementSize
+
+    /// Maps a position grid index onto the layer's attribute grid. Returns -1 when the
+    /// vertex lies in the position grid's skirt, which carries no attribute values.
+    let private attributeIndex (positionsGridSize : V2i) (attrSize : V2i) (positionIndex : int) =
+        let offX = (positionsGridSize.X - attrSize.X) / 2
+        let offY = (positionsGridSize.Y - attrSize.Y) / 2
+        let ax = (positionIndex % positionsGridSize.X) - offX
+        let ay = (positionIndex / positionsGridSize.X) - offY
+        if ax < 0 || ay < 0 || ax >= attrSize.X || ay >= attrSize.Y then -1
+        else ay * attrSize.X + ax
+
+    let private sampleLayer (positionsGridSize : V2i) (gridIndices : int[]) (w : float[]) (layer : VertexAttributeLayer) =
+        let header = layer.header
+        let indices = gridIndices |> Array.map (attributeIndex positionsGridSize header.size)
+
+        if indices |> Array.exists (fun i -> i < 0) then None
+        else
+            let values = Array.zeroCreate<float> header.components
+            let corner = Array.zeroCreate<float> header.components
+
+            let accumulate (read : int -> bool) =
+                let mutable ok = true
+                for k in 0 .. 2 do
+                    if ok then
+                        if read indices.[k] then
+                            for c in 0 .. values.Length - 1 do
+                                values.[c] <- values.[c] + w.[k] * corner.[c]
+                        else ok <- false
+                ok
+
+            let ok =
+                match layer.payload with
+                | AaraPayload.InMemory payload ->
+                    accumulate (fun i ->
+                        let o = i * header.ElementSize
+                        if o < 0 || o + header.ElementSize > payload.Length then false
+                        else
+                            decodeElement header payload o corner
+                            true
+                    )
+                | AaraPayload.OnDisk path ->
+                    use stream = Prinziple.openRead path
+                    let buffer = Array.zeroCreate<byte> header.ElementSize
+                    accumulate (fun i ->
+                        if tryReadElement stream header buffer i then
+                            decodeElement header buffer 0 corner
+                            true
+                        else false
+                    )
+
+            if ok then Some { name = layer.name; values = values; source = AttributeSource.VertexData }
+            else None
+
+    /// Barycentrically interpolates every per-vertex layer of a patch at a picked point.
+    ///
+    /// `gridIndices` are the three indices into the *position* grid of the hit triangle
+    /// (as produced by `TriangleSet.computeGridIndices`) and `weights` the corresponding
+    /// barycentric coordinates. Layers that do not cover the hit are omitted so the
+    /// caller can fall back to texture sampling for them.
+    ///
+    /// Interpolation is component-wise, so a layer that wraps - a longitude crossing the
+    /// 0/360 seam - is interpolated across the seam rather than around it.
+    let sample
+        (layers            : VertexAttributeLayer[])
+        (positionsGridSize : V2i)
+        (gridIndices       : int[])
+        (weights           : V3d) =
+
+        if layers.Length = 0 || gridIndices.Length < 3 || positionsGridSize.X <= 0 then []
+        else
+            let w = [| weights.X; weights.Y; weights.Z |]
+            layers |> Array.toList |> List.choose (sampleLayer positionsGridSize gridIndices w)
+
+    /// Barycentric sample of a single grid, e.g. the patch's texture coordinates.
+    let sampleOne (layer : VertexAttributeLayer) (positionsGridSize : V2i) (gridIndices : int[]) (weights : V3d) =
+        if gridIndices.Length < 3 || positionsGridSize.X <= 0 then None
+        else
+            let w = [| weights.X; weights.Y; weights.Z |]
+            sampleLayer positionsGridSize gridIndices w layer
+
+    /// Drops all cached layers so ZIP payloads and stale headers do not outlive their scene.
+    let clearCache () =
+        lock layerCache (fun () ->
+            lock fileCache (fun () -> fileCache.Clear())
+            layerCache.Clear()
+            inMemoryBytes <- 0L
+        )

--- a/src/PRo3D.Core/VertexAttributes.fs
+++ b/src/PRo3D.Core/VertexAttributes.fs
@@ -96,9 +96,15 @@ module VertexAttributes =
     /// Irrelevant for plain directories, which are read with random access.
     let private inMemoryCacheLimit = 512L * 1024L * 1024L
 
-    /// Cached layers keyed by absolute file path, and cached layer *sets* keyed by
-    /// absolute patch directory. Attribute layers are immutable on disk, so a patch is
-    /// discovered once and reused for every pick.
+    /// Cached layers keyed by absolute file path, and cached layer *sets* keyed by absolute
+    /// patch directory. Attribute layers are immutable on disk, so a patch is discovered once
+    /// and reused for every pick.
+    ///
+    /// Both dictionaries and the byte accounting are guarded by one lock: the eviction path
+    /// runs inside a `tryGetLayer` call but clears `layerCache` too, and `getLayers` calls
+    /// `tryGetLayer`, so two separate locks would either race or deadlock. Monitor is
+    /// re-entrant, so the nested call is fine.
+    let private cacheLock = obj()
     let private fileCache = Dictionary<string, Option<VertexAttributeLayer>>()
     let private layerCache = Dictionary<string, VertexAttributeLayer[]>()
     let mutable private inMemoryBytes = 0L
@@ -185,7 +191,7 @@ module VertexAttributes =
     /// Reads a single *.aara file as a sampleable layer, cached by path. Used for grids
     /// that are not attribute layers, e.g. the patch's texture coordinates.
     let tryGetLayer (path : string) =
-        lock fileCache (fun () ->
+        lock cacheLock (fun () ->
             match fileCache.TryGetValue path with
             | true, layer -> layer
             | _ ->
@@ -198,7 +204,7 @@ module VertexAttributes =
     /// for patches that ship no `<Attributes>` (older OPCs), which is the caller's
     /// signal to fall back to texture sampling.
     let getLayers (patchDir : string) (patchInfo : PatchFileInfo) =
-        lock layerCache (fun () ->
+        lock cacheLock (fun () ->
             match layerCache.TryGetValue patchDir with
             | true, layers -> layers
             | _ ->
@@ -239,6 +245,14 @@ module VertexAttributes =
             if n <= 0 then eof <- true else read <- read + n
         read = elementSize
 
+    /// Whether the attribute grid can be centred in the position grid at all. A negative
+    /// difference (attribute grid larger) or an odd one (asymmetric skirt) would silently
+    /// shift every sample onto a neighbouring vertex, so such a layer is refused instead.
+    let private isCentrable (positionsGridSize : V2i) (attrSize : V2i) =
+        let dx = positionsGridSize.X - attrSize.X
+        let dy = positionsGridSize.Y - attrSize.Y
+        dx >= 0 && dy >= 0 && dx % 2 = 0 && dy % 2 = 0
+
     /// Maps a position grid index onto the layer's attribute grid. Returns -1 when the
     /// vertex lies in the position grid's skirt, which carries no attribute values.
     let private attributeIndex (positionsGridSize : V2i) (attrSize : V2i) (positionIndex : int) =
@@ -251,6 +265,12 @@ module VertexAttributes =
 
     let private sampleLayer (positionsGridSize : V2i) (gridIndices : int[]) (w : float[]) (layer : VertexAttributeLayer) =
         let header = layer.header
+        if not (isCentrable positionsGridSize header.size) then
+            Log.warn "[VertexAttributes] %s: %dx%d attribute grid cannot be centred in a %dx%d position grid - skipping"
+                layer.name header.size.X header.size.Y positionsGridSize.X positionsGridSize.Y
+            None
+        else
+
         let indices = gridIndices |> Array.map (attributeIndex positionsGridSize header.size)
 
         if indices |> Array.exists (fun i -> i < 0) then None
@@ -320,8 +340,8 @@ module VertexAttributes =
 
     /// Drops all cached layers so ZIP payloads and stale headers do not outlive their scene.
     let clearCache () =
-        lock layerCache (fun () ->
-            lock fileCache (fun () -> fileCache.Clear())
+        lock cacheLock (fun () ->
+            fileCache.Clear()
             layerCache.Clear()
             inMemoryBytes <- 0L
         )

--- a/src/PRo3D.Core/ViewConfigModel.fs
+++ b/src/PRo3D.Core/ViewConfigModel.fs
@@ -189,7 +189,7 @@ module ViewConfigModel =
         //useSurfaceHighlighting = true
         showExplorationPointGui = true
         showLeafLabels = false
-        showPreviewIntersection = false
+        showPreviewIntersection = true
         previewIntersectionWorldSize = previewIntersectionWorldSize
     }
        
@@ -225,7 +225,7 @@ module ViewConfigModel =
                     filterTexture         = false
                     showExplorationPointGui = true
                     showLeafLabels        = false
-                    showPreviewIntersection = false
+                    showPreviewIntersection = true
                     previewIntersectionWorldSize = previewIntersectionWorldSize
                 }
             }
@@ -262,7 +262,7 @@ module ViewConfigModel =
                     filterTexture         = false
                     showExplorationPointGui = true
                     showLeafLabels        = false
-                    showPreviewIntersection = false
+                    showPreviewIntersection = true
                     previewIntersectionWorldSize = previewIntersectionWorldSize
                 }
             }
@@ -301,7 +301,7 @@ module ViewConfigModel =
                     filterTexture         = false
                     showExplorationPointGui = true
                     showLeafLabels        = false
-                    showPreviewIntersection = false
+                    showPreviewIntersection = true
                     previewIntersectionWorldSize = previewIntersectionWorldSize
                 }
             }
@@ -338,7 +338,7 @@ module ViewConfigModel =
                     filterTexture         = filterTexture 
                     showExplorationPointGui = true
                     showLeafLabels        = false
-                    showPreviewIntersection = false
+                    showPreviewIntersection = true
                     previewIntersectionWorldSize = previewIntersectionWorldSize
                 }
             }
@@ -380,7 +380,7 @@ module ViewConfigModel =
                     filterTexture           = filterTexture 
                     showExplorationPointGui = if showExplorationPointGui.IsSome then showExplorationPointGui.Value else true
                     showLeafLabels          = false
-                    showPreviewIntersection = Option.defaultValue false showPreviewIntersection'
+                    showPreviewIntersection = Option.defaultValue true showPreviewIntersection'
                     previewIntersectionWorldSize = { previewIntersectionWorldSize with value = Option.defaultValue previewIntersectionWorldSize.value previewIntersectionWorldSize' }
                 }
             }

--- a/src/PRo3D.Viewer/InitialViewerModel.fs
+++ b/src/PRo3D.Viewer/InitialViewerModel.fs
@@ -183,6 +183,7 @@ module Viewer =
 
             provenanceModel = ProvenanceModel.invalid
             surfaceIntersection   = None
+            cursorAttributes      = None
             ellipseModel = None
             backgroundPicking = ThreadPool.empty
             pickPreviewRequested = new ConsumableAsyncValue<_>()

--- a/src/PRo3D.Viewer/Scene.fs
+++ b/src/PRo3D.Viewer/Scene.fs
@@ -119,8 +119,14 @@ module SceneLoader =
            let loadOpcX (path : string) =
                let layers = SurfaceUtils.SurfaceAttributes.read path
                let textures = layers |> SurfaceProperties.getTextures
-               
-               { s with 
+
+               // *.opc.json sidecar: DEM reference model and, for OPCs derived from a
+               // SPICE DSK, the DSKBRIEF summary of the source *.bds shape model.
+               // Not persisted into the scene - logged so the provenance is visible.
+               OpcMetadata.tryReadForOpcx path
+               |> Option.iter (OpcMetadata.log s.name)
+
+               { s with
                    scalarLayers  = layers |> SurfaceProperties.getScalarsHmap //SurfaceProperties.getScalars
                    textureLayers = textures
                    primaryTexture = textures |> IndexList.tryFirst

--- a/src/PRo3D.Viewer/Viewer-Model.fs
+++ b/src/PRo3D.Viewer/Viewer-Model.fs
@@ -122,7 +122,7 @@ type ViewerAction =
 
 | PickSurface                     of SceneHit * string * bool
 | PreviewPickSurface              of SceneHit * string * bool
-| PreviewPickSurfaceFinished      of SceneHit * string * Option<Aardvark.Geometry.ObjectRayHit * V3d>
+| PreviewPickSurfaceFinished      of SceneHit * string * Option<Aardvark.Geometry.ObjectRayHit * V3d> * Option<AttributeHit>
 
 
 | PickObject                      of V3d*Guid
@@ -552,6 +552,15 @@ type MultiSelectionBox =
 
 type SurfaceIntersection = { surfaceName : string; hitPoint : V3d; normal : Option<V3d> }
 
+/// Per-vertex attribute values under the 3D cursor, shown in the "Cursor" panel.
+/// Refreshed by the background preview pick, so it only exists while the preview
+/// cursor is enabled and the mouse is over a surface in picking mode.
+type CursorAttributes =
+    {
+        surfaceName : string
+        hit         : AttributeHit
+    }
+
 type ProjectedEllipse = 
     {
         surfaceProjectedPoints : Option<array<V3d>>
@@ -653,6 +662,7 @@ type Model = {
     backgroundPicking    : ThreadPool<ViewerAction>
 
     surfaceIntersection : Option<SurfaceIntersection>
+    cursorAttributes    : Option<CursorAttributes>
     ellipseModel        : Option<EllipseModel>
     pickPreviewRequested : ConsumableAsyncValue<Model * SceneHit * string>
 

--- a/src/PRo3D.Viewer/Viewer-Model.g.fs
+++ b/src/PRo3D.Viewer/Viewer-Model.g.fs
@@ -1,5 +1,5 @@
-﻿//5a0851b5-7ede-7845-5bcc-5bce88c611c3
-//0c537f1c-d451-16f4-b0c1-6b5730b3ebd9
+//57309c4c-fee6-ad33-ab7c-51ce61eaba8d
+//937c3c0e-7857-93c8-de51-96e7f3092e7d
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -222,6 +222,7 @@ type AdaptiveModel(value : Model) =
     let _provenanceModel_ = AdaptiveProvenanceModel(value.provenanceModel)
     let _backgroundPicking_ = FSharp.Data.Adaptive.cval(value.backgroundPicking)
     let _surfaceIntersection_ = FSharp.Data.Adaptive.cval(value.surfaceIntersection)
+    let _cursorAttributes_ = FSharp.Data.Adaptive.cval(value.cursorAttributes)
     let _ellipseModel_ =
         let inline __arg2 (o : System.Object) (v : EllipseModel) =
             (unbox<AdaptiveEllipseModel> o).Update(v)
@@ -280,6 +281,7 @@ type AdaptiveModel(value : Model) =
             _provenanceModel_.Update(value.provenanceModel)
             _backgroundPicking_.Value <- value.backgroundPicking
             _surfaceIntersection_.Value <- value.surfaceIntersection
+            _cursorAttributes_.Value <- value.cursorAttributes
             _ellipseModel_.Update(value.ellipseModel)
             _pickPreviewRequested_.Value <- value.pickPreviewRequested
             _userPreferences_.Value <- value.userPreferences
@@ -325,6 +327,7 @@ type AdaptiveModel(value : Model) =
     member __.provenanceModel = _provenanceModel_
     member __.backgroundPicking = _backgroundPicking_ :> FSharp.Data.Adaptive.aval<FSharp.Data.Adaptive.ThreadPool<ViewerAction>>
     member __.surfaceIntersection = _surfaceIntersection_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.Option<SurfaceIntersection>>
+    member __.cursorAttributes = _cursorAttributes_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.Option<CursorAttributes>>
     member __.ellipseModel = _ellipseModel_ :> FSharp.Data.Adaptive.aval<Adaptify.FSharp.Core.AdaptiveOptionCase<EllipseModel, AdaptiveEllipseModel, AdaptiveEllipseModel>>
     member __.pickPreviewRequested = _pickPreviewRequested_ :> FSharp.Data.Adaptive.aval<Aardvark.Base.ConsumableAsyncValue<(Model * Aardvark.UI.SceneHit * Microsoft.FSharp.Core.string)>>
     member __.userPreferences = _userPreferences_ :> FSharp.Data.Adaptive.aval<PRo3D.UserPreferences>
@@ -372,6 +375,7 @@ module ModelLenses =
         static member provenanceModel_ = ((fun (self : Model) -> self.provenanceModel), (fun (value : ProvenanceModel) (self : Model) -> { self with provenanceModel = value }))
         static member backgroundPicking_ = ((fun (self : Model) -> self.backgroundPicking), (fun (value : FSharp.Data.Adaptive.ThreadPool<ViewerAction>) (self : Model) -> { self with backgroundPicking = value }))
         static member surfaceIntersection_ = ((fun (self : Model) -> self.surfaceIntersection), (fun (value : Microsoft.FSharp.Core.Option<SurfaceIntersection>) (self : Model) -> { self with surfaceIntersection = value }))
+        static member cursorAttributes_ = ((fun (self : Model) -> self.cursorAttributes), (fun (value : Microsoft.FSharp.Core.Option<CursorAttributes>) (self : Model) -> { self with cursorAttributes = value }))
         static member ellipseModel_ = ((fun (self : Model) -> self.ellipseModel), (fun (value : Microsoft.FSharp.Core.Option<EllipseModel>) (self : Model) -> { self with ellipseModel = value }))
         static member pickPreviewRequested_ = ((fun (self : Model) -> self.pickPreviewRequested), (fun (value : Aardvark.Base.ConsumableAsyncValue<(Model * Aardvark.UI.SceneHit * Microsoft.FSharp.Core.string)>) (self : Model) -> { self with pickPreviewRequested = value }))
         static member userPreferences_ = ((fun (self : Model) -> self.userPreferences), (fun (value : PRo3D.UserPreferences) (self : Model) -> { self with userPreferences = value }))

--- a/src/PRo3D.Viewer/Viewer/Picking.fs
+++ b/src/PRo3D.Viewer/Viewer/Picking.fs
@@ -24,7 +24,10 @@ module Picking =
 
     let mutable cache = HashMap.Empty
 
-    let pickRay (m : Model) (r : FastRay3d) (surfaceName : Option<string>) =
+    /// Intersects the scene's surfaces and keeps the full hit info (surface, bounding box,
+    /// object ray hit), which callers need to look up per-patch data such as attribute
+    /// layers. `pickRay` is the reduced variant most call sites want.
+    let pickRayInfo (m : Model) (r : FastRay3d) (surfaceName : Option<string>) =
         let ray = r.Ray
         let observerSystem = Gis.GisApp.getObserverSystem m.scene.gisApp
         let observedSystem (v : SurfaceId) = Gis.GisApp.getSpiceReferenceSystem m.scene.gisApp v
@@ -70,13 +73,17 @@ module Picking =
                 //let toLocal (v : V3d) = spiceTrafo.Backward.TransformPos(v)
 
                 //hitF >> Option.map toLocal
-                Some (hitInfo.hit, hitPosOnRay)
-            | _ -> 
+                Some (hitInfo, hitPosOnRay)
+            | _ ->
                 None
 
         if endLog then Log.stop()
 
-        hit 
+        hit
+
+    let pickRay (m : Model) (r : FastRay3d) (surfaceName : Option<string>) =
+        pickRayInfo m r surfaceName
+        |> Option.map (fun (hitInfo, hitPosOnRay) -> hitInfo.hit, hitPosOnRay)
 
     let pickVisualization (m : AdaptiveModel) =
         

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -1203,8 +1203,16 @@ module ViewerApp =
                             let ct = Async.DefaultCancellationToken
                             while not ct.IsCancellationRequested do
                                 let! (m, sceneHit, name) = Async.AwaitTask <| m.pickPreviewRequested.WaitAsync()
-                                let pick = Picking.pickRay m sceneHit.globalRay.Ray (Some name)
-                                let previewIntersection = PreviewPickSurfaceFinished(p, name, pick)
+                                let pick = Picking.pickRayInfo m sceneHit.globalRay.Ray (Some name)
+                                // per-vertex attribute layers only - the texture fallback
+                                // decodes one image per layer and cannot run per mouse move
+                                let attributes =
+                                    pick
+                                    |> Option.bind (fun (hitInfo, _) ->
+                                        ProfileAttributeExtraction.extractAttributesFromHit TextureFallback.Disabled hitInfo sceneHit.globalRay.Ray
+                                    )
+                                let hit = pick |> Option.map (fun (hitInfo, hitPosOnRay) -> hitInfo.hit, hitPosOnRay)
+                                let previewIntersection = PreviewPickSurfaceFinished(p, name, hit, attributes)
                                 mailbox.Post(MailboxAction.ViewerAction previewIntersection)
                         }
 
@@ -1214,12 +1222,12 @@ module ViewerApp =
                 }
             { m with backgroundPicking = ThreadPool.add "BackgroundPicking" p ThreadPool.empty; }
 
-        | ViewerAction.PreviewPickSurfaceFinished(_,_, None), _ -> 
+        | ViewerAction.PreviewPickSurfaceFinished(_, _, None, _), _ ->
             // preview request lead to no hit. ignore
-            m 
-        | ViewerAction.PreviewPickSurfaceFinished(_, name, hit), _ -> 
+            m
+        | ViewerAction.PreviewPickSurfaceFinished(_, name, hit, attributes), _ ->
             match hit with
-            | Some (p, hitPosOnRay) -> 
+            | Some (p, hitPosOnRay) ->
                 let info = p.GetIntersectionRayHitInfo()
                 let project p = 
                     let up = m.scene.referenceSystem.up.value
@@ -1232,8 +1240,9 @@ module ViewerApp =
                         p
                 let normal = if info.HasValidNormal then Some info.Normal else None
                 let s = { surfaceName = name; hitPoint = hitPosOnRay; normal = normal }
-                { m with 
+                { m with
                     surfaceIntersection = Some { surfaceName = name; hitPoint = hitPosOnRay; normal = normal }
+                    cursorAttributes = attributes |> Option.map (fun hit -> { surfaceName = name; hit = hit })
                     ellipseModel = EllipseAnnotations.App.update m.scene.referenceSystem.up.value  project (EllipseAnnotations.SetPreviewPoint s) m.ellipseModel
                 }
             | _ -> 

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -1223,8 +1223,9 @@ module ViewerApp =
             { m with backgroundPicking = ThreadPool.add "BackgroundPicking" p ThreadPool.empty; }
 
         | ViewerAction.PreviewPickSurfaceFinished(_, _, None, _), _ ->
-            // preview request lead to no hit. ignore
-            m
+            // preview request lead to no hit - drop the read-out rather than leaving the
+            // previous point's values on screen as if they were current
+            { m with cursorAttributes = None }
         | ViewerAction.PreviewPickSurfaceFinished(_, name, hit, attributes), _ ->
             match hit with
             | Some (p, hitPosOnRay) ->

--- a/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
+++ b/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
@@ -1074,8 +1074,50 @@ module Gui =
             ]    
 
     module Config =
-        let config (model : AdaptiveModel) = 
-            ConfigProperties.view model.scene.config 
+
+        /// Read-out of the OPC per-vertex attribute layers under the 3D cursor.
+        ///
+        /// The values come from the hit patch's `*.aara` attribute layers, barycentrically
+        /// interpolated at the picked point - not from sampling the attribute textures.
+        /// Texture sampling costs an image decode per layer, which is fine for profile
+        /// extraction but not per mouse move, so surfaces without per-vertex layers show
+        /// nothing here and say so.
+        let underCursor (m : AdaptiveModel) : DomNode<ViewerAction> =
+            // several opened namespaces carry records with `name` / `surfaceName` fields,
+            // so the types below are spelled out to keep field resolution unambiguous
+            let formatValues (values : float[]) =
+                values |> Array.map (sprintf "%g") |> String.concat "; "
+
+            let hint (message : string) =
+                div [style "color: #cccccc; padding: 4px"] [text message]
+
+            let content =
+                alist {
+                    let! enabled = m.scene.config.showPreviewIntersection
+                    if not enabled then
+                        yield hint "Preview cursor is off - enable \"Show Preview Cursor\" above."
+                    else
+                        let! cursor = m.cursorAttributes
+                        match cursor with
+                        | None ->
+                            yield hint "Hold CTRL and move the mouse over a surface."
+                        | Some (cursor : CursorAttributes) ->
+                            let hit : AttributeHit = cursor.hit
+                            yield Html.table [
+                                yield Html.row "Surface:"  [text cursor.surfaceName]
+                                yield Html.row "Patch:"    [text hit.patchName]
+                                yield Html.row "Position:" [text (hit.position.ToString("0.000"))]
+                                for a : SampledAttribute in hit.attributes do
+                                    yield Html.row (a.name + ":") [text (formatValues a.values)]
+                            ]
+                            if hit.attributes.IsEmpty then
+                                yield hint "No per-vertex attribute layers on this surface."
+                }
+
+            Incremental.div AttributeMap.empty content
+
+        let config (model : AdaptiveModel) =
+            ConfigProperties.view model.scene.config
             |> UI.map ConfigPropertiesMessage
             |> AVal.constant
               
@@ -1095,6 +1137,9 @@ module Gui =
                 ]
                 GuiEx.accordion "Screenshots" "Settings" false [
                     ScreenshotApp.view m.screenshotDirectory m.scene.screenshotModel |> UI.map ScreenshotMessage
+                ]
+                GuiEx.accordion "Under Cursor" "Crosshairs" true [
+                    underCursor m
                 ]
                 GuiEx.accordion "Data Management" "Settings" false [
                     Html.table [  
@@ -1446,7 +1491,7 @@ module Gui =
                     ]
 
                 require (viewerDependencies) (body bodyAttributes (blurg() |> List.map (UI.map ViewerMessage)))
-            | Some "config" -> 
+            | Some "config" ->
                 require (viewerDependencies) (body bodyAttributes [Config.configUI m |> UI.map ViewerMessage])
             | Some "viewplanner" -> 
                 require (viewerDependencies) (body bodyAttributes [ViewPlanner.viewPlannerUI m |> UI.map ViewerMessage])

--- a/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
+++ b/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
@@ -1111,7 +1111,9 @@ module Gui =
                                     yield Html.row (a.name + ":") [text (formatValues a.values)]
                             ]
                             if hit.attributes.IsEmpty then
-                                yield hint "No per-vertex attribute layers on this surface."
+                                // either the surface ships no *.aara layers at all, or the hit
+                                // triangle touches the position grid's skirt, which carries none
+                                yield hint "No per-vertex attribute layers cover this point."
                 }
 
             Incremental.div AttributeMap.empty content

--- a/src/Tests/OpcSidecarTests.fs
+++ b/src/Tests/OpcSidecarTests.fs
@@ -1,0 +1,297 @@
+﻿module OpcSidecarTests
+
+open System
+open System.IO
+
+open Expecto
+
+open Aardvark.Base
+open FSharp.Data.Adaptive
+
+open PRo3D.Core
+open PRo3D.Core.Surface
+
+/// Tests for the two sidecar files an OPC carries next to its hierarchy:
+///   * `*.opc.json` - product provenance, the DEM reference model and, for OPCs derived
+///     from a SPICE DSK (`*.bds`) shape model, the DSKBRIEF summary of that shape.
+///   * `*.opcx` - the attribute layer declarations, including the value range each
+///     texture layer is normalised into.
+module private Fixtures =
+
+    /// Directory holding an OPC with a `*.opc.json` sidecar that includes a DskBrief
+    /// block. Override with PRO3D_BDS_OPC.
+    let bdsOpcDir =
+        [
+            Environment.GetEnvironmentVariable "PRO3D_BDS_OPC"
+            @"C:\pro3ddata\HERA\OPCUpdate\BDS_Metadata\BDS_Metadata\Deimos"
+        ]
+        |> List.tryFind (fun p -> not (String.IsNullOrWhiteSpace p) && Directory.Exists p)
+
+    /// Directory holding an OPC whose `*.opcx` declares multi-channel attribute layers.
+    /// Override with PRO3D_AARA_OPC.
+    let aaraOpcDir =
+        [
+            Environment.GetEnvironmentVariable "PRO3D_AARA_OPC"
+            @"C:\pro3ddata\HERA\OPCUpdate\AARA_Textures\AARA_Textures\Dimorphos"
+        ]
+        |> List.tryFind (fun p -> not (String.IsNullOrWhiteSpace p) && Directory.Exists p)
+
+    let tryOpcx (dir : string) =
+        Directory.EnumerateFiles(dir, "*.opcx") |> Seq.tryHead
+
+let opcJsonTests () =
+    testList "opc.json" [
+
+        test "DskBrief summary is parsed" {
+            let text = """
+DSKBRIEF Program; Ver. 3.0.0, 02-NOV-2021; Toolkit Ver. N0067
+
+Summary for: 0_BDS/Deimos/deimos_k005_tho_v02.bds
+
+Body:                               402 (DEIMOS)
+  Surface:                          14021 (Name not available)
+  Reference frame:                  IAU_DEIMOS
+  Data type:                        2 (Shape model using triangular plates)
+  Coordinate system:                Planetocentric Latitudinal
+    Min, max longitude  (deg):       -180.000     180.000
+    Min, max latitude   (deg):        -90.0000     90.0000
+    Min, max radius      (km):          3.58220     8.70680
+
+    Type 2 parameters
+    -----------------
+      Number of vertices:                 2522
+      Number of plates:                   5040
+"""
+            match OpcMetadata.parseDskBrief text with
+            | None -> failtest "DSKBRIEF text should be recognised"
+            | Some dsk ->
+                Expect.equal dsk.body (Some "402 (DEIMOS)") "body"
+                Expect.equal dsk.referenceFrame (Some "IAU_DEIMOS") "reference frame"
+                Expect.equal dsk.coordinateSystem (Some "Planetocentric Latitudinal") "coordinate system"
+                Expect.equal dsk.vertexCount (Some 2522) "vertex count"
+                Expect.equal dsk.plateCount (Some 5040) "plate count"
+
+                match dsk.radiusRangeKm with
+                | Some r ->
+                    Expect.floatClose Accuracy.high r.Min 3.58220 "min radius"
+                    Expect.floatClose Accuracy.high r.Max 8.70680 "max radius"
+                | None -> failtest "radius range"
+
+                match dsk.longitudeRange, dsk.latitudeRange with
+                | Some lon, Some lat ->
+                    Expect.floatClose Accuracy.high lon.Min -180.0 "min longitude"
+                    Expect.floatClose Accuracy.high lat.Max 90.0 "max latitude"
+                | _ -> failtest "longitude/latitude range"
+        }
+
+        test "non-DSKBRIEF text is rejected" {
+            Expect.isNone (OpcMetadata.parseDskBrief "") "empty"
+            Expect.isNone (OpcMetadata.parseDskBrief "some unrelated note") "unrelated"
+        }
+
+        test "DemEllipsoid carries a frame and radii instead of a single axis" {
+            // The DemModel block's shape depends on ModelType. DemSphere (Deimos export)
+            // declares Center + Axis; DemEllipsoid (Dimorphos export) declares Center +
+            // AxisX/AxisY/AxisZ + Radii. Reading only Center/Axis silently drops the radii,
+            // which are the reference body's semi-axes.
+            let json = """
+            {
+                "product_information": { "product_type": "opc" },
+                "DemModel": {
+                    "ModelType": "DemEllipsoid",
+                    "Center": [0.0, 0.0, 0.0],
+                    "AxisX": [1.0, 0.0, 0.0],
+                    "AxisY": [0.0, -1.0, 0.0],
+                    "AxisZ": [0.0, 0.0, -1.0],
+                    "Radii": [89.5, 84.5, 57.5]
+                }
+            }
+            """
+
+            let metadata = OpcMetadata.ofJsonString "inline" json
+            match metadata.demModel with
+            | None -> failtest "DemModel should be present"
+            | Some dem ->
+                Expect.equal dem.modelType "DemEllipsoid" "model type"
+                Expect.equal dem.center (Some V3d.Zero) "centre"
+                Expect.isNone dem.axis "DemEllipsoid declares no single Axis"
+                Expect.equal dem.radii (Some (V3d(89.5, 84.5, 57.5))) "semi-axes"
+
+                match dem.frame with
+                | Some (x, y, z) ->
+                    Expect.equal x V3d.IOO "frame x"
+                    Expect.equal y -V3d.OIO "frame y"
+                    Expect.equal z -V3d.OOI "frame z"
+                | None -> failtest "frame"
+        }
+
+        test "DemSphere keeps its single axis and has no radii" {
+            let json = """
+            {
+                "DemModel": {
+                    "ModelType": "DemSphere",
+                    "Center": [39.232420540642, -75.516908187272, 339.02059989334],
+                    "Axis": [0.030056109818016003, 0.99816122607631, -0.05263836073096]
+                }
+            }
+            """
+
+            match (OpcMetadata.ofJsonString "inline" json).demModel with
+            | None -> failtest "DemModel should be present"
+            | Some dem ->
+                Expect.equal dem.modelType "DemSphere" "model type"
+                Expect.isSome dem.axis "axis"
+                Expect.isNone dem.frame "DemSphere declares no AxisX/Y/Z"
+                Expect.isNone dem.radii "DemSphere declares no Radii"
+        }
+
+        test "sidecar path is derived from the opcx path" {
+            let sidecar = OpcMetadata.sidecarPath (Path.Combine("some", "dir", "deimos_k005_tho_v02.opcx"))
+            Expect.equal (Path.GetFileName sidecar) "deimos_k005_tho_v02.opc.json" "sidecar file name"
+            Expect.equal (Path.GetDirectoryName sidecar) (Path.Combine("some", "dir")) "sidecar directory"
+        }
+
+        test "reads the BDS sidecar of a real OPC" {
+            match Fixtures.bdsOpcDir |> Option.bind Fixtures.tryOpcx with
+            | None -> skiptest "no OPC with a *.opc.json sidecar available (set PRO3D_BDS_OPC)"
+            | Some opcxPath ->
+
+            match OpcMetadata.tryReadForOpcx opcxPath with
+            | None -> failtest $"no sidecar found next to {opcxPath}"
+            | Some metadata ->
+                OpcMetadata.log "test" metadata
+
+                Expect.equal metadata.productType (Some "opc") "product type"
+                Expect.isSome metadata.creatorId "creator id"
+                Expect.isNonEmpty metadata.inputProducts "input products"
+
+                match metadata.demModel with
+                | None -> failtest "DemModel should be present"
+                | Some dem ->
+                    Expect.equal dem.modelType "DemSphere" "DEM model type"
+                    Expect.isSome dem.center "DEM centre"
+                    match dem.axis with
+                    | Some axis ->
+                        // the DEM sphere's axis is a direction, so it must be normalised
+                        Expect.floatClose Accuracy.medium axis.Length 1.0 "DEM axis should be unit length"
+                    | None -> failtest "DEM axis"
+                    Expect.isNone dem.radii "a DemSphere has no Radii"
+
+                match metadata.dskSummary with
+                | None -> failtest "DskBrief should be present and recognised"
+                | Some dsk ->
+                    Expect.isSome dsk.referenceFrame "reference frame"
+                    match dsk.radiusRangeKm with
+                    | Some r -> Expect.isGreaterThan r.Max r.Min "radius range should be non-degenerate"
+                    | None -> failtest "radius range"
+        }
+    ]
+
+let opcxAttributeLayerTests () =
+    let readLayers (xml : string) =
+        let doc = System.Xml.XmlDocument()
+        doc.LoadXml xml
+        SurfaceUtils.SurfaceAttributes.layers doc |> Seq.toList
+
+    let opcx (layerBody : string) =
+        $"""<?xml version='1.0' encoding='utf-8'?>
+<Aardvark version="4">
+  <SurfaceAttributes version="0" num="0">
+    <AttributeLayers num="1" count="1">
+      {layerBody}
+    </AttributeLayers>
+  </SurfaceAttributes>
+</Aardvark>"""
+
+    testList "opcx attribute layers" [
+
+        test "single channel range" {
+            let xml =
+                opcx """<AttributeLayer version="0" num="15">
+        <Type>Map</Type>
+        <Label>Elevation</Label>
+        <ChannelsDefinedRange>[0.004859322, 124.307319641]</ChannelsDefinedRange>
+        <ChannelsActualRange>[0.004859322, 124.307319641]</ChannelsActualRange>
+      </AttributeLayer>"""
+
+            match readLayers xml with
+            | [ ScalarLayer layer ] ->
+                Expect.equal layer.label "Elevation" "label"
+                Expect.floatClose Accuracy.high layer.definedRange.Min 0.004859322 "min"
+                Expect.floatClose Accuracy.high layer.definedRange.Max 124.307319641 "max"
+            | other -> failtest $"expected one scalar layer, got {other}"
+        }
+
+        test "multi channel range takes the first channel instead of failing" {
+            // ExportGpc writes one range per channel for multi-channel maps (normals,
+            // gravity vectors, lon/lat/radius). Range1d.Parse cannot read that, which used
+            // to make such OPCs fail to import until the *.opcx was hand-patched.
+            //
+            // The layer keeps the *first* channel's range, because that is the channel the
+            // attribute texture is read from. Unioning all three would widen this Gravity
+            // range by 25% and skew every value de-normalised through it.
+            let xml =
+                opcx """<AttributeLayer version="0" num="12">
+        <Type>Map</Type>
+        <Label>Gravity</Label>
+        <ChannelsDefinedRange>[[-0.000039896, 0.000040985], [-0.000046144, 0.000046183], [-0.000050788, 0.000050736]]</ChannelsDefinedRange>
+        <ChannelsActualRange>[[-0.000039896, 0.000040985], [-0.000046144, 0.000046183], [-0.000050788, 0.000050736]]</ChannelsActualRange>
+      </AttributeLayer>"""
+
+            match readLayers xml with
+            | [ ScalarLayer layer ] ->
+                Expect.equal layer.label "Gravity" "label"
+                Expect.floatClose Accuracy.high layer.definedRange.Min -0.000039896 "min of the first channel"
+                Expect.floatClose Accuracy.high layer.definedRange.Max 0.000040985 "max of the first channel"
+                Expect.equal layer.actualRange layer.definedRange "actual range parsed the same way"
+
+                // all three channel ranges are still recoverable from the raw text
+                let ranges =
+                    SurfaceUtils.SurfaceAttributes.parseChannelRanges
+                        "[[-0.000039896, 0.000040985], [-0.000046144, 0.000046183], [-0.000050788, 0.000050736]]"
+                Expect.equal ranges.Length 3 "three channel ranges"
+            | other -> failtest $"expected one scalar layer, got {other}"
+        }
+
+        test "unparsable range falls back instead of throwing" {
+            let xml =
+                opcx """<AttributeLayer version="0" num="13">
+        <Type>Map</Type>
+        <Label>Broken</Label>
+        <ChannelsDefinedRange>not a range</ChannelsDefinedRange>
+      </AttributeLayer>"""
+
+            match readLayers xml with
+            | [ ScalarLayer layer ] ->
+                Expect.equal layer.label "Broken" "label"
+                Expect.equal layer.definedRange (Range1d(0.0, 1.0)) "fallback range"
+                Expect.equal layer.actualRange layer.definedRange "actual range falls back to defined range"
+            | other -> failtest $"expected one scalar layer, got {other}"
+        }
+
+        test "the unpatched Dimorphos opcx loads" {
+            match Fixtures.aaraOpcDir |> Option.bind Fixtures.tryOpcx with
+            | None -> skiptest "no OPC with multi-channel attribute layers available (set PRO3D_AARA_OPC)"
+            | Some opcxPath ->
+
+            let layers = SurfaceUtils.SurfaceAttributes.read opcxPath |> Seq.toList
+            let scalars = layers |> List.choose (function ScalarLayer l -> Some l | _ -> None)
+            let textures = layers |> List.choose (function TextureLayer l -> Some l | _ -> None)
+
+            Log.line "[Test] %s: %d scalar layers, %d texture layers"
+                (Path.GetFileName opcxPath) scalars.Length textures.Length
+            for l in scalars do
+                Log.line "[Test]   %-12s %A" l.label l.definedRange
+
+            Expect.isNonEmpty scalars "opcx should declare scalar layers"
+            Expect.isNonEmpty textures "opcx should declare texture layers"
+            for l in scalars do
+                Expect.isGreaterThan l.definedRange.Max l.definedRange.Min $"{l.label}: range should be non-degenerate"
+        }
+    ]
+
+let tests () =
+    testList "OpcSidecar" [
+        opcJsonTests()
+        opcxAttributeLayerTests()
+    ]

--- a/src/Tests/ProfileAttributeExtractionTest.fs
+++ b/src/Tests/ProfileAttributeExtractionTest.fs
@@ -34,6 +34,18 @@ module Data =
     let annotationPath (testDataSource : string) =
         Path.Combine(testDataSource, "Dimorphos_DRACO1", "testAnnotatation.pro3d.ann")
 
+    /// Directory holding OPC hierarchies that ship per-vertex attribute layers
+    /// (`*.aara` files listed in each patch's `<Attributes>`). Set PRO3D_AARA_OPC to
+    /// point at one, e.g. the HERA AARA_Textures export's "Dimorphos" folder.
+    let aaraOpcBasePath (testDataSource : string) =
+        let candidates =
+            [
+                Environment.GetEnvironmentVariable "PRO3D_AARA_OPC"
+                Path.Combine(testDataSource, "AARA_Textures", "Dimorphos")
+            ]
+        candidates
+        |> List.tryFind (fun p -> not (String.IsNullOrWhiteSpace p) && Directory.Exists p)
+
 let private noHitFilter =
     Func<IIntersectableObjectSet,int,int,RayHit3d,bool>(fun _ _ _ _ -> false)
 
@@ -62,7 +74,23 @@ let private intersectAllKdTrees
                 with _ -> ()
     bestHit
 
-let initKdTreeLoading() =        
+let private loadHierarchies (opcBasePath : string) =
+    let serializer = Serialization.binarySerializer
+    Directory.GetDirectories(opcBasePath)
+    |> Array.map (fun basePath ->
+        PatchHierarchy.load serializer.Pickle serializer.UnPickle (OpcPaths.OpcPaths basePath)
+    )
+
+let private buildPatchInfoLookup (hierarchies : PatchHierarchy[]) =
+    let d = Dictionary<string, PatchFileInfo * OpcPaths>()
+    for h in hierarchies do
+        for leaf in QTree.getLeaves h.tree do
+            let info = leaf.info
+            let dir = h.opcPaths.Patches_DirAbsPath +/ info.Name
+            d.[dir +/ info.Positions] <- (info, OpcPaths h.opcPaths.Opc_DirAbsPath)
+    d
+
+let initKdTreeLoading() =
     Serialization.init()
     Serialization.registry.RegisterFactory (fun _ -> KdTrees.level0KdTreePickler)
     Serialization.registry.RegisterFactory (fun _ -> Init.incorePickler)
@@ -82,14 +110,7 @@ let tests (parameters : TestUtils.TestParameters) =
             if not (Directory.Exists opcBasePath) then
                 skiptest "OPC data not available"
 
-            let serializer = Serialization.binarySerializer
-
-            let hierarchies =
-                Directory.GetDirectories(opcBasePath)
-                |> Array.map (fun basePath ->
-                    PatchHierarchy.load serializer.Pickle serializer.UnPickle (OpcPaths.OpcPaths basePath)
-                )
-
+            let hierarchies = loadHierarchies opcBasePath
             Expect.isGreaterThan hierarchies.Length 0 "should have at least one hierarchy"
 
             let h = hierarchies.[0]
@@ -106,65 +127,53 @@ let tests (parameters : TestUtils.TestParameters) =
                 |> ViewerModality.matchy info.Local2Global info.Local2Global2d
 
             let mapping = ProfileAttributeExtraction.buildTriangleToGridMapping affine objectSetPath
-            Expect.isGreaterThan mapping.Length 0 "should have triangles"
+            Expect.isGreaterThan mapping.TriangleCount 0 "should have triangles"
+            Expect.isGreaterThan mapping.gridSize.X 0 "grid size should be positive"
 
-            for tri in mapping do
-                Expect.equal tri.Length 3 "each triangle should have 3 indices"
+            // the compact quad form must reproduce exactly what computeGridIndices emits
+            let positions = objectSetPath |> Aara.fromFile<V3f>
+            let reference = TriangleSet.computeGridIndices mapping.gridSize positions.Data
+            Expect.equal mapping.TriangleCount (reference.Length / 3) "triangle count should match computeGridIndices"
+
+            let vertexCount = mapping.gridSize.X * mapping.gridSize.Y
+            for triIdx in 0 .. mapping.TriangleCount - 1 do
+                match mapping.TryGetTriangleIndices triIdx with
+                | None -> failtest $"no grid indices for triangle {triIdx}"
+                | Some tri ->
+                    Expect.equal tri.Length 3 "each triangle should have 3 indices"
+                    for c in 0 .. 2 do
+                        Expect.equal tri.[c] reference.[triIdx * 3 + c] "index should match computeGridIndices"
+                        Expect.isTrue (tri.[c] >= 0 && tri.[c] < vertexCount) "index should be inside the position grid"
         }
 
-        test "extractAttributesAtUV returns attributes for a patch" {
+        test "aara header round trip" {
             if not (Directory.Exists opcBasePath) then
                 skiptest "OPC data not available"
 
-            let serializer = Serialization.binarySerializer
-
-            let hierarchies =
-                Directory.GetDirectories(opcBasePath)
-                |> Array.map (fun basePath ->
-                    PatchHierarchy.load serializer.Pickle serializer.UnPickle (OpcPaths.OpcPaths basePath)
-                )
-
+            let hierarchies = loadHierarchies opcBasePath
             let h = hierarchies.[0]
-            let leaves = QTree.getLeaves h.tree |> Seq.toArray
-            let leaf = leaves.[0]
-            let info = leaf.info
-            let opcPaths = OpcPaths h.opcPaths.Opc_DirAbsPath
+            let leaf = QTree.getLeaves h.tree |> Seq.head
+            let dir = h.opcPaths.Patches_DirAbsPath +/ leaf.info.Name
+            let positionsPath = dir +/ leaf.info.Positions
 
-            let uv = V2f(0.5f, 0.5f)
-            let attributes = ProfileAttributeExtraction.extractAttributesAtUV uv info opcPaths
-
-            Log.line "[Test] extracted %d attributes at UV (0.5, 0.5):" attributes.Count
-            for kvp in attributes do
-                Log.line "[Test]   %s: %A" kvp.Key kvp.Value
-
-            // we expect at least some attributes (textures beyond the primary)
-            Expect.isGreaterThanOrEqual attributes.Count 0 "should not crash"
+            match VertexAttributes.tryGetLayer positionsPath with
+            | None -> failtest $"could not read aara header of {positionsPath}"
+            | Some layer ->
+                // Positions are V3f grids; cross-check against the reference loader.
+                let reference = positionsPath |> Aara.fromFile<V3f>
+                Expect.equal layer.header.components 3 "positions have 3 components"
+                Expect.equal layer.header.size (reference.Size.XY.ToV2i()) "grid size should match Aara.fromFile"
         }
 
         testCase "full kdtree intersection and attribute extraction" <| fun () ->
             if not (Directory.Exists opcBasePath) then
                 skiptest "OPC data not available"
 
-            let serializer = Serialization.binarySerializer
-
-            let hierarchies =
-                Directory.GetDirectories(opcBasePath)
-                |> Array.map (fun basePath ->
-                    PatchHierarchy.load serializer.Pickle serializer.UnPickle (OpcPaths.OpcPaths basePath)
-                )
-
-            // build patchInfoLookup
-            let patchInfoLookup = Dictionary()
-            for h in hierarchies do
-                let leaves = QTree.getLeaves h.tree |> Seq.toArray
-                for leaf in leaves do
-                    let info = leaf.info
-                    let dir = h.opcPaths.Patches_DirAbsPath +/ info.Name
-                    let objectSetPath = dir +/ info.Positions
-                    patchInfoLookup.[objectSetPath] <- (info, OpcPaths h.opcPaths.Opc_DirAbsPath)
+            let hierarchies = loadHierarchies opcBasePath
+            let patchInfoLookup = buildPatchInfoLookup hierarchies
             Log.line "[Test] built patch info lookup with %d entries" patchInfoLookup.Count
 
-            // load kdtrees
+            let serializer = Serialization.binarySerializer
             let kdTreeMap =
                 hierarchies |> Array.fold (fun acc h ->
                     let trees =
@@ -187,30 +196,222 @@ let tests (parameters : TestUtils.TestParameters) =
                 let hitPoint = ray.Ray.GetPointOnRay(hit.RayHit.T)
                 Log.line "[Test] hit at %A" hitPoint
 
-                let gridMapping = ProfileAttributeExtraction.buildTriangleToGridMapping kd.affine kd.objectSetPath
+                let mapping = ProfileAttributeExtraction.buildTriangleToGridMapping kd.affine kd.objectSetPath
                 let triIdx = hit.SetObject.Index
                 let triangleSet = hit.SetObject.Set :?> TriangleSet
                 let triangle = DebugKdTreesX.getTriangle triangleSet triIdx
+                let weights = ProfileAttributeExtraction.computeBarycentric triangle hitPoint
+                let gridIndices = mapping.TryGetTriangleIndices triIdx |> Option.defaultValue [||]
 
-                let uv = ProfileAttributeExtraction.getUVAtHit kd.coordinatesPath gridMapping triIdx triangle hitPoint
-                Log.line "[Test] UV: %A" uv
+                match ProfileAttributeExtraction.getUVAtHit kd.coordinatesPath mapping.gridSize gridIndices weights with
+                | None -> failtest "no texture coordinates at hit"
+                | Some uv ->
+                    Log.line "[Test] UV: %A" uv
+                    Expect.isTrue (uv.X >= 0.0f && uv.X <= 1.0f) "UV.X should be in [0,1]"
+                    Expect.isTrue (uv.Y >= 0.0f && uv.Y <= 1.0f) "UV.Y should be in [0,1]"
 
-                Expect.isTrue (uv.X >= 0.0f && uv.X <= 1.0f) "UV.X should be in [0,1]"
-                Expect.isTrue (uv.Y >= 0.0f && uv.Y <= 1.0f) "UV.Y should be in [0,1]"
-
-                match patchInfoLookup.TryGetValue(kd.objectSetPath) with
-                | true, (patchInfo, opcPaths) ->
-                    let attributes = ProfileAttributeExtraction.extractAttributesAtUV uv patchInfo opcPaths
-                    Log.line "[Test] extracted %d attributes" attributes.Count
-                    for kvp in attributes do
-                        Log.line "[Test]   %s: %A" kvp.Key kvp.Value
-                | _ ->
-                    failtest "no patch info found for hit objectSetPath"
+                    match patchInfoLookup.TryGetValue(kd.objectSetPath) with
+                    | true, (patchInfo, opcPaths) ->
+                        let attributes =
+                            ProfileAttributeExtraction.extractAttributesAtUV uv patchInfo opcPaths (fun _ -> None) (fun _ -> false)
+                        Log.line "[Test] extracted %d attributes" attributes.Length
+                        for a in attributes do
+                            Log.line "[Test]   %s: %A (%A)" a.name a.values a.source
+                    | _ ->
+                        failtest "no patch info found for hit objectSetPath"
 
             | Some (_, Level0KdTree.InCoreKdTree _) ->
                 failtest "InCoreKdTree not expected"
             | None ->
                 failtest "no kdtree hit - check ray direction and bounding box"
+
+        testCase "per-vertex layers are physically consistent" <| fun () ->
+            // Only OPCs exported with per-vertex attribute layers can be checked here.
+            match Data.aaraOpcBasePath testDataSource with
+            | None -> skiptest "no OPC with per-vertex attribute layers available (set PRO3D_AARA_OPC)"
+            | Some aaraBasePath ->
+
+            let hierarchies = loadHierarchies aaraBasePath
+            let patchInfoLookup = buildPatchInfoLookup hierarchies
+
+            let serializer = Serialization.binarySerializer
+            let kdTreeMap =
+                hierarchies |> Array.fold (fun acc h ->
+                    let trees =
+                        KdTrees.loadKdTrees h Trafo3d.Identity ViewerModality.XYZ
+                            serializer false true DebugKdTreesX.loadTriangles' false
+                    HashMap.union acc trees
+                ) HashMap.empty
+
+            let bounds =
+                kdTreeMap |> HashMap.toList |> List.fold (fun (b : Box3d) (bb : Box3d, _) -> b.ExtendedBy bb) Box3d.Invalid
+            Log.line "[Test] %d kd-trees, bounds %A" (HashMap.count kdTreeMap) bounds
+
+            let cache = ref (HashMap.empty<string, ConcreteKdIntersectionTree>)
+
+            // shoot rays at the body from six directions so several patches are exercised
+            let directions = [ V3d.OOI; -V3d.OOI; V3d.OIO; -V3d.OIO; V3d.IOO; -V3d.IOO ]
+
+            let mutable checkedHits = 0
+
+            for dir in directions do
+                let origin = bounds.Center - dir * (bounds.Size.NormMax * 2.0)
+                let ray = FastRay3d(Ray3d(origin, dir))
+                match intersectAllKdTrees kdTreeMap cache ray with
+                | Some (hit, Level0KdTree.LazyKdTree kd) ->
+                    let hitPoint = ray.Ray.GetPointOnRay(hit.RayHit.T)
+                    let mapping = ProfileAttributeExtraction.buildTriangleToGridMapping kd.affine kd.objectSetPath
+                    let triangleSet = hit.SetObject.Set :?> TriangleSet
+                    let triangle = DebugKdTreesX.getTriangle triangleSet hit.SetObject.Index
+                    let weights = ProfileAttributeExtraction.computeBarycentric triangle hitPoint
+                    let gridIndices = mapping.TryGetTriangleIndices hit.SetObject.Index |> Option.defaultValue [||]
+
+                    match patchInfoLookup.TryGetValue(kd.objectSetPath) with
+                    | true, (patchInfo, _) ->
+                        let patchDir = Path.GetDirectoryName kd.objectSetPath
+                        let layers = VertexAttributes.getLayers patchDir patchInfo
+                        Expect.isGreaterThan layers.Length 0 $"{patchInfo.Name} should expose per-vertex layers"
+
+                        let sampled = VertexAttributes.sample layers mapping.gridSize gridIndices weights
+                        let byName = sampled |> List.map (fun a -> a.name, a.values) |> Map.ofList
+                        for a in sampled do
+                            Log.line "[Test] %-10s %-10s %A" patchInfo.Name a.name a.values
+
+                        // The offset between the position grid and the (smaller) attribute
+                        // grid is the one thing that can silently go wrong, and these
+                        // invariants pin it down. The third LonLatRad channel is the vertex
+                        // radius, so it must match the picked point's distance from the body
+                        // centre; an off-by-one in the offset samples a neighbouring vertex
+                        // and breaks this immediately.
+                        match byName |> Map.tryFind "LonLatRad" with
+                        | Some [| _; _; radius |] ->
+                            let expected = hitPoint.Length
+                            Expect.isLessThan (abs (radius - expected)) 0.05
+                                $"{patchInfo.Name}: LonLatRad radius {radius} should match |hitPoint| {expected}"
+                            checkedHits <- checkedHits + 1
+                        | _ -> ()
+
+                        // Per-vertex normals are unit length, but the barycentric blend of
+                        // three unit vectors is shorter than 1 wherever they diverge - on
+                        // Dimorphos's boulder field by several percent. So the invariant is
+                        // "never longer than unit, and not degenerate".
+                        match byName |> Map.tryFind "Normal" with
+                        | Some [| x; y; z |] ->
+                            let length = V3d(x, y, z).Length
+                            Expect.isLessThan length (1.0 + 1e-3) $"{patchInfo.Name}: Normal should not exceed unit length"
+                            Expect.isGreaterThan length 0.5 $"{patchInfo.Name}: Normal should not be degenerate"
+                        | _ -> ()
+
+                        // Magnitude is the length of the Gravity vector
+                        match byName |> Map.tryFind "Gravity", byName |> Map.tryFind "Magnitude" with
+                        | Some [| x; y; z |], Some [| magnitude |] ->
+                            let length = V3d(x, y, z).Length
+                            Expect.isLessThan (abs (magnitude - length) / magnitude) 1e-3
+                                $"{patchInfo.Name}: Magnitude {magnitude} should be |Gravity| {length}"
+                        | _ -> ()
+                    | _ -> ()
+                | _ -> ()
+
+            Expect.isGreaterThan checkedHits 2 "should have validated several patches"
+            Log.line "[Test] validated per-vertex layers at %d hits" checkedHits
+
+        testCase "texture fallback reproduces per-vertex values" <| fun () ->
+            // The attribute textures store each layer normalised into its *.opcx
+            // ChannelsDefinedRange, so the fallback has to map samples back onto that range
+            // before they can be compared with the per-vertex values.
+            match Data.aaraOpcBasePath testDataSource with
+            | None -> skiptest "no OPC with per-vertex attribute layers available (set PRO3D_AARA_OPC)"
+            | Some aaraBasePath ->
+
+            match Directory.EnumerateFiles(aaraBasePath, "*.opcx") |> Seq.tryHead with
+            | None -> skiptest "no *.opcx next to the OPC"
+            | Some opcxPath ->
+
+            let scalarLayers =
+                SurfaceUtils.SurfaceAttributes.read opcxPath |> SurfaceProperties.getScalarsHmap
+            let rangeOf = ProfileAttributeExtraction.rangeLookup scalarLayers
+            Log.line "[Test] %d scalar layers from %s" (HashMap.count scalarLayers) (Path.GetFileName opcxPath)
+            Expect.isGreaterThan (HashMap.count scalarLayers) 0 "opcx should declare scalar layers"
+
+            let hierarchies = loadHierarchies aaraBasePath
+            let patchInfoLookup = buildPatchInfoLookup hierarchies
+
+            let serializer = Serialization.binarySerializer
+            let kdTreeMap =
+                hierarchies |> Array.fold (fun acc h ->
+                    let trees =
+                        KdTrees.loadKdTrees h Trafo3d.Identity ViewerModality.XYZ
+                            serializer false true DebugKdTreesX.loadTriangles' false
+                    HashMap.union acc trees
+                ) HashMap.empty
+
+            let bounds =
+                kdTreeMap |> HashMap.toList |> List.fold (fun (b : Box3d) (bb : Box3d, _) -> b.ExtendedBy bb) Box3d.Invalid
+            let cache = ref (HashMap.empty<string, ConcreteKdIntersectionTree>)
+
+            // Only smooth, non-wrapping layers are compared:
+            //  - Slope is a gradient field, so nearest-texel and interpolated values
+            //    legitimately differ by a large fraction of its range,
+            //  - LonLatRad's first channel is a wrapped longitude, so a texel on the other
+            //    side of the 0/360 seam reads as the range maximum instead.
+            let smoothLayers = Set.ofList [ "Elevation"; "Potential"; "Magnitude" ]
+
+            let mutable compared = 0
+            let mutable worst = 0.0
+            let mutable worstLayer = ""
+
+            for dir in [ V3d.OOI; -V3d.OOI; V3d.OIO; -V3d.OIO; V3d.IOO; -V3d.IOO ] do
+                let origin = bounds.Center - dir * (bounds.Size.NormMax * 2.0)
+                let ray = FastRay3d(Ray3d(origin, dir))
+                match intersectAllKdTrees kdTreeMap cache ray with
+                | Some (hit, Level0KdTree.LazyKdTree kd) ->
+                    let hitPoint = ray.Ray.GetPointOnRay(hit.RayHit.T)
+                    let mapping = ProfileAttributeExtraction.buildTriangleToGridMapping kd.affine kd.objectSetPath
+                    let triangleSet = hit.SetObject.Set :?> TriangleSet
+                    let triangle = DebugKdTreesX.getTriangle triangleSet hit.SetObject.Index
+                    let weights = ProfileAttributeExtraction.computeBarycentric triangle hitPoint
+                    let gridIndices = mapping.TryGetTriangleIndices hit.SetObject.Index |> Option.defaultValue [||]
+
+                    match patchInfoLookup.TryGetValue(kd.objectSetPath) with
+                    | true, (patchInfo, opcPaths) ->
+                        let patchDir = Path.GetDirectoryName kd.objectSetPath
+                        let layers = VertexAttributes.getLayers patchDir patchInfo
+                        let fromVertices = VertexAttributes.sample layers mapping.gridSize gridIndices weights
+                        let fromTextures =
+                            match ProfileAttributeExtraction.getUVAtHit kd.coordinatesPath mapping.gridSize gridIndices weights with
+                            | Some uv ->
+                                ProfileAttributeExtraction.extractAttributesAtUV uv patchInfo opcPaths rangeOf (fun _ -> false)
+                            | None -> []
+
+                        let textureByName = fromTextures |> List.map (fun a -> a.name, a.values) |> Map.ofList
+
+                        for v in fromVertices do
+                            if smoothLayers.Contains v.name then
+                                match textureByName |> Map.tryFind v.name, rangeOf v.name with
+                                | Some t, Some range when t.Length > 0 ->
+                                    // judged relative to the layer's range, the only scale a
+                                    // normalised encoding can sensibly be measured against
+                                    let scale = max 1e-12 range.Size
+                                    let deviation = abs (v.values.[0] - t.[0]) / scale
+                                    if deviation > worst then
+                                        worst <- deviation
+                                        worstLayer <- v.name
+                                    compared <- compared + 1
+                                    Log.line "[Test] %-10s vertex %-14g texture %-14g dev %.4f of range"
+                                        v.name v.values.[0] t.[0] deviation
+                                | _ -> ()
+                    | _ -> ()
+                | _ -> ()
+
+            Expect.isGreaterThan compared 0 "should have compared at least one layer"
+            Log.line "[Test] compared %d values, worst deviation %.4f of range (%s)" compared worst worstLayer
+            // The tolerance is deliberately loose: the two paths sample differently
+            // (nearest-texel vs barycentric interpolation) on grids of different size, so a
+            // few percent of the layer range is expected. What this pins down is the
+            // de-normalisation - without it the texture values are raw [0,1] samples and the
+            // deviation is on the order of a whole range.
+            Expect.isLessThan worst 0.10
+                $"de-normalised texture samples should match per-vertex values (worst: {worstLayer})"
 
         testCase "end-to-end profile extraction from annotation file" <| fun () ->
             if not (Directory.Exists opcBasePath) then
@@ -250,12 +451,7 @@ let tests (parameters : TestUtils.TestParameters) =
                 Expect.isGreaterThan points.Length 1 "annotation should have at least 2 points"
 
                 // load hierarchies and kdtrees
-                let hierarchies =
-                    timed "load patch hierarchies" (fun () ->
-                        Directory.GetDirectories(opcBasePath)
-                        |> Array.map (fun basePath ->
-                            PatchHierarchy.load serializer.Pickle serializer.UnPickle (OpcPaths.OpcPaths basePath)
-                        ))
+                let hierarchies = timed "load patch hierarchies" (fun () -> loadHierarchies opcBasePath)
 
                 let kdTreeMap =
                     timed "load kdtrees" (fun () ->
@@ -267,25 +463,26 @@ let tests (parameters : TestUtils.TestParameters) =
                         ) HashMap.empty)
                 Log.line "[Test] kdTreeMap size: %d" (HashMap.count kdTreeMap)
 
-                // build patchInfoLookup
-                let patchInfoLookup =
-                    timed "build patchInfoLookup" (fun () ->
-                        let d = Dictionary()
-                        for h in hierarchies do
-                            let leaves = QTree.getLeaves h.tree |> Seq.toArray
-                            for leaf in leaves do
-                                let info = leaf.info
-                                let dir = h.opcPaths.Patches_DirAbsPath +/ info.Name
-                                let objectSetPath = dir +/ info.Positions
-                                d.[objectSetPath] <- (info, OpcPaths h.opcPaths.Opc_DirAbsPath)
-                        d)
+                let patchInfoLookup = timed "build patchInfoLookup" (fun () -> buildPatchInfoLookup hierarchies)
                 Log.line "[Test] patchInfoLookup size: %d" patchInfoLookup.Count
+
+                // attribute layer ranges - texture samples are normalised into them
+                let scalarLayers =
+                    let probes = [ opcBasePath; Path.GetDirectoryName opcBasePath ]
+                    match probes |> List.tryPick (fun d -> Directory.EnumerateFiles(d, "*.opcx") |> Seq.tryHead) with
+                    | Some opcx -> SurfaceUtils.SurfaceAttributes.read opcx |> SurfaceProperties.getScalarsHmap
+                    | None ->
+                        Log.warn "[Test] no *.opcx found - texture samples stay normalised"
+                        HashMap.empty
+                let rangeOf = ProfileAttributeExtraction.rangeLookup scalarLayers
 
                 // for each annotation point, intersect and extract
                 let mutable hitCount = 0
                 let mutable missCount = 0
                 let mutable allAttrNames = Set.empty
                 let mutable accDistance = 0.0
+                let mutable vertexSourced = 0
+                let mutable textureSourced = 0
                 let samples = ResizeArray<ProfileSample>()
 
                 // per-step accumulators
@@ -318,25 +515,41 @@ let tests (parameters : TestUtils.TestParameters) =
                         let hitPoint = ray.Ray.GetPointOnRay(hit.RayHit.T)
 
                         stepSw.Restart()
-                        let gridMapping = ProfileAttributeExtraction.buildTriangleToGridMapping kd.affine kd.objectSetPath
+                        let mapping = ProfileAttributeExtraction.buildTriangleToGridMapping kd.affine kd.objectSetPath
+                        let gridSize = mapping.gridSize
                         stepSw.Stop(); tGrid <- tGrid + stepSw.Elapsed.TotalMilliseconds
 
                         let triIdx = hit.SetObject.Index
                         let triangleSet = hit.SetObject.Set :?> TriangleSet
                         let triangle = DebugKdTreesX.getTriangle triangleSet triIdx
+                        let weights = ProfileAttributeExtraction.computeBarycentric triangle hitPoint
+                        let gridIndices = mapping.TryGetTriangleIndices triIdx |> Option.defaultValue [||]
 
                         stepSw.Restart()
-                        let uv = ProfileAttributeExtraction.getUVAtHit kd.coordinatesPath gridMapping triIdx triangle hitPoint
+                        let uv = ProfileAttributeExtraction.getUVAtHit kd.coordinatesPath gridSize gridIndices weights
                         stepSw.Stop(); tUv <- tUv + stepSw.Elapsed.TotalMilliseconds
 
                         match patchInfoLookup.TryGetValue(kd.objectSetPath) with
                         | true, (patchInfo, opcPaths) ->
                             stepSw.Restart()
-                            let attributes = ProfileAttributeExtraction.extractAttributesAtUV uv patchInfo opcPaths
+                            let patchDir = Path.GetDirectoryName kd.objectSetPath
+                            let layers = VertexAttributes.getLayers patchDir patchInfo
+                            let fromVertices = VertexAttributes.sample layers gridSize gridIndices weights
+                            let covered = fromVertices |> List.map (fun a -> a.name) |> Set.ofList
+                            let fromTextures =
+                                match uv with
+                                | Some uv -> ProfileAttributeExtraction.extractAttributesAtUV uv patchInfo opcPaths rangeOf covered.Contains
+                                | None    -> []
                             stepSw.Stop(); tExtract <- tExtract + stepSw.Elapsed.TotalMilliseconds
 
-                            for kvp in attributes do
-                                allAttrNames <- allAttrNames |> Set.add kvp.Key
+                            let attributes = Dictionary<string, float[]>()
+                            for a in fromVertices @ fromTextures do
+                                attributes.[a.name] <- a.values
+                                allAttrNames <- allAttrNames |> Set.add a.name
+                                match a.source with
+                                | AttributeSource.VertexData      -> vertexSourced <- vertexSourced + 1
+                                | AttributeSource.TextureSampling -> textureSourced <- textureSourced + 1
+
                             samples.Add({ position = hitPoint; distance = accDistance; attributes = attributes })
                             hitCount <- hitCount + 1
                         | _ ->
@@ -354,11 +567,12 @@ let tests (parameters : TestUtils.TestParameters) =
                 Log.line "[Timing] %-32s total %8.1f ms   per-hit %6.2f ms" "intersectAllKdTrees" tIntersect (tIntersect / float n)
                 Log.line "[Timing] %-32s total %8.1f ms   per-hit %6.2f ms" "buildTriangleToGridMapping" tGrid (tGrid / float n)
                 Log.line "[Timing] %-32s total %8.1f ms   per-hit %6.2f ms" "getUVAtHit" tUv (tUv / float n)
-                Log.line "[Timing] %-32s total %8.1f ms   per-hit %6.2f ms" "extractAttributesAtUV" tExtract (tExtract / float n)
+                Log.line "[Timing] %-32s total %8.1f ms   per-hit %6.2f ms" "attribute sampling" tExtract (tExtract / float n)
                 Log.line "[Timing] loop wall: %.1f s   mem %7.1f -> %7.1f MB (+%+.1f)"
                     loopSw.Elapsed.TotalSeconds memBeforeLoop (mb ()) (mb () - memBeforeLoop)
                 Log.line "[Timing] kd object-set cache holds %d entries (of %d bboxes)"
                     (HashMap.count kdObjectSetCache.Value) (HashMap.count kdTreeMap)
+                Log.line "[Test] %d values from per-vertex layers, %d from texture sampling" vertexSourced textureSourced
 
                 Log.line "[Test] hits: %d, misses: %d, attributes: %A" hitCount missCount (allAttrNames |> Set.toList)
                 Expect.isGreaterThan hitCount 0 "should have at least one hit"

--- a/src/Tests/Program.fs
+++ b/src/Tests/Program.fs
@@ -22,6 +22,9 @@ let allTests () : Test =
 
         ProjectedImageMetadataTest.tests()
 
+        // *.opc.json sidecars; the fixture-backed case self-skips without the data
+        OpcSidecarTests.tests()
+
         // Kernel-swap count matters: the native DeInit does not fully clear CSPICE's
         // binary-kernel (DAF) state, so handles go stale after repeated metakernel swaps
         // (SPICE(DAFNOSUCHHANDLE) on SPK/CK reads; text-kernel frames keep working).

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -39,6 +39,7 @@
     <None Include="RemoteApi.rest" />
     <Compile Include="TriangleSetTests.fs" />
     <Compile Include="ProfileAttributeExtractionTest.fs" />
+    <Compile Include="OpcSidecarTests.fs" />
     <Compile Include="BaseTests.fs" />
     <Compile Include="Program.fs" />
     <None Include="paket.references" />

--- a/src/Tests/TriangleSetTests.fs
+++ b/src/Tests/TriangleSetTests.fs
@@ -210,6 +210,83 @@ let tests () =
             Expect.equal indices.[5] 7 "f"
         }
 
+        test "quad mapping matches the kd-tree triangle order when vertex 0 is valid" {
+            // The kd-tree object set that hit.SetObject.Index refers to is built by
+            // DebugKdTreesX.loadTriangles' = ComputeIndexArray + getTriangleSet. That path
+            // does NOT compact: an invalid quad leaves six zero indices, so it becomes the
+            // degenerate triangle (v0, v0, v0) - which survives the NaN filter whenever v0
+            // itself is valid. So the mapping used to look up per-vertex attributes must
+            // follow that numbering, not a compacted one.
+            //
+            // 4x2 grid, vertex 1 NaN, vertex 0 VALID:
+            //  0--X--2--3        quad(0,0) and quad(1,0) touch the NaN,
+            //  |  |  |  |        quad(2,0) is valid
+            //  4--5--6--7
+            let positions = [|
+                V3f(0.0f, 0.0f, 0.0f); V3f.NaN;                V3f(2.0f, 0.0f, 0.0f); V3f(3.0f, 0.0f, 0.0f)
+                V3f(0.0f, 1.0f, 0.0f); V3f(1.0f, 1.0f, 0.0f); V3f(2.0f, 1.0f, 0.0f); V3f(3.0f, 1.0f, 0.0f)
+            |]
+            let size = V2i(4, 2)
+            let vertices = positions |> Array.map (fun p -> p.ToV3d())
+
+            let invalids = DebugKdTreesX.getInvalidIndices3f positions |> List.toArray
+            let kdTriangles = DebugKdTreesX.getTriangleSet (PRo3DCSharp.ComputeIndexArray(size, invalids)) vertices
+            let kdCount = triangleCount kdTriangles
+            Expect.equal kdCount 6 "the two degenerate quads survive because vertex 0 is valid"
+
+            let mapping : PatchTriangleGrid =
+                { gridSize = size; quadStart = TriangleSet.computeTriangleQuadStarts size positions }
+
+            Expect.equal mapping.TriangleCount kdCount
+                "mapping must cover exactly the triangles the kd-tree holds"
+
+            // every non-degenerate kd-tree triangle must map back to its own three corners
+            let tris = extractTriangles kdTriangles
+            let mutable realTriangles = 0
+            for i in 0 .. kdCount - 1 do
+                let t = tris.[i]
+                let degenerate = t.P0 = t.P1 && t.P1 = t.P2
+                match mapping.TryGetTriangleIndices i, degenerate with
+                | None, true -> ()   // degenerate filler carries no grid position
+                | Some g, false ->
+                    realTriangles <- realTriangles + 1
+                    Expect.equal vertices.[g.[0]] t.P0 $"triangle {i} P0"
+                    Expect.equal vertices.[g.[1]] t.P1 $"triangle {i} P1"
+                    Expect.equal vertices.[g.[2]] t.P2 $"triangle {i} P2"
+                | None, false -> failtest $"no grid indices for real triangle {i}"
+                | Some _, true -> failtest $"degenerate filler triangle {i} was given grid indices"
+            Expect.equal realTriangles 2 "one valid quad = two real triangles"
+        }
+
+        test "quad mapping skips invalid quads when vertex 0 is NaN" {
+            // Mirror case: with vertex 0 NaN the degenerate fillers are NaN too and get
+            // filtered, so the kd-tree holds only the valid quads' triangles.
+            let positions = [|
+                V3f.NaN;               V3f(1.0f, 0.0f, 0.0f); V3f(2.0f, 0.0f, 0.0f); V3f(3.0f, 0.0f, 0.0f)
+                V3f(0.0f, 1.0f, 0.0f); V3f(1.0f, 1.0f, 0.0f); V3f(2.0f, 1.0f, 0.0f); V3f(3.0f, 1.0f, 0.0f)
+            |]
+            let size = V2i(4, 2)
+            let vertices = positions |> Array.map (fun p -> p.ToV3d())
+
+            let invalids = DebugKdTreesX.getInvalidIndices3f positions |> List.toArray
+            let kdTriangles = DebugKdTreesX.getTriangleSet (PRo3DCSharp.ComputeIndexArray(size, invalids)) vertices
+            let kdCount = triangleCount kdTriangles
+            Expect.equal kdCount 4 "quad(0,0) drops; quad(1,0) and quad(2,0) survive"
+
+            let mapping : PatchTriangleGrid =
+                { gridSize = size; quadStart = TriangleSet.computeTriangleQuadStarts size positions }
+            Expect.equal mapping.TriangleCount kdCount "mapping must match the compacted order"
+
+            let tris = extractTriangles kdTriangles
+            for i in 0 .. kdCount - 1 do
+                match mapping.TryGetTriangleIndices i with
+                | None -> failtest $"no grid indices for triangle {i}"
+                | Some g ->
+                    Expect.equal vertices.[g.[0]] tris.[i].P0 $"triangle {i} P0"
+                    Expect.equal vertices.[g.[1]] tris.[i].P1 $"triangle {i} P1"
+                    Expect.equal vertices.[g.[2]] tris.[i].P2 $"triangle {i} P2"
+        }
+
         test "computeGridIndices matches legacy on clean grid" {
             // 3x2 grid, no NaN → 2 quads → 4 triangles
             let positions = [|


### PR DESCRIPTION
Closes #668. Related: #667 (drop PRo3D's duplicate opcx parser), aardvark-platform/OPCViewer.Base#2 (same parser bug upstream).

Newer OPC exports ship their attribute layers twice: as texture layers under `Images/<Layer>/`, and additionally as **per-vertex `*.aara` grids** in each patch directory. Reading the per-vertex form needs three small random-access reads per layer instead of a full image decode, which makes attribute extraction fast enough to run interactively.

Docs: [`docs/VertexAttributes.md`](docs/VertexAttributes.md).

## The grid offset

The attribute grid is **smaller** than the position grid — the positions carry a symmetric skirt whose width shrinks with the hierarchy level, because it is a constant number of source DEM pixels:

| level | positions | attributes | offset |
|-------|-----------|------------|--------|
| 0     | 1032²     | 1024²      | 4      |
| 1     | 1028²     | 1024²      | 2      |
| 2     | 1026²     | 1024²      | 1      |

```
attributeIndex(x, y) = positionIndex(x + off, y + off),   off = (posSize - attrSize) / 2
```

Established empirically: `LonLatRad`'s third channel is the vertex radius in metres, so it must equal `|Local2Global · XYZ_Local|`. Across all 9 patches of `g_01960mm_spc_dtm_dimo_0000n00000_v003` the centred offset agrees to float32 round-off (median 2·10⁻⁶ m); **every other offset is off by ≥ 0.19 m**. The same invariant guards the code as a test.

## Three problems the comparison surfaced in the existing texture path

1. **Texture samples were normalised, not physical.** Attribute textures store each layer scaled into its `ChannelsDefinedRange`; per-vertex layers hold physical values. The profile CSV was therefore exporting `[0,1]` numbers, and the nodata sentinel `-99999` as if it were a measurement. Samples are now mapped back onto the layer's range and nodata is dropped.
2. **Most layers were unreachable.** The loop counted `DiffuseColorNWeights` entries as textures and capped at `numTextures - 1`, so it only ever reached 3 of the 8 layers on this dataset.
3. **The patch lookup silently missed everything on some datasets.** `buildPatchInfoLookup` keyed on the full positions path case-sensitively, but `OpcPaths.Patches_DirAbsPath` probes `"patches"` before `"Patches"` (and `Directory.Exists` is case-insensitive on Windows) while persisted kd-trees may carry either spelling. Now case-insensitive with separator normalisation.

## Under Cursor readout

The 3D preview cursor is **on by default** and its readout is the *Under Cursor* section of the **Config** panel, below *Screenshots*. It shows the surface, patch and every per-vertex layer under the mouse (hold `CTRL`).

Per-vertex data only — the texture fallback is one image decode per layer and cannot run per mouse move, so a surface without per-vertex layers says so rather than stalling. Extraction runs on the existing background picking thread.

## Memory

The triangle-to-grid mapping is now one int per quad instead of an `int[3]` per triangle — **4 MB instead of ~100 MB per 1032² patch** — and the cache is bounded to 32 patches, because the cursor pulls in a new patch whenever it crosses a patch boundary. Caches are dropped when a surface is removed. ZIP-backed OPCs cannot seek, so their payloads are held in memory instead, bounded at 512 MB.

## Multi-channel `*.opcx` ranges

For multi-channel `Map` layers ExportGpc writes one range per channel:

```xml
<ChannelsDefinedRange>[[-0.000039896, 0.000040985], [-0.000046144, 0.000046183], [-0.000050788, 0.000050736]]</ChannelsDefinedRange>
```

`Range1d.Parse` only understands `[min, max]`, so these OPCs could not be imported without hand-editing the `*.opcx`. Both forms parse now. The **first** channel's range is kept — that is the channel the false-colour legend and the de-normalisation above refer to (attribute textures are read via `ChannelWithIndex 0`); unioning the channels would widen the `Gravity` range by 25% and skew every de-normalised value.

## `*.opc.json` sidecar

`OpcMetadata` reads the sidecar next to the `*.opcx` and logs it at import (not persisted into the scene): product provenance, the DEM reference model, and for DSK-derived OPCs the DSKBRIEF summary of the source `*.bds`. `DemSphere` and `DemEllipsoid` have different schemas (single `Axis` vs `AxisX/Y/Z` + `Radii`) and both are read.

## Verification

Built and run against `C:\pro3ddata\HERA\OPCUpdate`:

* Solution builds; `OpcSidecar` 10/10, `ProfileAttributeExtraction` 2/2 (4 skipped — they need `Dimorphos_DRACO1`, absent here). Data-backed tests self-skip; point them with `PRO3D_AARA_OPC` / `PRO3D_BDS_OPC`.
* **Grid offset**: radius invariant validated at 6 hits across patches at all three levels.
* **De-normalisation**: de-normalised texture samples match per-vertex values to ≤ 7% of a layer's range for smooth layers; without it the deviation is on the order of a whole range.
* **Unpatched `*.opcx`**: fed the original ExportGpc file, the parser yields ranges **identical to the hand-patched one**, layer for layer. A copy of the OPC with the original sidecar sits next to the patched one for end-to-end checks.
* **In the app**: imported the un-hacked OPC, `7 per-vertex layers (LonLatRad, Normal, Gravity, Magnitude, Potential, Elevation, Slope)`, no lookup warnings, `[OpcMetadata]` block logged for both the `DemSphere` and `DemEllipsoid` exports.

Not verified: the *Under Cursor* panel has not been screenshotted, only exercised by hand.
