### PR TITLE
fix(snapshots): match the offscreen framebuffer signature to the app's

### DIFF
--- a/src/PRo3D.SimulatedViews/Snapshots/SnapshotApp.fs
+++ b/src/PRo3D.SimulatedViews/Snapshots/SnapshotApp.fs
@@ -21,6 +21,28 @@ open Chiron
 
 
 
+/// The framebuffer the snapshots are rendered into has to have the *same* signature the
+/// scene graph's render objects were prepared against, otherwise the runtime rejects the
+/// prepared command ("Prepared command has framebuffer signature ... but expected ...")
+/// and every frame comes out black. Both the offscreen targets here and the app signature
+/// in PRo3D.Snapshots/Program.fs are built from these values so they cannot drift apart.
+module SnapshotFramebuffer =
+    open Aardvark.Rendering
+
+    [<Literal>]
+    let samples = 8
+
+    let depthStencilFormat = TextureFormat.Depth24Stencil8
+
+    let attachments =
+        [
+            DefaultSemantic.Colors, TextureFormat.Rgba8
+            DefaultSemantic.DepthStencil, depthStencilFormat
+        ]
+
+    let createSignature (runtime : IRuntime) =
+        runtime.CreateFramebufferSignature(attachments, samples)
+
 type NearFarRecalculation =
   | Both
   | FarPlane
@@ -139,14 +161,11 @@ module SnapshotApp =
         if verbose then
             Log.line "calculated near plane as %f and far plane as %f" near far
 
-        let col   = app.runtime.CreateTexture (resolution, TextureDimension.Texture2D, TextureFormat.Rgba8, 1, 1);
-        let depth = app.runtime.CreateTexture (resolution, TextureDimension.Texture2D, TextureFormat.DepthComponent32f, 1, 1); //Depth24Stencil8 test laura
+        let samples = SnapshotFramebuffer.samples
+        let col   = app.runtime.CreateTexture (resolution, TextureDimension.Texture2D, TextureFormat.Rgba8, 1, samples);
+        let depth = app.runtime.CreateTexture (resolution, TextureDimension.Texture2D, SnapshotFramebuffer.depthStencilFormat, 1, samples);
 
