### PR TITLE
fix(sequenced bookmarks): stop playback losing the camera orientation

### DIFF
--- a/src/PRo3D.Core/SequencedBookmarks/BookmarkAnimations.fs
+++ b/src/PRo3D.Core/SequencedBookmarks/BookmarkAnimations.fs
@@ -30,24 +30,28 @@ module BookmarkAnimations =
         let frustum_ = SceneStateViewConfig.frustumModel_ >-> FrustumModel.frustum_
         let focal_   = SceneStateViewConfig.frustumModel_ >-> FrustumModel.focal_ >-> NumericInput.value_
 
-        let private viewsCoincide (a : CameraView) (b : CameraView) =
-            Vec.distance a.Location b.Location < 1e-8 &&
-            Vec.distance a.Forward  b.Forward  < 1e-10 &&
-            Vec.distance a.Sky      b.Sky      < 1e-10
-
-        /// Wrapper around Animation.Camera.interpolate that is robust for coincident
-        /// camera views. The stock primitive derives its duration from the camera path,
-        /// so two identical views collapse to a zero-duration animation; Animation.seconds
-        /// then cannot rescale it ("Cannot scale composite animation with zero duration")
-        /// and it samples to Unchecked.defaultof<CameraView> (null), which nulls out
-        /// navigation.camera.view. For coincident endpoints we return a unit-duration
-        /// constant hold instead.
-        /// TODO: fix upstream in aardvark.media and remove this wrapper.
+        /// Interpolates between two camera views over a fixed unit duration.
+        ///
+        /// Deliberately does not use Animation.Camera.interpolate: that primitive composes a
+        /// position and an orientation animation whose durations are derived from how far each
+        /// one travels, and a component that does not move collapses to zero duration and then
+        /// samples to its default value rather than holding still. Two bookmarks that share an
+        /// orientation but not a location - a pure dolly - therefore produced a correct position
+        /// with Unchecked.defaultof<Rot3d>, i.e. CameraView.orient loc (Rot3d()) sky, whose
+        /// forward is +Y: the camera stared off into the sky for the whole segment. Fully
+        /// coincident endpoints degenerated further, to a null CameraView.
+        ///
+        /// Sampling position and orientation together under one explicit duration removes the
+        /// dependency on how far either travels, so identical endpoints simply hold. This
+        /// mirrors what the snapshot path already does in SnapshotAnimation.lerpCamera, which
+        /// is why batch-rendered animations never showed the bug.
         let cameraInterpolateSafe (src : CameraView) (dst : CameraView) : IAnimation<'Model, CameraView> =
-            if viewsCoincide src dst then
-                Animation.create (fun (_ : float) -> dst) |> Animation.seconds 1.0
-            else
-                Animation.Camera.interpolate src dst
+            Animation.create (fun (t : float) ->
+                let location = src.Location + (dst.Location - src.Location) * t
+                let orientation = Rot.SlerpShortest(src.Orientation, dst.Orientation, t)
+                CameraView.orient location orientation dst.Sky
+            )
+            |> Animation.seconds 1.0
 
         // interpolate ViewConfigModel for animation
         let interpVcm (src : SceneStateViewConfig) (dst : SceneStateViewConfig)
@@ -111,7 +115,7 @@ module BookmarkAnimations =
                 else 
                     []
             
-            let toNext = 
+            let toNext =
                 let animCam =
                     cameraInterpolateSafe (src.bookmark.cameraView) (dst.bookmark.cameraView)
                     

--- a/src/Tests/Features/Section08_SequencedBookmarks.fs
+++ b/src/Tests/Features/Section08_SequencedBookmarks.fs
@@ -1,4 +1,4 @@
-/// Section 8 — Sequenced Bookmarks
+﻿/// Section 8 — Sequenced Bookmarks
 ///   TC-8.1 (Sequenced Bookmarks — Add and Animate)
 ///   TC-8.2 (Record and Generate Images) drives the renderer / an external
 ///   snapshot process, so it is not covered here.
@@ -9,13 +9,62 @@
 ///   the real AnimationSettings.update.
 module PRo3D.Tests.Section08_SequencedBookmarks
 
+open Aardvark.Base
+open Aardvark.Rendering                  // CameraView
 open Aardvark.UI.Primitives              // Numeric
+open Aardvark.UI.Animation               // IAnimation, Action, LocalTime
 
 open Expecto
 
 open PRo3D.Core                          // AnimationSettings (module)
+open PRo3D.Core.BookmarkAnimations       // Primitives.cameraInterpolateSafe
 open PRo3D.Core.SequencedBookmarks       // AnimationSettingsAction, AnimationLoopMode
 open PRo3D.Tests
