### PR TITLE
fix(screenshot): take the shot off the update thread

### DIFF
--- a/src/PRo3D.Base/Utilities.fs
+++ b/src/PRo3D.Base/Utilities.fs
@@ -1432,6 +1432,7 @@ module Copy =
 module ScreenshotUtilities = 
     module Utilities =
         open System.Net.Http
+        open System.Threading
 
         type ClientStatistics =
           {
@@ -1456,10 +1457,8 @@ module ScreenshotUtilities =
             else
                 body
 
-        let downloadClientStatistics baseAddress (httpClient : HttpClient) =
-            let path = sprintf "%s/rendering/stats.json" baseAddress //sprintf "%s/rendering/stats.json" baseAddress
-            Log.line "[Screenshot] querying rendering stats at: %s" path
-            let result = httpClient.GetStringAsync(path).Result |> unwrapDoubleEncodedJson
+        let private parseClientStatistics path (body : string) =
+            let result = body |> unwrapDoubleEncodedJson
 
             let clientBla : list<ClientStatistics> =
                 try
@@ -1470,6 +1469,21 @@ module ScreenshotUtilities =
             match clientBla with
             | [] -> failwith (sprintf "No rendering client reported statistics at %s" path)
             | _ -> clientBla
+
+        let downloadClientStatisticsAsync baseAddress (httpClient : HttpClient) (ct : CancellationToken) =
+            task {
+                let path = sprintf "%s/rendering/stats.json" baseAddress
+                Log.line "[Screenshot] querying rendering stats at: %s" path
+                let! body = httpClient.GetStringAsync(path, ct)
+                return parseClientStatistics path body
+            }
+
+        /// Blocking wrapper for the callers that still live in a synchronous `update`
+        /// (RemoteControlApp, Rover-Model). New code should await the async version -
+        /// blocking here costs a second thread and can starve the pool.
+        let downloadClientStatistics baseAddress (httpClient : HttpClient) =
+            (downloadClientStatisticsAsync baseAddress httpClient CancellationToken.None)
+                .GetAwaiter().GetResult()
 
         let getScreenshotUrl baseAddress clientStatistic width height =                                
 

--- a/src/PRo3D.Base/WebClientDeprecation.fs
+++ b/src/PRo3D.Base/WebClientDeprecation.fs
@@ -12,5 +12,8 @@ module Helpers =
                 return! File.WriteAllBytesAsync(filename, data)
             }
 
+        /// GetAwaiter().GetResult() rethrows the original exception, while Wait() wraps it
+        /// in an AggregateException whose message is the useless "One or more errors
+        /// occurred." - keep the actual cause visible in the log.
         member x.DownloadFile(uri : string, filename : string) =
-            x.DownloadFileAsync(uri, filename).Wait()
+            x.DownloadFileAsync(uri, filename).GetAwaiter().GetResult()

--- a/src/PRo3D.SimulatedViews/Screenshots/ScreenshotApp.fs
+++ b/src/PRo3D.SimulatedViews/Screenshots/ScreenshotApp.fs
@@ -6,6 +6,7 @@ open Aardvark.UI
 open Aardvark.UI.Primitives
 open PRo3D.Base
 open System.IO
+open System.Threading
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module ScreenshotApp =
@@ -16,50 +17,97 @@ module ScreenshotApp =
         | ImageFormat.PNG  -> "png"
         | _ -> "png"
     
-    let createUrl 
-        baseUrl 
-        numberOfSamples 
-        (m : ScreenshotModel) 
-        (httpClient : System.Net.Http.HttpClient) =
-
-        let stats = ScreenshotUtilities.Utilities.downloadClientStatistics baseUrl httpClient
-        
+    let private urlOfStats
+        baseUrl
+        numberOfSamples
+        (m : ScreenshotModel)
+        (stats : list<ScreenshotUtilities.Utilities.ClientStatistics>) =
         let color = m.backgroundColor.c.ToC4f().ToV4f()
         let renderingNodeId =
             match stats with
             | first :: _ -> first.name
             | [] -> failwith "[Screenshots] no rendering client available"
-        let url = 
-            sprintf "%s/rendering/screenshot/%s?w=%i&h=%i&samples=%i&fmt=%s&background=[%f,%f,%f,%f]" 
-                baseUrl 
-                renderingNodeId 
-                (int m.width.value) 
+        let url =
+            sprintf "%s/rendering/screenshot/%s?w=%i&h=%i&samples=%i&fmt=%s&background=[%f,%f,%f,%f]"
+                baseUrl
+                renderingNodeId
+                (int m.width.value)
                 (int m.height.value)