-        let signature = 
-             app.runtime.CreateFramebufferSignature ([
-                 DefaultSemantic.Colors, TextureFormat.Rgba8
-                 DefaultSemantic.DepthStencil, TextureFormat.DepthComponent32f 
-             ], 1)
+        let signature = SnapshotFramebuffer.createSignature app.runtime
 
         let fbo = 
             app.runtime.CreateFramebuffer(
@@ -222,14 +241,11 @@ module SnapshotApp =
                                          (app : SnapshotApp<'model,'aModel, 'msg>) =
         let sg = app.sg 
         let resolution = V3i (a.resolution.X, a.resolution.Y, 1)
-        let col   = app.runtime.CreateTexture (resolution, TextureDimension.Texture2D, TextureFormat.Rgba8, 1, 8);
-        let depth = app.runtime.CreateTexture (resolution, TextureDimension.Texture2D, TextureFormat.Depth24Stencil8, 1, 8);
+        let samples = SnapshotFramebuffer.samples
+        let col   = app.runtime.CreateTexture (resolution, TextureDimension.Texture2D, TextureFormat.Rgba8, 1, samples);
+        let depth = app.runtime.CreateTexture (resolution, TextureDimension.Texture2D, SnapshotFramebuffer.depthStencilFormat, 1, samples);
 
-        let signature = 
-             app.runtime.CreateFramebufferSignature ([
-                 DefaultSemantic.Colors, TextureFormat.Rgba8
-                 DefaultSemantic.DepthStencil, TextureFormat.Depth24Stencil8
-             ], 8)
+        let signature = SnapshotFramebuffer.createSignature app.runtime
 
         let taskclear = app.runtime.CompileClear(signature,AVal.constant C4f.Black,AVal.constant 1.0)
         let task = app.runtime.CompileRender(signature, sg)

--- a/src/PRo3D.Snapshots/Program.fs
+++ b/src/PRo3D.Snapshots/Program.fs
@@ -97,11 +97,10 @@ let startApplication (startupArgs : CLStartupArgs) =
   
         Log.line "PRo3D Viewer - Version: %s; powered by Aardvark" viewerVersion
   
-        let signature =
-            runtime.CreateFramebufferSignature [
-                DefaultSemantic.Colors, TextureFormat.Rgba8
-                DefaultSemantic.DepthStencil, TextureFormat.Depth24Stencil8
-            ]
+        // must match the offscreen targets the snapshots are rendered into, see
+        // SnapshotFramebuffer - a mismatch makes the runtime reject every prepared
+        // command and all rendered frames come out black
+        let signature = SnapshotFramebuffer.createSignature runtime
 
         use sendQueue = new BlockingCollection<string>()    
       


### PR DESCRIPTION
Every snapshot rendered black. A 182-frame sequenced-bookmark animation produced 181 identical 3150-byte PNGs, and the run performed exactly **one** texture load â€” nothing was ever drawn.

## Root cause

The runtime rejected each prepared render command:

```
ERROR: [GL] Prepared command has framebuffer signature
  { Samples = 1 ... DepthStencilAttachment = Some Depth24Stencil8 }
but expected
  { Samples = 8 ... DepthStencilAttachment = Some Depth24Stencil8 }
ERROR: [SNAPSHOT] Could not render image 000000_Bookmark_0.png
```

A render object may only be drawn into a framebuffer whose signature matches the one it was prepared against. The scene graph is prepared against the app signature in `PRo3D.Snapshots/Program.fs`, but each snapshot path built its own offscreen target from hardcoded values â€” and all three had drifted apart:

| | samples | depth |
|---|---|---|
| `Program.fs:100` (app signature) | *no argument* â†’ 1 | `Depth24Stencil8` |
| `executeBookmarkAnimation` | 8 | `Depth24Stencil8` |
| `executeCameraAnimation` | 1 | `DepthComponent32f` |

So **bookmark** animations failed on the sample count, and **camera** animations failed on the depth format. The camera path is not a side case â€” `executeAnimation` routes `PanoramaCollection` through it, and `SnapshotAnimation.fs:313` falls back to a `CameraAnimation` when there are no sequenced bookmarks. All three snapshot animation kinds were affected.

## Fix

One source of truth, since three hardcoded copies had already drifted twice:

```fsharp
module SnapshotFramebuffer =
    [<Literal>]
    let samples = 8
    let depthStencilFormat = TextureFormat.Depth24Stencil8
    let attachments = [ DefaultSemantic.Colors, TextureFormat.Rgba8
                        DefaultSemantic.DepthStencil, depthStencilFormat ]
    let createSignature (runtime : IRuntime) =
        runtime.CreateFramebufferSignature(attachments, samples)
```

Both snapshot paths and the app signature now build from it. Samples stay at **8**, so snapshots keep their multisampling.

## Testing

Against a real Jezero scene (9 OPC surfaces) and the `batchRendering.json` the viewer emits, on both paths, zero signature errors:

| Path | Before | After |
|---|---|---|
| Bookmark animation | 181 Ã— 3150 B, all black | **182** frames, 1.32â€“2.04 MB, all distinct |
| Camera / panorama animation | 4 Ã— 3150 B, all black | 5 frames, 1.32â€“1.38 MB, all distinct |

The bookmark run gains a frame because `000000` previously failed outright rather than rendering black. Output was compared against the same view in the viewer and matches.

Reproduced identically on the rc1 standalone package and on a local Debug build beforehand, so this is a `releases/6.0.0` code bug rather than something about the packaging.

## Reviewer note

The camera path's depth attachment changes from `DepthComponent32f` to `Depth24Stencil8`. That buffer feeds `renderDepth` (`--renderDepth`), which is a live CLI flag — not dead code, despite the stale *"not in use"* comment at `SnapshotApp.fs:74`.

Tested on this branch: `--renderDepth` runs clean and writes a `_depth.exr` per frame. Depth *content* is separately broken — five different camera positions give five byte-identical depth files — but that is pre-existing and unrelated: rebuilding with `samples = 1` yields the same md5, so it does not depend on the sample count. Filed as #674.

So this change does not regress anything that currently works.

Needed for **rc2**: 6.0.0-rc1 ships with all snapshot animation kinds rendering black.