+
+/// Drives an animation to the given point (0..1 of its duration) and reads its value.
+/// Perform only enqueues an action; the value is produced by Commit, which runs the
+/// state machine - so every action has to be followed by a commit.
+let private sampleCamera (t : float) (anim : IAnimation<unit, CameraView>) : CameraView =
+    let instance = anim.Create (Sym.ofString "test")
+    let tick = GlobalTime.zero
+
+    instance.Perform (Action.Start LocalTime.zero)
+    instance.Commit((), tick) |> ignore
+
+    instance.Perform (Action.Update (LocalTime.ofNormalizedPosition instance.Duration t, false))
+    instance.Commit((), tick) |> ignore
+
+    instance.Value
+
+/// Playback does not use a segment as-is. When both bookmarks carry a scene state -
+/// the normal case - interpolateBm combines the camera animation with the focal-length
+/// animation via Animation.map2 and then rescales the result to the bookmark's duration
+/// (`toNext |> Animation.seconds dst.duration.value`). Composing and rescaling is where
+/// a zero-duration component collapses, so the tests have to go through it too.
+let private asPlayed (anim : IAnimation<unit, CameraView>) =
+    let focalLike = Animation.create (fun (t : float) -> t) |> Animation.seconds 1.0
+    Animation.map2 (fun cam _ -> cam) anim focalLike
+    |> Animation.seconds 5.0
+
+/// A camera on the Jezero surface, taken from a real sequenced bookmark.
+let private jezeroView =
+    CameraView(
+        V3d(0.20811065578437726, 0.9253978445872588, 0.31674719285615177),      // sky
+        V3d(709857.680527099, 3141912.186800803, 1073840.48391507),             // location
+        V3d(-0.7031123388120046, -0.27585526813175626, -0.6553906545368723),    // forward
+        V3d(-0.2776991696603903, 0.9550167504467744, -0.10404891895648513),     // up
+        V3d(0.6546114956065489, 0.10884336180971418, -0.7480888399179051))      // right
+
+/// Two bookmarks that look the same way from different places - the case that regressed.
+let private pureDolly =
+    let dst = CameraView.orient (V3d(709419.8932611526, 3141740.427727654, 1073432.410173595))
+                                jezeroView.Orientation
+                                jezeroView.Sky
+    jezeroView, dst
+
+/// What CameraView.orient produces from a default (all-zero) rotation: forward +Y.
+let private defaultRotForward =
+    (CameraView.orient jezeroView.Location Unchecked.defaultof<Rot3d> jezeroView.Sky).Forward
 
 let tests =
     testList "Section 8 — Sequenced Bookmarks" [
@@ -51,5 +100,74 @@ let tests =
         test "TC-8.1 SetLoopMode sets the playback loop mode" {
             let m = AnimationSettings.update AnimationSettings.init (AnimationSettingsAction.SetLoopMode AnimationLoopMode.Repeat)
             Expect.equal m.loopMode AnimationLoopMode.Repeat "loop mode should be Repeat"
+        }
+
+        // TC-8.3 Playback camera interpolation
+        //
+        // Playing a sequence drives the camera through BookmarkAnimations.Primitives
+        // .cameraInterpolateSafe. A segment where one of position/orientation does not
+        // change is the interesting case: an implementation that animates the two
+        // components separately, with a duration derived from how far each one travels,
+        // lets the static component collapse to zero duration and sample to its default
+        // rather than hold. That produced Rot3d() - whose forward is +Y - for a pure
+        // dolly, i.e. the camera looking off into the sky for the whole segment.
+        //
+        // Of these, only "a pure rotation keeps the position" actually fails against the
+        // implementation that shipped in 6.0.0-rc2; the rest pass on both and are guards.
+        //
+        // TODO: the reported symptom - a pure *dolly* losing its orientation - is not
+        // reproduced at this level. It stays green on the old implementation whether the
+        // segment is sampled bare, rescaled the way interpolateBm rescales it, or composed
+        // with a focal animation through Animation.map2 as the both-scene-states branch
+        // does. Reproducing it needs a test one level up, over interpolateBm /
+        // pathWithPausing with real SequencedBookmarkModels carrying scene states, where
+        // Animation.sequential, the pause segment and the global-duration rescale are all
+        // in play. Until then that case is covered by manual verification only.
+
+        test "TC-8.3 a pure dolly keeps the orientation of both endpoints" {
+            let a, b = pureDolly
+            let mid = sampleCamera 0.5 (asPlayed (Primitives.cameraInterpolateSafe a b))
+
+            Expect.isLessThan (Vec.distance mid.Forward a.Forward) 1e-6
+                "forward should hold: both endpoints look the same way"
+            Expect.isGreaterThan (Vec.distance mid.Forward defaultRotForward) 1e-3
+                "forward must not collapse to the default rotation's +Y"
+        }
+
+        test "TC-8.3 a pure dolly interpolates the position" {
+            let a, b = pureDolly
+            let mid = sampleCamera 0.5 (asPlayed (Primitives.cameraInterpolateSafe a b))
+
+            Expect.isLessThan (Vec.distance mid.Location ((a.Location + b.Location) * 0.5)) 1e-6
+                "midpoint of the segment should be the midpoint of the two locations"
+        }
+
+        test "TC-8.3 a pure rotation keeps the position" {
+            let a = jezeroView
+            let b = CameraView.orient a.Location (Rot3d.RotationZ 0.4 * a.Orientation) a.Sky
+            let mid = sampleCamera 0.5 (asPlayed (Primitives.cameraInterpolateSafe a b))
+
+            Expect.isLessThan (Vec.distance mid.Location a.Location) 1e-6
+                "location should hold when only the orientation changes"
+        }
+
+        test "TC-8.3 coincident endpoints hold the view" {
+            let a = jezeroView
+            let mid = sampleCamera 0.5 (asPlayed (Primitives.cameraInterpolateSafe a a))
+
+            Expect.isFalse (obj.ReferenceEquals(mid, null)) "a coincident segment must not sample to null"
+            Expect.isLessThan (Vec.distance mid.Forward a.Forward) 1e-6 "forward should hold"
+            Expect.isLessThan (Vec.distance mid.Location a.Location) 1e-6 "location should hold"
+        }
+
+        test "TC-8.3 endpoints are reproduced at t=0 and t=1" {
+            let a, b = pureDolly
+            let anim = asPlayed (Primitives.cameraInterpolateSafe a b)
+
+            let atStart = sampleCamera 0.0 anim
+            let atEnd   = sampleCamera 1.0 anim
+
+            Expect.isLessThan (Vec.distance atStart.Location a.Location) 1e-6 "t=0 should be the source location"
+            Expect.isLessThan (Vec.distance atEnd.Location   b.Location) 1e-6 "t=1 should be the destination location"
         }
     ]