-                numberOfSamples 
+                numberOfSamples
                 (imageFormatToString m.imageFormat)
                 color.X color.Y color.Z color.W
 
         Log.line "[Screenshots] URL: %s" url
         url
-        
+
+    let createUrlAsync
+        baseUrl
+        numberOfSamples
+        (m : ScreenshotModel)
+        (httpClient : System.Net.Http.HttpClient)
+        (ct : CancellationToken) =
+        task {
+            let! stats = ScreenshotUtilities.Utilities.downloadClientStatisticsAsync baseUrl httpClient ct
+            return urlOfStats baseUrl numberOfSamples m stats
+        }
+
     let mutable imgNr = 0
-    let rec findFreeName outputPath (m : ScreenshotModel) = 
+    let private imgNrLock = obj()
+
+    let rec findFreeName outputPath (m : ScreenshotModel) =
         let filename = sprintf "img%03i.%s" imgNr (imageFormatToString m.imageFormat)
-        let filenamepath = Path.combine [outputPath;filename]        
+        let filenamepath = Path.combine [outputPath;filename]
         if not (File.Exists filenamepath) then
             filenamepath
-        else 
+        else
             imgNr <- imgNr + 1
             findFreeName outputPath m
-    
+
+    /// Screenshots run on a background thread (see makeScreenshot), so hand out names
+    /// under a lock - otherwise two shots in flight can pick the same file.
+    let private nextFreeName outputPath (m : ScreenshotModel) =
+        lock imgNrLock (fun () ->
+            if not (Directory.Exists outputPath) then
+                Directory.CreateDirectory outputPath |> ignore
+            let filenamepath = findFreeName outputPath m
+            imgNr <- imgNr + 1
+            filenamepath
+        )
+
+    /// a large, multisampled shot can take a while to render and to transfer
+    let private requestTimeout = System.TimeSpan.FromMinutes 10.0
+
+    /// One client for the whole process: a new HttpClient per shot opens a fresh
+    /// connection and leaves the socket in TIME_WAIT. The timeout is set here *and*
+    /// per request - HttpClient.Timeout cannot be changed once a request has gone out,
+    /// so the per-request token is what makes a deadline adjustable, while this one is
+    /// the backstop that keeps a future call without a token from hanging forever.
+    let private httpClient =
+        new System.Net.Http.HttpClient(Timeout = requestTimeout)
+
+    /// The rendering service only renders the screenshot once its render task can read
+    /// the scene graph. `update` runs inside `transact`, so waiting there for the HTTP
+    /// response keeps that transaction open, the server never gets to evaluate the scene,
+    /// and the request dies in HttpClient's 100s timeout ("A task was canceled.").
+    /// So the round trip has to happen off the update thread - and once it does, there is
+    /// no reason to block a thread on it either.
+    let makeScreenshotAsync baseUrl numberOfSamples outputPath (m : ScreenshotModel) =
+        task {
+            try
+                use cts = new CancellationTokenSource(requestTimeout)
+                let! url = createUrlAsync baseUrl numberOfSamples m httpClient cts.Token
+                let filenamepath = nextFreeName outputPath m
+                let! data = httpClient.GetByteArrayAsync(url, cts.Token)
+                do! File.WriteAllBytesAsync(filenamepath, data, cts.Token)
+                Log.line "[Screenshot] Screenshot saved to %s" filenamepath
+            with e ->
+                Log.error "[Screenshot] taking a screenshot failed: %A" e
+        }
+
+    /// Fire and forget: `update` cannot await, and every failure is already logged inside
+    /// makeScreenshotAsync, so there is no fault left for anyone to observe.
     let makeScreenshot baseUrl numberOfSamples outputPath (m : ScreenshotModel) =
-        let wc = new System.Net.Http.HttpClient()
-        let url = createUrl baseUrl numberOfSamples m wc
-        let filenamepath = findFreeName outputPath m 
-        imgNr <- imgNr + 1
-        
-        wc.DownloadFile(url, filenamepath)
-        Log.line "[Screenshot] Screenshot saved to %s" filenamepath
+        makeScreenshotAsync baseUrl numberOfSamples outputPath m |> ignore
 
     let update baseUrl numberOfSamples outputPath (m : ScreenshotModel) (action : ScreenshotAction) =
         match action with


### PR DESCRIPTION
Second half of #660. After [#661](https://github.com/pro3d-space/PRo3D/pull/661) fixed the `stats.json` deserialization, the screenshot still never arrived — it now failed in the image download instead:

