### PR TITLE
ci(deploy): fail when the resolved version is not the top release-notes entry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(./build.sh Version | grep -oP 'VERSION=\K.*')
+
+          # The version is *not* the topmost entry of PRODUCT_RELEASE_NOTES.md: FAKE's
+          # ReleaseNotes.load returns the entry with the highest SemVer. Under SemVer 11.4 a
+          # pre-release identifier containing letters compares lexically in ASCII order, so
+          # a counter that reaches two digits sorts below its predecessor -
+          # 6.0.0-prerelease10 < 6.0.0-prerelease9 - and the build silently resolves to the
+          # older version. That release already exists, so skip is set, every downstream job
+          # is skipped, and the workflow reports success having produced nothing.
+          # Fail loudly instead of shipping nothing. See docs/Build-Deploy-System.md.
+          TOP=$(grep -m1 '^## ' PRODUCT_RELEASE_NOTES.md | sed 's/^## *//' | tr -d '\r')
+          if [ "$VERSION" != "$TOP" ]; then
+            echo "::error::Top entry of PRODUCT_RELEASE_NOTES.md is '$TOP' but the build resolved '$VERSION'."
+            echo "::error::The release version is the highest SemVer in that file, not its first entry."
+            echo "::error::Zero-pad prerelease counters (rc001, rc002, ...) - see docs/Build-Deploy-System.md."
+            exit 1
+          fi
+
           TAG_NAME="v$VERSION"
 
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then


### PR DESCRIPTION
Releasing `6.0.0-prerelease10` produced **nothing while reporting success**. This makes that failure mode loud.

## What happened

The release version does not come from the topmost entry of `PRODUCT_RELEASE_NOTES.md`. FAKE's `ReleaseNotes.load` returns the entry with the **highest SemVer**, and under [SemVer §11.4](https://semver.org/#spec-item-11) a pre-release identifier containing letters is compared *lexically in ASCII order*:

```
"prerelease10"  vs  "prerelease9"
 ^^^^^^^^^^ equal, then '1' (0x31) < '9' (0x39)   →   prerelease10 < prerelease9
```

So the deploy resolved `6.0.0-prerelease9`, found that release already present, set `skip=true`, and every downstream job was skipped. **A workflow whose jobs all skip is green** — nothing anywhere signalled that no release had been built. It was only noticed because the expected artifacts never appeared.

## The guard

In `deploy.yml`'s `Check if release exists` step, before the existing lookup:

```bash
TOP=$(grep -m1 '^## ' PRODUCT_RELEASE_NOTES.md | sed 's/^## *//' | tr -d '\r')
if [ "$VERSION" != "$TOP" ]; then
  echo "::error::Top entry of PRODUCT_RELEASE_NOTES.md is '$TOP' but the build resolved '$VERSION'."
  ...
  exit 1
fi
```

The error message points at the zero-padding rule now documented in `docs/Build-Deploy-System.md`.

This is deliberately a *different* mechanism from the naming convention. The convention (`rc001`, `rc002`, …) prevents the ordering problem; the guard catches it whatever the cause — a typo, a hand-edited heading, a future scheme with its own edge case. The naming rule also cannot be retrofitted mid-line, so `6.0.x` will keep counting unpadded and stays exposed until the next `MAJOR.MINOR.PATCH`.

## Testing

- YAML parses; all 8 jobs still resolve (`check-release`, `test`, `draft`, `win32_x64`, `mac_x64`, `mac_arm64`, `linux_x64`, `standalone`)
- Verified both directions against the real file:
  - current notes (`## 6.0.0` on top, resolves `6.0.0`) → **passes**
  - simulated `## 6.0.0-prerelease10` on top with resolver returning `6.0.0` → **fails the run**
- All **129** headings in `PRODUCT_RELEASE_NOTES.md` are bare `## <version>` with no trailing text, so the exact comparison holds today

## Trade-off worth a look

A malformed or mistyped heading now **stops the deploy** instead of silently shipping an older version. I think that is the right direction given the alternative is a green run that produces nothing, and every existing heading already conforms — but it is a hard failure on a formatting mistake, so say if you would rather it warned and continued.