### PR DESCRIPTION
Playing a sequenced-bookmark animation sent the camera off into the sky: the position moved between bookmarks correctly while the view direction snapped to +Y for the whole segment (pitch jumping from −34° to +68° on a Jezero scene). Clicking an individual bookmark was fine, and batch-rendered snapshots of the same sequence were fine too.

## Root cause

Instrumenting the applied camera showed `forward = [0, 1, 0]` on every frame with `location` interpolating correctly. `CameraView.orient loc (Rot3d()) sky` reproduces exactly that vector — so the orientation reaching the camera was a **default, all-zero rotation**. The inputs were verified correct (both bookmarks `forward = [-0.703, -0.276, -0.655]`), so the value was lost in between.

`Animation.Camera.interpolate` composes a position animation and an orientation animation whose durations derive from *how far each one travels*. A component that does not move collapses to zero duration and then samples to its default rather than holding. Two bookmarks that share an orientation but differ in position — a plain dolly — therefore produced a good position and a null rotation.

The existing `cameraInterpolateSafe` guard (ca43d959) only covered **fully** coincident endpoints, where the collapse degenerates further into a null `CameraView` and crashes. The partial case slipped through and failed silently instead.

Why the snapshot path was unaffected: it is a **separate implementation**. `SnapshotAnimation.lerpCamera` steps an explicit frame count and never depends on how far a component travels. Verifying batch renders therefore said nothing about playback.

## Fix

Sample position and orientation together under one explicit duration, so nothing depends on how far either component travels and identical endpoints simply hold:

```fsharp
let cameraInterpolateSafe (src : CameraView) (dst : CameraView) : IAnimation<'Model, CameraView> =
    Animation.create (fun (t : float) ->
        let location    = src.Location + (dst.Location - src.Location) * t
        let orientation = Rot.SlerpShortest(src.Orientation, dst.Orientation, t)
        CameraView.orient location orientation dst.Sky)
    |> Animation.seconds 1.0
```

This subsumes the old `viewsCoincide` special case, so that helper and its upstream TODO are gone.

## Tests — please read this bit

New `TC-8.3` block in `Section08_SequencedBookmarks.fs`, driving the real animation through `Create` / `Perform` / `Commit`.

Against the implementation that shipped in **rc2**:

| Test | old | new |
|---|---|---|
| a pure rotation keeps the position | ❌ **fails** | ✅ |
| a pure dolly keeps the orientation | ✅ | ✅ |
| a pure dolly interpolates the position | ✅ | ✅ |
| coincident endpoints hold the view | ✅ | ✅ |
| endpoints reproduced at t=0 and t=1 | ✅ | ✅ |

Only **one** is a genuine red→green — the mirror case, where the static component is the position. The other four pass on both implementations and are guards, not proof.

**The reported symptom — a pure *dolly* losing its orientation — is not reproduced at this level.** It stays green on the old implementation whether the segment is sampled bare, rescaled the way `interpolateBm` rescales it, or composed with a focal animation through `Animation.map2` as the both-scene-states branch does. Reproducing it needs a test one level up, over `interpolateBm` / `pathWithPausing` with real `SequencedBookmarkModel`s carrying scene states, where `Animation.sequential`, the pause segment and the global-duration rescale are all in play. That is recorded as a TODO in the test file.

So the fix is verified **manually** against the reporting scene (a two-bookmark pure dolly, saved as `sbFail`) — playback now holds the view for the whole segment — and verified **by test** for the mirror degeneracy. I would rather state that than let a green suite imply the dolly case is covered.

Section 8: 11 passed, 0 failed.