```
Update for message 'ViewerMessage (ScreenshotMessage CreateScreenshot)' failed:
System.AggregateException ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
  at Task.Wait()
  at ScreenshotAppModule.makeScreenshot
  ...
  at FSharp.Data.Adaptive.TransactionModule.transact
  at Aardvark.UI.MutableApp.processMessages
```

## Root cause

A deadlock, not a network problem. The `TaskCanceledException` is `HttpClient`'s 100 s timeout, and the stack shows why: `makeScreenshot` waited for the request **inside `transact`**, on the update thread.

The rendering service renders screenshots on demand, and its render task has to *read* the adaptive scene graph (`Aardvark.Service.Giraffe/Server.fs`, `task.Run(AdaptiveToken.Top, clientInfo, state)`) — which it cannot do while that transaction is still open. So the server waited on the update thread, the update thread waited on the server, and the client gave up after 100 s. The log shows the render completing two minutes later, once the transaction had closed and nobody was listening any more:

```
Trying to save image to stream with FreeImage loader: success in 0.045 s
```

This also explains two long-standing symptoms: the exact same URL works when pasted into a browser (nothing holds a transaction open then), and the UI freezes for the duration — the "thereafter, no activities were possible anymore on the application windows" in #488.

## Changes

**`ScreenshotApp.fs`** — the round trip is now async rather than running on the update thread:

```fsharp
let makeScreenshotAsync baseUrl numberOfSamples outputPath (m : ScreenshotModel) =
    task {
        try
            use cts = new CancellationTokenSource(requestTimeout)
            let! url = createUrlAsync baseUrl numberOfSamples m httpClient cts.Token
            let filenamepath = nextFreeName outputPath m
            let! data = httpClient.GetByteArrayAsync(url, cts.Token)
            do! File.WriteAllBytesAsync(filenamepath, data, cts.Token)
            Log.line "[Screenshot] Screenshot saved to %s" filenamepath
        with e ->
            Log.error "[Screenshot] taking a screenshot failed: %A" e
    }
```

`update` starts it and returns immediately, which closes the transaction — the thing the server was waiting for. There is no sync boundary that would justify blocking a pooled thread on the I/O; `update` cannot await, but it does not need the result either, and every failure is logged inside the task, so no fault is left unobserved.

Also in this file:
- **One `HttpClient` for the process** instead of one per shot. A fresh client per call opens a new connection and leaves the socket in `TIME_WAIT`; the old code additionally never disposed it.
- **Per-request `CancellationTokenSource` deadline** (10 min — a large multisampled shot legitimately takes a while to render and transfer), with the same value on the client as a backstop so a future call that forgets a token cannot hang forever. `HttpClient.Timeout` is per client and cannot be changed once a request has gone out, so a shared client needs the token to make the deadline per call.
- Create the output directory if missing, matching what `getScreenshotFilename` already does on the automation path.
- Hand out file names under a lock, since shots can now overlap.

**`Utilities.fs`** — `downloadClientStatistics` split into an async core plus a thin blocking wrapper, kept for the callers that are still synchronous `update` functions (`RemoteControlApp`, `Rover-Model`).

**`WebClientDeprecation.fs`, `Utilities.fs`** — in the remaining blocking wrappers, `Wait()` / `.Result` → `GetAwaiter().GetResult()`, so the original exception survives instead of being buried in an `AggregateException` whose message is the useless "One or more errors occurred." That wrapper is what made this failure unreadable in the first place.

## Testing

`dotnet build src/PRo3D.sln` clean. Verified in the GUI — two consecutive shots landed as `img041.png` / `img042.png` (both valid 500×500 PNGs, correct content), with the thread ids showing the update thread dropping out after the first await:

```
16: [Screenshot] querying rendering stats at: .../rendering/stats.json   <- update thread, pre-await
19: [Screenshots] URL: .../rendering/screenshot/n1241?w=500&h=500...     <- pool, after 1st await
19: [Screenshot] Screenshot saved to ...\img042.png                      <- pool, after 2nd await
```

The second shot also exercises the shared client: a client disposed after the first request would have thrown `ObjectDisposedException` there.

## Not addressed here

- Four other per-call `HttpClient` sites remain, two of them the automation screenshot path and none of them disposed: `PRo3D.Base/Utilities.fs:1502,1514`, `PRo3D.Viewer/Utilities.fs:43,52` (plus `SceneConverter.fs:81`, which at least uses `use`). Same treatment would apply, but it widens this diff beyond the bug.
- `RemoteControlApp.fs:85,90,102,113` takes a screenshot synchronously right after `send`ing a camera change to the main app. That send is asynchronous, so the shot can capture the previous camera. Separate issue.
- The `ClientStatistics` triplication noted in #660 is still open.
