### PR TITLE
Annotation polygon fill

### DIFF
--- a/plans/annotationPolygonFill.md
+++ b/plans/annotationPolygonFill.md
@@ -30,6 +30,15 @@ UI, the serialization and the packed draw call. Options A and C are drop-in repl
 
 ## Known limitations
 
+> **Accepted, not a bug: large polygons on rugged terrain.** The cap is flat within each
+> triangle, so across a large or rough polygon its middle sits above or below the surface while
+> only the rim is anchored. No depth offset fixes this - it is inherent to Option B. Verified in
+> the viewer and accepted as the shipped behaviour.
+>
+> The fix, if it ever becomes worth it, is Option A: subdivide in chart space and raycast every
+> interior vertex onto the surface. That replaces the geometry step in section 5 and reuses the
+> model, UI, serialization, renderer and picking unchanged.
+
 - **The cap is flat within each triangle.** With a plane chart the whole cap is planar; with a
   geographic chart the vertices sit on the datum but triangle interiors still chord across it.
   Full surface conformance needs subdivision (Option A).

--- a/plans/annotationPolygonFill.md
+++ b/plans/annotationPolygonFill.md
@@ -1,0 +1,611 @@
+# Annotation polygon fill — Option B (cap on a surface chart)
+
+Fill closed annotations (`Polygon`, `Ellipse`, `AxisEllipse`, `Axis4PEllipse`) with a
+translucent cap built in a 2D **surface chart** — either a fitted plane or a geographic
+(lat/lon) parameterisation — generalising the two modes the ellipse code already implements.
+
+**Explicitly out of scope** (see discussion for the full option set):
+- terrain-following fill meshes (Option A — subdivide in chart space + raycast every vertex)
+- stencil prism / shadow-volume fills (Option C — `GeologicSurfaceApp.StencilAreaMasking`)
+- shader-analytic or decal fills (Option D)
+
+Option B is the cheap first ship: it establishes the chart abstraction, the model fields, the
+UI, the serialization and the packed draw call. Options A and C are drop-in replacements for
+*step 5 only* (geometry generation) and reuse everything else.
+
+## Decisions taken
+
+- **Occluded, not overlay.** `DepthTest.LessOrEqual` + depth offset: a ridge in front hides the
+  fill and it reads as lying on the surface. The original request said "overlay the scene", but
+  a fill that ignores occlusion reads as a floating decal and destroys depth perception. The
+  "doesn't shine through far geometry" bonus comes free with this choice.
+- **Per-annotation fill properties** — `showFill` / `fillColor` / `fillAlpha` on `Annotation`
+  (section 3), not a global toggle. Buys selective filling and a fill colour independent of the
+  outline, at the cost of the serialization and UI plumbing.
+- **Geographic chart is opt-in**; the annotation's own chart wins where it has one (ellipses),
+  else the fitted plane (section 2).
+- **Fills are clickable** (section 8), with a config toggle to switch it off.
+- **Merge/split region model deferred** to that PR (section 10); this PR only keeps the
+  renderer region-capable so the decision stays cheap.
+
+## Known limitations
+
+- **The cap is flat within each triangle.** With a plane chart the whole cap is planar; with a
+  geographic chart the vertices sit on the datum but triangle interiors still chord across it.
+  Full surface conformance needs subdivision (Option A).
+- **Overlapping translucent fills blend in arbitrary order.** One packed draw with depth writes
+  disabled means no back-to-front sorting between annotations. Accepted; the alternative is
+  per-annotation passes, which defeats the packed design.
+- **The cap rim is straight between control points** (step 5), so in plan view it does not
+  exactly follow a terrain-projected outline that wiggles between corners.
+
+---
+
+## 1. Fix `getPolylinePoints` duplication (independent, do first)
+
+`Drawing.Sg.fs:161-182` emits `startPoint, samples…, endPoint` **per segment**. Segment *i*'s
+`endPoint` and segment *i+1*'s `startPoint` are the same corner by construction
+(`Drawing-App.fs:161`), so every interior corner is duplicated; the last interior sample can
+also coincide with `endPoint` (`Drawing-App.fs:171-179`, sample count is
+`floor(len / samplingDistance)`), giving triples.
+
+This is not a fill-specific problem. Duplicates become **zero-length segments** in
+`linesNoIndirect` (`PackedRendering.fs:474-486`), which the thick-line geometry shader expands
+via a direction normalize — `normalize(p1 - p0)` on a zero vector. A latent source of artifacts
+today, independent of this feature.
+
+Fix inside `getPolylinePoints` with an epsilon consecutive-duplicate filter. All 8 call sites
+(`Drawing.Sg.fs:259,355,468`, `PackedRendering.fs:373,455,581,591,665`,
+`OpcViewer/AnnotationViewer.fs:227`) are geometry consumers; none rely on duplicates.
+
+**Commit separately** from the fill feature — standalone bug fix, wants its own before/after
+check on line rendering.
+
+## 2. Surface charts — new `src\PRo3D.Base\SurfaceChart.fs`
+
+The ellipse code already has two ways to get from world space into a 2D domain where planar
+geometry is valid, and back:
+
+- **fitted plane** — `constructAndSampleFromPlane` (`EllipseAnnotation.fs:62-82`) via
+  `GetWorldToPlane` / `GetPlaneToWorld`
+- **geographic** — `constructAndSampleGeographical` (`:84-119`) via
+  `CooTransformation.tryGetLatLonAlt` / `tryGetXYZFromLatLonAlt`, with `Conv` (`:9-16`)
+  carrying the base altitude
+
+These are the same abstraction twice. Make it explicit and use it everywhere planar geometry is
+done on a curved surface:
+
+```fsharp
+/// A 2D chart of a neighbourhood of the surface: the domain in which planar
+/// geometry (ellipse construction, triangulation, area) is valid.
+/// Both directions are partial — geographic conversion can fail.
+type SurfaceChart = {
+    name    : string
+    toChart : V3d -> V2d option
+    toWorld : V2d -> V3d option
+}
+
+module SurfaceChart =
+    val ofPlane      : Plane3d -> SurfaceChart                              // total
+    val ofUpVector   : up: V3d -> origin: V3d -> SurfaceChart               // CrossSectionClipping.fs:10-24
+    val geographic   : Planet -> SpiceReferenceSystem option -> basePoint: V3d -> SurfaceChart
+```
+
+`ofPlane` caches the two matrices rather than rebuilding them per point.
+
+Place at `PRo3D.Base.fsproj` ~line 58, after `GisModels.fs` (54) and `CooTransformation.fs`
+(43), before `Annotation\RegressionInfo.fs` (59).
+
+### Why this matters for fills, not just tidiness
+
+With a plane chart, `toWorld` lifts every vertex onto a **secant plane** — over a km-scale
+polygon on Mars that plane cuts through the body and the cap sinks below the datum in the
+middle. With a geographic chart, `toWorld` puts vertices back at the base *altitude*, so the
+cap follows the body's curvature. For large annotations that is a materially better fill, and
+it comes free once the abstraction exists.
+
+### Chart-specific hazards to handle in `geographic`
+
+- **Antimeridian seam.** A polygon crossing ±180° longitude wraps and triangulates wrongly.
+  Unwrap longitudes relative to the first point (add ±360 to keep the ring contiguous).
+- **Poles.** Longitude degenerates; reject a point set spanning a pole rather than emitting
+  nonsense.
+- Equirectangular lat/lon is neither conformal nor equal-area. Triangulation *topology* is
+  unaffected (ear clipping only needs a consistent simple polygon) but ear quality degrades at
+  high latitude — acceptable, worth a comment.
+
+### Chart selection
+
+v1 rule, explicit rather than heuristic: use the annotation's own construction chart when it
+has one (ellipses do), else the fitted plane. Geographic stays **opt-in**. Note that
+`Drawing-App.fs:98` currently hard-disables the geographic ellipse path (`let geo = false`);
+this abstraction is what makes re-enabling it tractable, but that is a separate change.
+
+### Follow-up callers (not this PR)
+
+Four more places implement an ad-hoc chart and should migrate once this lands:
+`AnnotationHelpers.calculatePolygonArea:109`, `AnnotationQuery.queryFunctionsFromPointsOnPlane:61`,
+`CrossSection.buildPolygon:27`, and both `EllipticAnnotations.constructAndSample*`.
+
+## 3. Model — `src\PRo3D.Base\Annotation\Annotation-Model.fs`
+
+Add three fields to `Annotation` (record at `:474`):
+
+```fsharp
+    showFill  : bool
+    fillColor : ColorInput
+    fillAlpha : NumericInput      // 0.0 .. 1.0
+```
+
+Add an initial next to `textSize`/`thickness`:
+
+```fsharp
+    let fillAlpha = { value = 0.35; min = 0.0; max = 1.0; step = 0.05; format = "{0:0.00}" }
+```
+
+In `Annotation.make` (`:1034`) default to `showFill = false`, `fillColor = color`,
+`fillAlpha = Initial.fillAlpha`.
+
+The compiler will flag every other record-construction site; all take the same defaults:
+`Annotation-Model.fs` `readV0`–`readV5` (`:534`, `:597`, `:661`, `:725`, `:792`, `:860`),
+`SbmtImporter.fs:127,244`, `MeasurementsImporter.fs:160`.
+
+### Serialization
+
+**No version bump.** Follow the `crossSectionClipping` precedent (`:899-902`, `:989`): optional
+read in `readV5` only, hard default in `readV0`–`readV4`. Serialize primitives rather than
+`ColorInput`/`NumericInput` to avoid `Ext` plumbing:
+
+```fsharp
+// in readV5
+let! showFill  = Json.tryRead "showFill"
+let! fillColor = Json.tryRead "fillColor"      // C4b string
+let! fillAlpha = Json.tryRead "fillAlpha"      // float
+...
+showFill  = showFill |> Option.defaultValue false
+fillColor = fillColor |> Option.map (fun s -> { c = C4b.Parse s }) |> Option.defaultValue color
+fillAlpha = { Initial.fillAlpha with value = fillAlpha |> Option.defaultValue Initial.fillAlpha.value }
+```
+
+**Write all three unconditionally.** Gating the write on `x.showFill` silently discards a
+configured colour and alpha when the user turns the fill off and saves.
+
+`Annotation-Model.g.fs` is regenerated by Adaptify on build (`PRo3D.Base.fsproj:8`).
+
+## 4. UI — `src\PRo3D.Core\Drawing\Drawing-Properties.fs`
+
+Add to `AnnotationProperties.Action` (`:17`) and `update` (`:33`):
+
+```fsharp
+| SetShowFill      of bool
+| ChangeFillColor  of ColorPicker.Action
+| SetFillAlpha     of Numeric.Action
+```
+
+Three rows in `view` (`:84`) and `viewBulk` (`:110`). Distinct ColorPicker ids so the pickers do
+not collide: `"pro3dFill"` / `"pro3dBulkFill"` (the panel already uses `"pro3d"` / `"pro3dBulk"`
+for this reason, see the comment at `:105-109`).
+
+Gate the rows on `geometry` being a closed kind. `DnS` is excluded — it already has its own
+plane visualisation via `showDns`.
+
+## 5. Geometry — new `src\PRo3D.Base\Annotation\PolygonFill.fs`
+
+```fsharp
+module PolygonFill =
+    type FillMesh = { positions : V3d[]; chart : SurfaceChart }   // TriangleList, world space
+
+    /// Exposed for testing — the duplicate/degenerate handling is the fiddly part.
+    val normalize      : eps: float -> V3d[] -> V3d[]
+    val tryComputeFill : SurfaceChart -> V3d[] -> FillMesh option
+```
+
+Place after `SurfaceChart.fs`, before `Annotation-Model.fs`.
+
+### Input: control points, not the sampled rim
+
+Feed `a.points` (picked corners / the analytic ellipse ring), **not** `Sg.getPolylinePoints`:
+
+- **Cost.** Default sampling distance is 1 metre (`Drawing-Model.fs:167` ←
+  `Annotation.Initial.samplingAmount = 1.0`). A 4-corner polygon 200 m across gives ~800 rim
+  points; a km-scale one gives thousands. Ear clipping is O(n²) and the enclosing `AVal.custom`
+  re-runs on any annotation change. Control points are 4–20.
+- **Robustness.** A terrain-following rim flattened into the chart is far more likely to
+  self-intersect than a clean corner polygon.
+- **The rim buys nothing.** A flat-per-triangle cap and a terrain-following outline disagree in
+  3D by construction.
+- The closing segment from `closePolyline` is built backwards
+  (`startPoint = firstP; endPoint = lastP`, `Drawing-App.fs:55`), so the rim ring's last edge
+  runs in reverse — harmless for a `LineList`, not for a boundary walk.
+
+Ellipses are unaffected: segments are disabled for them (`Drawing-App.fs:150`), so `a.points`
+already *is* the 200-sample analytic ring.
+
+### Steps
+
+1. **`normalize`** — drop consecutive duplicates within `eps`, then drop the trailing point if
+   it is within `eps` of the first. `closePolyline` appends a duplicate first point to
+   `a.points` **only** in the `Linear` branch (`Drawing-App.fs:68`); Viewpoint/Sky/Bookmark add
+   a closing *segment* and leave `points` open (`:55-66`). `computeEllipsePoints` emits
+   `samples+1` points, so ellipse rings always carry the duplicate
+   (`EllipseConstruction.fs:69-78`). Require ≥ 3 remaining.
+
+   **`normalize` is the fallback for legacy data, and it is not optional.** Section 1 fixes
+   duplicates that `getPolylinePoints` *computes* from `segments`, so it applies to old and new
+   projects alike — but it does not touch anything stored. Stored `a.points`, which is what the
+   fill reads, can legitimately contain duplicates: `closePolyline`'s `Linear` branch appends
+   `firstP` (`Drawing-App.fs:68`), `computeEllipsePoints` emits `samples+1`
+   (`EllipseConstruction.fs:69-78`), a user can pick the same spot twice, and importers can
+   carry them in. `normalize` therefore runs on every fill computation regardless of data age.
+
+   Behind it, libtess is itself built to tolerate duplicate and degenerate contour vertices, so
+   a duplicate that slips through yields `[]` or a valid tessellation rather than an exception.
+   Worst case `tryComputeFill` returns `None`: no fill is drawn and the outline still renders.
+   The failure mode is a missing fill, never a crash.
+
+   **Do not normalize on load.** Rewriting stored points would silently change
+   `calculatePolygonArea` results and the rendered outline for existing projects. Normalize at
+   fill time only, and leave user data alone.
+
+   **Do not filter `IsNaN` here.** No producer of `annotation.points` can emit NaN: interactive
+   picking skips failed samples rather than substituting (`Drawing-App.fs:177-179`), ellipse
+   reprojection uses `Array.choose` (`EllipseAnnotation.fs:69-79`), both importers build points
+   from finite arithmetic (`SbmtImporter.fs:224-227`, `MeasurementsImporter.fs:76,138`). The
+   `IsNaN` filters in `AnnotationHelpers.fs` (`:113`, `:228`, `:305`, `:419`) are consumer-side
+   guards in front of plane fits, added in `cbbb5bd1`, not evidence of a producer — do not
+   propagate them into new code.
+
+2. **To chart**: `chart.toChart` over the points; any `None` → `None` overall (a partial
+   projection means the chart does not cover this annotation).
+
+   Where the chart comes from: `dnsResults.plane` for DnS/ellipse annotations makes the fill
+   coincide exactly with the ring (`EllipseAnnotation.fs:62-64` built it on that plane); a
+   `PlaneFitting.planeFit` chart for plain polygons makes the fill agree with the area reported
+   by `AnnotationHelpers.calculatePolygonArea` (`:109`).
+
+   **This is where NaN can genuinely reach the fill code.** `DipAndStrikeResults` initialises
+   every field to `NaN`/`V3d.NaN` (`Annotation-Model.fs:237-242`) and that sentinel round-trips
+   through the file format (`annotation_1.ann:112-114`), so a stored `dnsResults` may carry a
+   degenerate plane. Validate the plane at chart construction — reject non-finite normal or
+   distance and `Plane3d.Invalid` — and fall back to the fitted plane, then to `None`. Guard
+   the chart, not the points.
+
+3. **Tessellate carrying the original 3D points as an attribute.**
+
+   ```fsharp
+   PolygonTessellator.Triangulate(
+       regions     = [ chartPts, worldPts ],          // V2d[] * V3d[]
+       rule        = TessellationRule.EvenOdd,
+       interpolate = fun ws vs -> Array.map2 (*) ws vs |> Array.sum)
+   //  : list<Triangle2d<V3d>>
+   ```
+
+   `Aardvark.Geometry.PolygonTessellator.Triangulate` (`PolyRegion2d.fs:249-284` in
+   aardvark.base) is libtess-backed and carries a per-vertex attribute `'a` through
+   tessellation; invented vertices are resolved through the `interpolate` callback
+   (`:259-260`).
+
+   **Why this matters: the chart is used for topology only.** Passing the original world
+   points as the attribute means every output vertex that coincides with an input point comes
+   back as *exactly that point* — so the fill rim coincides with the drawn outline, terrain
+   projection and all. Only triangle interiors chord across the surface.
+
+   Without this, the fill would have to lift vertices back through `chart.toWorld`, which
+   **re-flattens them onto the datum**. That is visibly wrong for ellipses in particular: their
+   `a.points` are already surface-projected (`constructAndSampleFromPlane` raycasts them and
+   `Drawing-App.fs:98-105` writes the result back), so a `toWorld` rim would float above or
+   below the ring the user can see.
+
+   > This is only necessary because the tessellator has no *indexed* output — it returns
+   > triangles, not indices into the input. Indices would not actually suffice anyway: boolean
+   > ops and self-intersection resolution create vertices corresponding to no input index. The
+   > attribute channel is the more general answer and it already exists.
+
+   `chart.toWorld` is therefore **not needed on the fill path at all**. Keep it on
+   `SurfaceChart` — the ellipse sampler and any future Option A subdivision do need it.
+
+4. **Emit** the `Triangle2d<V3d>` list as a flat world-space triangle soup, taking the `V3d`
+   attribute of each vertex and discarding the 2D position. No index buffer — the packed draw
+   concatenates many annotations.
+
+5. **Reject empty results.** The tessellator returns `[]` for collinear and degenerate input,
+   so that is the only rejection needed — no special-casing, no `try/catch`, and no manual
+   winding fix (libtess normalises orientation via the `TessellationRule`). The signed-area
+   loop from `CrossSectionClipping.fs:36-45` is *not* needed here.
+
+   Self-intersecting input does **not** fail — it resolves by winding rule into a non-empty
+   region. Pin the actual behaviour with a test (section 9) rather than assuming.
+
+> **Where `PolyRegion` fits.** The attributed path above covers the simple fill and needs no
+> region type. `Aardvark.Geometry.PolyRegion` (`PolyRegion2d.fs:485-616`) is the *region*
+> abstraction — boolean ops plus `containsPoint` — and it is what section 10 needs. Note it is
+> attribute-free (`private(polygons : list<Polygon2d>)`, `:485`) and its `Triangulate()` calls
+> the non-attributed `LibTess.triangulate` (`:493`), so the world-point channel does **not**
+> survive a union. That gap is section 10's problem, not this PR's.
+
+> **Keep `FillMesh` region-capable from the start.** A triangle soup is a triangle soup whether
+> or not it came from a region with holes or several components, so the renderer needs no
+> changes when merge/split starts producing them. The *model* stays a single ring for this PR;
+> that is where the cost lands later.
+
+## 6. Renderer — `src\PRo3D.Core\Drawing\PackedRendering.fs`
+
+New `fills` function modelled on `linesNoIndirect` (`:435-518`):
+
+```fsharp
+let fills (depthOffset : aval<float>) (annoSet : aset<Guid * AdaptiveAnnotation>) (view : aval<M44d>) =
+```
+
+Inside a single `AVal.custom`, for each annotation where `visible && showFill` and `geometry` is
+a closed kind: read `anno.points`, build the chart, call `PolygonFill.tryComputeFill`, append
+positions and one `C4f` per vertex from `fillColor.c` with `A = fillAlpha`.
+
+Transform vertices into model space with the shared `modelTrafo.Backward`, reusing the
+first-annotation-wins `mutable modelTrafo` from `:462-468`.
+
+> **That trick is correct, do not "fix" it.** `getPolylinePoints` and `points` are world-space,
+> so the trafo serves only as a float32 precision pivot; any common pivot works. It is not a
+> per-annotation model transform.
+
+```fsharp
+Sg.draw IndexedGeometryMode.TriangleList
+|> Sg.vertexAttribute DefaultSemantic.Positions ...
+|> Sg.vertexAttribute DefaultSemantic.Colors ...
+|> Sg.uniform "MV" mv
+|> Sg.uniform "DepthOffset" (depthOffset |> AVal.map (fun d -> (d * fillOffsetFactor) / (100.0 - 0.1)))
+```
+
+Shader: `StableLight.stableTrafo'` (`:30-77`) + `DefaultSurfaces.vertexColor` +
+`PRo3D.Base.Shader.DepthOffset.depthOffsetFS`.
+
+> **Shader detail to verify at implementation time.** `depthOffsetFS` computes
+> `(v.pos.Z - offset) / v.pos.W` (`Utilities.fs:261-293`) and needs clip-space position with
+> `W` intact. The line path only works because the geometry shader explicitly restores `W`
+> (`PackedRendering.fs:298-301`, comment: *"restore W component for depthOffset"*). There is no
+> geometry shader here, so a vertex shader emitting `viewProj * p` is already correct — but
+> confirm `stableTrafo'` passes clip position through rather than perspective-dividing.
+
+Render state:
+
+- `Sg.blendMode BlendMode.Blend`
+- `Sg.writeBuffers' [WriteBuffer.Color DefaultSemantic.Colors]` — **no depth write**
+- depth test per open decision (i)
+- a dedicated `RenderPass` ordered **before** the packed lines pass, so outlines land on top.
+  Do not rely on `Sg.ofList` ordering.
+- `fillOffsetFactor`: a cap needs a much larger bias than a surface-hugging line. Start at
+  ~5× `config.offset`; promote to its own `ViewConfigModel` numeric input
+  (`ViewConfigModel.fs:156,186`) if 5× is not a good universal default.
+
+`CullMode.None` and `FillMode.Fill` are already applied by `Viewer.fs:2365-2378` — which
+matters, because the winding fix in 5.3 guarantees consistent orientation, not front-facing.
+
+### Caching
+
+The enclosing `AVal.custom` re-runs on any annotation change and re-triangulates everything.
+Add a `Dictionary<Guid, V3d[] * FillMesh>` keyed on annotation id + point-array reference from
+the start — the triangulation is a pure function of the points and the chart, and it is ~10
+lines.
+
+## 7. Wiring — `src\PRo3D.Core\Drawing\Drawing-App.fs`
+
+Packed branch (`:866-946`): build `packedFills` next to `packedPoints` (`:926`), prepend to the
+overlay list (`:930-936`). Legacy branch (`:948-979`): per-annotation construction wrapped in
+`Sg.trafo t`.
+
+> The two branches **do not** handle the SPICE reference-system trafo the same way: the packed
+> path drops it (`:886`, `:943`), the legacy path applies it (`:961`, `:977`). Tracked as
+> [pro3d-space/PRo3D#672](https://github.com/pro3d-space/PRo3D/issues/672). Until fixed, the
+> fill must mirror whatever the *outline* does in each branch, or fill and outline visibly
+> separate for annotations carrying a reference system. This is why a single shared fill sg
+> cannot serve both branches.
+
+`PRo3D.Snapshots\Program.fs:89` sets `usePackedAnnotationRendering <- false`, so skipping the
+legacy branch means snapshots silently render without fills.
+
+## 8. Picking — build it, clickable by default
+
+`Sg.pickable'` uses the line bounding box and the pick target only rasterizes lines
+(`pickRenderTarget:522-550`), so clicking inside a filled polygon does not select it today.
+Fix: feed the fill triangles into the same pick render target with a matching `ObjId` vertex
+attribute and the existing `Picking.pickId` shader (`:307-331`) — same geometry as the visible
+fill, one extra draw in an offscreen pass.
+
+Add a config flag to disable it (fills clickable **on** by default).
+
+> An earlier draft argued for defaulting this off, on the grounds that a large filled polygon
+> would swallow clicks meant for drawing a new annotation on the terrain inside it. **That
+> hazard does not exist**: `allowAnnotationPicking` (`Viewer.fs:2248-2256`) is true only in
+> `Interactions.PickAnnotation` and `Interactions.DrawLog`, so annotation picking is off
+> entirely while drawing. The modes are mutually exclusive.
+
+The residual case the toggle exists for is selecting an annotation that lies *behind* a large
+fill while in `PickAnnotation` mode.
+
+Note the depth interaction: the visible fill does not write depth (section 6), but the pick
+target is a separate pass with its own depth buffer, so fill and line pick geometry compete
+there normally. Give the fill the same `DepthOffset` treatment as the visible draw so a fill
+does not win the pick against its own outline.
+
+Once merge/split lands, this can be reimplemented as `PolyRegion.containsPoint` in chart space
+and the pick-target geometry dropped entirely (section 10).
+
+## 9. Unit tests — `src\Tests\PolygonFillTests.fs`
+
+Expecto, following `TriangleSetTests.fs`; register in `Program.fs` and add to `Tests.fsproj`.
+The whole filling logic is pure and therefore fully testable without a renderer — the only part
+that is not is the sg construction in step 6.
+
+### Point normalisation — the duplicate machinery
+
+This is where the real defects live (`getPolylinePoints` produces doubles *and* triples), so
+test `normalize` directly rather than only through `tryComputeFill`:
+
+- open ring passes through unchanged
+- trailing point exactly equal to first is dropped
+- trailing point within `eps` of first is dropped; just outside `eps` is kept
+- the `getPolylinePoints` shape `[a; b; b; c; c; a]` → `[a; b; c]`
+- the triple shape `[a; b; b; b; c; c; c; a]` → `[a; b; c]`
+- all-identical points → `None` from `tryComputeFill`
+- exactly 2 distinct points padded with duplicates → `None` (must not be fooled into counting 3)
+- fewer than 3 points → `None`
+- a legitimate ring that revisits a *non-adjacent* point is **not** silently collapsed
+- `normalize` is idempotent: `normalize (normalize xs) = normalize xs`
+
+### Charts
+
+- `ofPlane` round-trip: `toWorld (toChart p) ≈ p` for points on the plane; for off-plane points
+  the result lands *on* the plane (`plane.Height v ≈ 0`)
+- `geographic` round-trip within tolerance for several lat/lons; returns `None` where
+  `CooTransformation` fails rather than emitting NaN
+- antimeridian: a ring spanning ±180° longitude produces a contiguous chart polygon (unwrapped),
+  and its triangulation has the same triangle count as the same ring away from the seam
+- pole spanning → rejected
+- **chart independence**: the same polygon under a plane chart and a geographic chart yields the
+  same triangle *count* and the same index topology, differing only in vertex positions
+
+### Triangulation and invariants
+
+`PolyRegion` owns triangulation and winding, so these test *our* use of it, not its internals:
+
+- convex square → summed triangle area equals the square's
+- concave L → summed area equals the polygon's; no triangle centroid falls outside the polygon
+  (catches ears cut across a concavity)
+- 200-sample ellipse ring → area ≈ `πab` within tolerance
+- collinear points → `None` (via `isEmpty`)
+- self-intersecting bowtie → a **non-empty** region whose area is the winding-rule resolution,
+  not a crash and not garbage. Pin the actual behaviour with a test rather than assuming it;
+  this is the case an earlier draft wrongly expected to fail.
+- winding: CW and CCW inputs produce the same summed area (regions are orientation-normalised)
+- degenerate `dnsResults` plane (all-NaN, per `Annotation-Model.fs:237-242`) → falls back to the
+  fitted plane and still produces a fill, rather than `None`
+- **every output vertex lies on the chart surface** (plane chart: `plane.Height v ≈ 0`)
+- **summed triangle area == `AnnotationHelpers.calculatePolygonArea`** for the same points —
+  ties the rendered fill to the number shown in the properties panel
+- a region with a hole (constructed via `PolyRegion.difference`) triangulates to a mesh whose
+  summed area equals outer − inner — proves the renderer path is region-ready for section 10
+
+## 10. Next feature: merge / split annotations (plan ahead, do not build yet)
+
+Boolean ops on annotations are the natural follow-up and they fall out of this design almost
+entirely: both prerequisites — a shared 2D chart and a region type — are introduced here.
+
+```
+merge  a b = PolyRegion.union        (region a) (region b)
+split  a b = PolyRegion.difference   (region a) (region b)
+common a b = PolyRegion.intersection (region a) (region b)
+```
+
+### What this PR should get right so the follow-up is cheap
+
+- **`SurfaceChart` is load-bearing, not tidiness.** Two annotations can only be combined in a
+  *common* chart. Two polygons with different fitted planes have no meaningful union until one
+  chart is chosen for both — so `SurfaceChart` needs to be a value that can be constructed
+  independently of any single annotation and shared. The signature in section 2 already allows
+  that; do not let it collapse into "the annotation's plane".
+- **Keep the renderer region-capable** (section 5) so merged results render without changes.
+
+### The one hard problem, worth deciding early
+
+**A region is not a ring, but `Annotation.points : IndexList<V3d>` is.** A union can produce a
+polygon with holes, or several disjoint components. `toPolygons` will hand back multiple rings;
+the model cannot store them. Three ways out:
+
+1. **Restrict** — only commit a merge when the result is a single hole-free ring; refuse with a
+   message otherwise. Zero model change, but refuses many legitimate merges.
+2. **Explode** — emit one annotation per component and discard holes. No model change, but
+   silently wrong for anything with a hole.
+3. **Extend the model** to a list of rings with orientation. Correct, but it is an
+   `Annotation` format change: version bump to 6, a `readV6`, and every consumer that assumes a
+   single ring (`calculatePolygonArea`, the exporters, `getPolylinePoints`, the line packer)
+   has to cope.
+
+(3) is the honest answer and (1) is the cheap one. Worth deciding before the merge/split PR
+starts, because it determines whether that PR is a week or a day.
+
+### An aardvark.base contribution worth making
+
+The attribute channel that makes the fill rim exact (section 5, step 3) **does not survive a
+boolean op**. `PolygonTessellator.Triangulate` and `Combine` both carry a per-vertex `'a`
+through libtess via the `interpolate : float[] -> 'a[] -> 'a` callback
+(`PolyRegion2d.fs:238-284`), but `PolyRegion` itself is `list<Polygon2d>` (`:485`) — plain,
+attribute-free — and its operators (`+`, `-`, `*`, `^^^`) drop any payload.
+
+So a merged annotation cannot carry its original terrain-projected world points through the
+union, and its fill would fall back to `chart.toWorld` — re-flattening the rim onto the datum,
+exactly the artifact section 5 avoids.
+
+The fix belongs upstream, not in PRo3D: a `PolyRegion<'a>` whose boolean operators thread the
+attribute through, taking the same `interpolate` callback the tessellator already accepts. The
+underlying machinery is already wired — libtess's `CombineCallback` is invoked for precisely
+the vertices a boolean op invents (`:259-260`). It is a matter of threading `'a` through the
+type and its operators.
+
+Note that an *indexed* variant would not be sufficient: boolean ops create vertices that
+correspond to no input index, so "60% of A + 40% of B" has to be expressible. The attribute +
+`interpolate` design already handles that; indices cannot.
+
+Filed upstream as [aardvark-platform/aardvark.base#100](https://github.com/aardvark-platform/aardvark.base/issues/100).
+Source is checked out at `C:\Users\haral\Desktop\aardvark\aardvark.base`.
+
+### Vendoring — the answer for *this* feature, and it does not block on upstream
+
+**Nothing needs vendoring for the fill.** `Aardvark.Geometry.PolygonTessellator.Triangulate`
+with its `'a` attribute channel ships in the 5.3.26 package PRo3D already resolves (verified by
+reflection against the packaged assembly), so section 5 works against the released library.
+
+Only boolean ops need the attributed `boundary`, and #100 must not gate them. So when merge/split
+starts, vendor rather than wait: copy `src/Aardvark.Geometry/PolyRegion2d.fs` into `PRo3D.Base`,
+implement the attributed `boundary` + `PolyRegion<'a>` there, use it, and upstream the same diff.
+Feasibility is confirmed:
+
+- **Self-contained** — one 716-line file whose only external dependency is
+  `Unofficial.LibTessDotNet` 2.0.2, a public NuGet package (`Aardvark.Geometry.fsproj:36`).
+  `PRo3D.Base` would take a direct reference on it.
+- **Licence** — aardvark.base is Apache 2.0; vendor with attribution and keep the header.
+- **`module private LibTess`** is file-private, so the file cannot be extended from outside —
+  copying it wholesale is the only option, which is what vendoring means anyway.
+
+Two rules that keep the upstream PR clean:
+
+1. **Put it in a different namespace** (`PRo3D.Base.Geometry`, not `Aardvark.Geometry`).
+   `PRo3D.Base` already references the real `Aardvark.Geometry`, so an identical
+   namespace + type name would be ambiguous at every use site.
+2. **Keep the file byte-identical to upstream** except the namespace line and the new
+   attributed additions. No reformatting, no drive-by improvements. Then the upstream PR is
+   the diff minus the namespace change.
+
+Record the upstream commit the copy was taken from in a header comment, and mark the file
+`TODO: delete when #100 lands`. The alternative — doing the work upstream first and waiting for
+a release — blocks PRo3D on aardvark's cadence for no benefit.
+
+### Free wins to fold in at the same time
+
+- `AnnotationQuery.queryFunctionsFromPointsOnPlane` (`:61-97`) currently reduces the annotation
+  to its **convex hull** (`:81`, `ComputeConvexHullIndexPolygon`) before doing point-in-polygon.
+  Concave annotations therefore over-select today. `PolyRegion.containsPoint` fixes that
+  outright.
+- Section 8's optional fill-picking becomes `containsPoint` in chart space — no GPU pick
+  geometry needed at all.
+- `AnnotationHelpers.calculatePolygonArea` (`:109`) and `CrossSection.buildPolygon` (`:27`) are
+  the other two ad-hoc charts; migrating them onto `SurfaceChart` + `PolyRegion` retires the
+  last of the hand-rolled polygon code.
+
+## 11. Verification beyond unit tests
+
+- Round-trip: load `src\Tests\data\mola-annotations.pro3d.ann` (no fill fields) → defaults
+  applied, no read error → toggle fill on → save → reload → survives → toggle off, save, reload
+  → colour and alpha survive.
+- Old-reader compat: a file saved with fills still declares `version 5`; older builds ignore
+  unknown keys. Confirm against a 6.0.0-prerelease build.
+- Visual: polygon + `AxisEllipse` on an OPC scene — fill sits on the terrain, outline on top,
+  occlusion per decision (i).
+- Step 1 regression: line rendering unchanged (or improved) after the `getPolylinePoints`
+  dedupe — check a dense polygon and a DnS annotation.
+- Snapshot path: render a snapshot containing a filled annotation (the legacy-branch check).
+
+## Order of work
+
+1 (standalone, own commit) → 2 → 5 + 9 (chart and fill logic land with their tests) → 3 → 6 →
+7 → 8 (picking) → 4 (UI) → 11 (verification).
+
+Section 10 is the next PR, not this one.

--- a/plans/annotationPolygonFill.md
+++ b/plans/annotationPolygonFill.md
@@ -411,6 +411,26 @@ overlay list (`:930-936`). Legacy branch (`:948-979`): per-annotation constructi
 `PRo3D.Snapshots\Program.fs:89` sets `usePackedAnnotationRendering <- false`, so skipping the
 legacy branch means snapshots silently render without fills.
 
+## 7b. Default fill in the drawing toolbar — implemented
+
+Two controls beside thickness and sampling in `viewAnnotationToolsHorizontal`
+(`Drawing.UI.fs:83-93`): whether the next annotation is filled, and at what alpha.
+
+- `DrawingModel.fillNewAnnotations : bool` and `defaultFillAlpha : NumericInput`
+- `SetFillNewAnnotations` / `ChangeDefaultFillAlpha`, handled beside `ChangeThickness`
+- applied in `addPoint`'s existing `with` clause (`Drawing-App.fs:198`) — `Annotation.make`'s
+  signature is untouched
+
+**No fill colour control, deliberately.** `Drawing.UI.fs:87` records that the tool-level colour
+picker was removed because annotation colour comes from the active group's default. A toolbar
+fill colour would reintroduce exactly that and give one annotation two colour sources.
+`Annotation.make` already sets `fillColor = color`, so the fill follows the group colour for
+free; the properties panel still allows a per-annotation override.
+
+Session state, like the controls next to it: `drawing : DrawingModel` lives on `Model`, not
+`Scene` (`Viewer-Model.fs:598`), so geometry, thickness, sampling and now the fill defaults all
+reset each launch.
+
 ## 8. Picking — build it, clickable by default
 
 `Sg.pickable'` uses the line bounding box and the pick target only rasterizes lines
@@ -437,6 +457,23 @@ does not win the pick against its own outline.
 
 Once merge/split lands, this can be reimplemented as `PolyRegion.containsPoint` in chart space
 and the pick-target geometry dropped entirely (section 10).
+
+### The object-id space — implemented
+
+Line and fill draws both write object ids indexing the same array. They originally agreed only
+because each enumerated `annoSet.Content` independently and happened to see the same order —
+two separate `AVal.custom` nodes with nothing enforcing agreement. A drift would have shown up
+as clicking one annotation and selecting another.
+
+`PackedRendering.orderedAnnotations` is now the single cached ordering both consume; object id N
+*is* index N of that array, so `fills` uses the loop index directly and its counter is gone. Any
+future packed draw that writes `ObjId` must take its ids from the same ordering.
+
+> Unrelated: a report of hover highlighting while ctrl+click failed to select is **not** this.
+> Ctrl is a stateful toggle that flips `model.pick` on key-up (`Viewer.fs:1571-1576`), and
+> selection is gated on `match (act, model.draw, model.pick)` needing `(_, false, true)`
+> (`Drawing-App.fs:615`) while hover is gated only by `allowAnnotationPicking`. A parity mismatch
+> produces exactly that symptom. Pre-existing; worth its own look if it recurs.
 
 ## 9. Unit tests — `src\Tests\PolygonFillTests.fs`
 

--- a/plans/annotationPolygonFill.md
+++ b/plans/annotationPolygonFill.md
@@ -568,32 +568,53 @@ the model cannot store them. Three ways out:
 (3) is the honest answer and (1) is the cheap one. Worth deciding before the merge/split PR
 starts, because it determines whether that PR is a week or a day.
 
-### An aardvark.base contribution worth making
+### The upstream gap — fixed, pending release
 
-The attribute channel that makes the fill rim exact (section 5, step 3) **does not survive a
-boolean op**. `PolygonTessellator.Triangulate` and `Combine` both carry a per-vertex `'a`
-through libtess via the `interpolate : float[] -> 'a[] -> 'a` callback
-(`PolyRegion2d.fs:238-284`), but `PolyRegion` itself is `list<Polygon2d>` (`:485`) — plain,
-attribute-free — and its operators (`+`, `-`, `*`, `^^^`) drop any payload.
+The attribute channel that makes the fill rim exact (section 5, step 3) originally **did not
+survive a boolean op**: `PolygonTessellator.Triangulate` and `Combine` carried a per-vertex `'a`
+through libtess, but `PolyRegion` was `list<Polygon2d>` and its operators dropped any payload.
+A merged annotation could not carry its terrain-projected world points through a union, so its
+fill would fall back to `chart.toWorld` and re-flatten the rim onto the datum — exactly the
+artifact section 5 avoids.
 
-So a merged annotation cannot carry its original terrain-projected world points through the
-union, and its fill would fall back to `chart.toWorld` — re-flattening the rim onto the datum,
-exactly the artifact section 5 avoids.
+Filed as [aardvark-platform/aardvark.base#100](https://github.com/aardvark-platform/aardvark.base/issues/100)
+and **implemented upstream** in
+[`0420fd19`](https://github.com/aardvark-platform/aardvark.base/commit/0420fd19bdf3ca27e9bd6c77036afbabf652e50f):
 
-The fix belongs upstream, not in PRo3D: a `PolyRegion<'a>` whose boolean operators thread the
-attribute through, taking the same `interpolate` callback the tessellator already accepts. The
-underlying machinery is already wired — libtess's `CombineCallback` is invoked for precisely
-the vertices a boolean op invents (`:259-260`). It is a matter of threading `'a` through the
-type and its operators.
+```fsharp
+type PolyRegion<'a> =
+    member Triangulate : (float[] -> 'a[] -> 'a) -> …     // TessellationRule.EvenOdd
+    static member Union / Difference / Intersection / Xor // each takes the interpolate callback
+```
 
-Note that an *indexed* variant would not be sufficient: boolean ops create vertices that
-correspond to no input index, so "60% of A + 40% of B" has to be expressible. The attribute +
-`interpolate` design already handles that; indices cannot.
+It carries point-aligned attributes through construction, all four boolean operations, contour
+closure, orientation and redundant-vertex cleanup. Legacy `PolyRegion` is untouched.
+`AttributedPolyRegion.removeRedundant` drops attributes alongside the collinear vertices it
+culls — the alignment hazard this plan flagged. Covered by `AttributedPolyRegionTests.fs`.
 
-Filed upstream as [aardvark-platform/aardvark.base#100](https://github.com/aardvark-platform/aardvark.base/issues/100).
-Source is checked out at `C:\Users\haral\Desktop\aardvark\aardvark.base`.
+**Assessment: it fits.** `Triangulate` uses `TessellationRule.EvenOdd`, the same rule the fill
+already uses via `PolygonTessellator.Triangulate`, so moving the fill onto `PolyRegion<'a>` when
+merge/split arrives is semantically continuous. The required `interpolate` callback is the
+weighted blend `PolygonFill.interpolateWorld` already implements. Forcing it explicitly per
+operation is the right call — there is no sensible default for blending an invented vertex.
 
-### Vendoring — the answer for *this* feature, and it does not block on upstream
+**The one gap is availability.** `0420fd19` is on master and in no tag (latest is 5.3.27);
+PRo3D resolves Aardvark.Geometry 5.3.26. So merge/split still cannot consume it from a package.
+
+Two things to confirm when adopting, both cheap:
+- our rings reach `Union` consistently oriented — it is positive-winding, and `ensureCcw` exists
+  upstream, but our input comes from arbitrary user drawing order
+- the self-intersecting bowtie still resolves as section 9 pins it; region construction plus
+  orientation normalisation is a different path from direct EvenOdd tessellation
+
+### Vendoring — now only a bridge until the release lands
+
+Since #100 is implemented, vendoring no longer means writing our own attributed boolean ops. If
+merge/split starts before a release carrying `0420fd19`, copy that file verbatim as a bridge and
+delete it when the package catches up — the steps below still apply, but the diff is upstream's
+own code rather than ours, so there is nothing to contribute back.
+
+
 
 **Nothing needs vendoring for the fill.** `Aardvark.Geometry.PolygonTessellator.Triangulate`
 with its `'a` attribute channel ships in the 5.3.26 package PRo3D already resolves (verified by

--- a/src/OpcViewer/AnnotationViewer.fs
+++ b/src/OpcViewer/AnnotationViewer.fs
@@ -63,7 +63,9 @@ module AnnotationViewer =
 
         let mv = view |> AVal.map (fun c -> (CameraView.viewTrafo c).Forward)
         let points = points (model.selectedLeaves |> ASet.map (fun x -> x.id)) annoSet config.offset mv
-        let lines, pickIds, bb = PackedRendering.linesNoIndirect config.offset hoveredAnnotation (picked |> AVal.map Option.toList |> ASet.ofAVal) annoSet mv
+        // the packed object-id space: object id N is index N of this ordering, and of pickIds below
+        let ordered = PackedRendering.orderedAnnotations annoSet
+        let lines, pickIds, bb = PackedRendering.linesNoIndirect config.offset hoveredAnnotation (picked |> AVal.map Option.toList |> ASet.ofAVal) ordered mv
 
         let pickColors = 
             //let size = AVal.constant (V2i(128,128))

--- a/src/PRo3D.Base/Annotation/Annotation-Model.fs
+++ b/src/PRo3D.Base/Annotation/Annotation-Model.fs
@@ -512,6 +512,11 @@ type Annotation = {
 
     crossSectionClipping : bool
     crossSectionRefPoint : Option<V3d>
+
+    /// fills the interior of closed geometries (polygon, ellipses); ignored for open ones
+    showFill   : bool
+    fillColor  : ColorInput
+    fillAlpha  : NumericInput
 }
 with
     static member current = 5
@@ -529,6 +534,16 @@ with
         max     = 360.0
         step    = 0.1
         format  = "{0:0.0}"
+    }
+
+    // lives on the type rather than in module Annotation.Initial because the version readers
+    // below need it, and the module is defined after the type
+    static member initialFillAlpha = {
+        value   = 0.35
+        min     = 0.0
+        max     = 1.0
+        step    = 0.05
+        format  = "{0:0.00}"
     }
         
     static member private readV0 =
@@ -591,6 +606,9 @@ with
                 ellipticResults  = None
                 crossSectionClipping = false
                 crossSectionRefPoint = None
+                showFill             = false
+                fillColor            = color
+                fillAlpha            = Annotation.initialFillAlpha
             }
         }
 
@@ -655,6 +673,9 @@ with
                 ellipticResults  = None
                 crossSectionClipping = false
                 crossSectionRefPoint = None
+                showFill             = false
+                fillColor            = color
+                fillAlpha            = Annotation.initialFillAlpha
             }
         }
 
@@ -719,6 +740,9 @@ with
                 ellipticResults  = None
                 crossSectionClipping = false
                 crossSectionRefPoint = None
+                showFill             = false
+                fillColor            = color
+                fillAlpha            = Annotation.initialFillAlpha
             }
         }
 
@@ -786,6 +810,9 @@ with
                 ellipticResults  = None
                 crossSectionClipping = false
                 crossSectionRefPoint = None
+                showFill             = false
+                fillColor            = color
+                fillAlpha            = Annotation.initialFillAlpha
             }
         }
 
@@ -854,6 +881,9 @@ with
                 ellipticResults  = None
                 crossSectionClipping = false
                 crossSectionRefPoint = None
+                showFill             = false
+                fillColor            = color
+                fillAlpha            = Annotation.initialFillAlpha
             }
         }
 
@@ -901,6 +931,13 @@ with
             let crossSectionRefPoint : Option<V3d> =
                 crossSectionRefPoint |> Option.map V3d.Parse
 
+            // optional, no version bump - same approach as crossSectionClipping above.
+            // primitives rather than ColorInput/NumericInput, so the input records can be
+            // rebuilt with current min/max/step instead of pinning stale bounds in the file.
+            let! showFill  = Json.tryRead "showFill"
+            let! fillColor = Json.tryRead "fillColor"
+            let! fillAlpha = Json.tryRead "fillAlpha"
+
             return {
                 version          = Annotation.current
                 key              = key           |> Guid.Parse
@@ -930,6 +967,14 @@ with
                 ellipticResults  = ellipseProperties
                 crossSectionClipping = crossSectionClipping |> Option.defaultValue false
                 crossSectionRefPoint = crossSectionRefPoint
+                showFill             = showFill |> Option.defaultValue false
+                fillColor            =
+                    fillColor
+                    |> Option.map (fun (s : string) -> { c = C4b.Parse s })
+                    |> Option.defaultValue color
+                fillAlpha            =
+                    { Annotation.initialFillAlpha with
+                        value = fillAlpha |> Option.defaultValue Annotation.initialFillAlpha.value }
             }
         }
 
@@ -990,6 +1035,12 @@ with
             match x.crossSectionRefPoint with
             | Some rp -> do! Json.write "crossSectionRefPoint" (rp.ToString())
             | None -> ()
+
+            // written unconditionally: gating on showFill would discard a configured fill
+            // colour and alpha as soon as the user switches the fill off and saves
+            do! Json.write "showFill"  x.showFill
+            do! Json.write "fillColor" (x.fillColor.c.ToString())
+            do! Json.write "fillAlpha" x.fillAlpha.value
         }
 
 module Annotation =
@@ -1073,6 +1124,9 @@ module Annotation =
             ellipticResults  = None
             crossSectionClipping = false
             crossSectionRefPoint = None
+            showFill             = false
+            fillColor            = color
+            fillAlpha            = Annotation.initialFillAlpha
         }
 
     let initial =

--- a/src/PRo3D.Base/Annotation/Annotation-Model.g.fs
+++ b/src/PRo3D.Base/Annotation/Annotation-Model.g.fs
@@ -1,5 +1,5 @@
-//02f7b0e2-2f2f-a35e-ea38-b810240cec41
-//20cca9a3-0146-ffe1-59ca-65f794a9c26b
+//9f7d23fc-a144-26a8-f475-baaa35ab4d7c
+//8b6f74da-c2f2-c74d-f95c-5ec8c214cc27
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -233,6 +233,9 @@ type AdaptiveAnnotation(value : Annotation) =
     let _semanticType_ = FSharp.Data.Adaptive.cval(value.semanticType)
     let _crossSectionClipping_ = FSharp.Data.Adaptive.cval(value.crossSectionClipping)
     let _crossSectionRefPoint_ = FSharp.Data.Adaptive.cval(value.crossSectionRefPoint)
+    let _showFill_ = FSharp.Data.Adaptive.cval(value.showFill)
+    let _fillColor_ = Aardvark.UI.AdaptiveColorInput(value.fillColor)
+    let _fillAlpha_ = Aardvark.UI.Primitives.AdaptiveNumericInput(value.fillAlpha)
     let mutable __value = value
     let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
     static member Create(value : Annotation) = AdaptiveAnnotation(value)
@@ -268,6 +271,9 @@ type AdaptiveAnnotation(value : Annotation) =
             _semanticType_.Value <- value.semanticType
             _crossSectionClipping_.Value <- value.crossSectionClipping
             _crossSectionRefPoint_.Value <- value.crossSectionRefPoint
+            _showFill_.Value <- value.showFill
+            _fillColor_.Update(value.fillColor)
+            _fillAlpha_.Update(value.fillAlpha)
     member __.Current = __adaptive
     member __.version = _version_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.int>
     member __.key = __value.key
@@ -297,6 +303,9 @@ type AdaptiveAnnotation(value : Annotation) =
     member __.semanticType = _semanticType_ :> FSharp.Data.Adaptive.aval<SemanticType>
     member __.crossSectionClipping = _crossSectionClipping_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
     member __.crossSectionRefPoint = _crossSectionRefPoint_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.Option<Aardvark.Base.V3d>>
+    member __.showFill = _showFill_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
+    member __.fillColor = _fillColor_
+    member __.fillAlpha = _fillAlpha_
 [<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 module AnnotationLenses = 
     type Annotation with
@@ -328,4 +337,7 @@ module AnnotationLenses =
         static member semanticType_ = ((fun (self : Annotation) -> self.semanticType), (fun (value : SemanticType) (self : Annotation) -> { self with semanticType = value }))
         static member crossSectionClipping_ = ((fun (self : Annotation) -> self.crossSectionClipping), (fun (value : Microsoft.FSharp.Core.bool) (self : Annotation) -> { self with crossSectionClipping = value }))
         static member crossSectionRefPoint_ = ((fun (self : Annotation) -> self.crossSectionRefPoint), (fun (value : Microsoft.FSharp.Core.Option<Aardvark.Base.V3d>) (self : Annotation) -> { self with crossSectionRefPoint = value }))
+        static member showFill_ = ((fun (self : Annotation) -> self.showFill), (fun (value : Microsoft.FSharp.Core.bool) (self : Annotation) -> { self with showFill = value }))
+        static member fillColor_ = ((fun (self : Annotation) -> self.fillColor), (fun (value : Aardvark.UI.ColorInput) (self : Annotation) -> { self with fillColor = value }))
+        static member fillAlpha_ = ((fun (self : Annotation) -> self.fillAlpha), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : Annotation) -> { self with fillAlpha = value }))
 

--- a/src/PRo3D.Base/Annotation/PolygonFill.fs
+++ b/src/PRo3D.Base/Annotation/PolygonFill.fs
@@ -1,0 +1,107 @@
+namespace PRo3D.Base.Annotation
+
+open Aardvark.Base
+open Aardvark.Geometry
+open PRo3D.Base
+
+/// Triangulates the interior of a closed annotation ring.
+///
+/// The ring is flattened into a SurfaceChart to decide *topology* only. Each vertex carries its
+/// original world position through the tessellator as an attribute, so the resulting mesh is
+/// stitched from the input points themselves rather than from their flattened images - the fill
+/// boundary coincides exactly with the outline the user drew, terrain projection included. Only
+/// triangle interiors chord across the surface.
+module PolygonFill =
+
+    type FillMesh =
+        {
+            /// Triangle list: three consecutive entries per triangle, world space. No index
+            /// buffer, because the packed renderer concatenates many annotations into one draw.
+            positions : V3d[]
+            /// The chart the topology was decided in. Kept for diagnostics.
+            chart     : SurfaceChart
+        }
+
+    /// World-space distance below which two consecutive ring points count as identical.
+    /// Well above double-precision noise at planetary magnitudes, far below meaningful detail.
+    [<Literal>]
+    let DefaultEpsilon = 1e-6
+
+    /// Collapses consecutive duplicates and strips the closing point, leaving an open ring.
+    ///
+    /// Stored annotation points genuinely contain duplicates, and no amount of fixing the
+    /// producers changes what is already in users' project files: closePolyline appends the first
+    /// point again in the Linear branch (Drawing-App.fs:68), computeEllipsePoints emits
+    /// samples+1 points (EllipseConstruction.fs:69-78), and a user can pick the same spot twice.
+    ///
+    /// Runs on every fill, therefore, not only on freshly drawn annotations. Stored points are
+    /// never rewritten - doing so would silently change calculatePolygonArea results and the
+    /// rendered outline of existing projects.
+    let normalize (eps : float) (ps : V3d[]) : V3d[] =
+        if ps.Length = 0 then Array.empty
+        else
+            let res = System.Collections.Generic.List<V3d>(ps.Length)
+            res.Add ps.[0]
+
+            for i in 1 .. ps.Length - 1 do
+                if Vec.Distance(res.[res.Count - 1], ps.[i]) > eps then
+                    res.Add ps.[i]
+
+            // the tessellator closes contours itself, so a ring closed by repetition would
+            // contribute a zero-length edge
+            while res.Count > 1 && Vec.Distance(res.[0], res.[res.Count - 1]) <= eps do
+                res.RemoveAt(res.Count - 1)
+
+            res.ToArray()
+
+    /// Weighted blend of the world positions libtess combines when it invents a vertex.
+    ///
+    /// Only fires where the tessellator splits an edge - self-intersections, and later boolean
+    /// ops. Vertices that coincide with an input point arrive with weight 1 on a single source
+    /// and so come back bit-identical.
+    let private interpolateWorld (weights : float[]) (values : V3d[]) : V3d =
+        let mutable acc = V3d.Zero
+        for i in 0 .. (min weights.Length values.Length) - 1 do
+            acc <- acc + values.[i] * weights.[i]
+        acc
+
+    /// Triangulates a closed ring within the given chart. None when the ring is degenerate, or
+    /// when the chart does not cover it.
+    let tryComputeFill (chart : SurfaceChart) (points : V3d[]) : FillMesh option =
+        let ring = normalize DefaultEpsilon points
+
+        if ring.Length < 3 then None
+        else
+
+        let projected = ring |> Array.map chart.toChart
+
+        if projected |> Array.exists Option.isNone then
+            Log.warn "[PolygonFill] chart '%s' does not cover all %d ring points" chart.name ring.Length
+            None
+        else
+
+        let chartPoints = projected |> Array.map Option.get
+
+        // libtess hands the combine callback fixed-size slots; guard rather than let an
+        // unexpected shape take down the whole render
+        let triangles =
+            try
+                PolygonTessellator.Triangulate(
+                    [ chartPoints, ring ],
+                    TessellationRule.EvenOdd,
+                    interpolateWorld)
+            with e ->
+                Log.warn "[PolygonFill] tessellation failed for a %d point ring: %s" ring.Length e.Message
+                []
+
+        match triangles with
+        | [] -> None
+        | ts ->
+            let positions = Array.zeroCreate (List.length ts * 3)
+
+            ts |> List.iteri (fun i (t : Triangle2d<V3d>) ->
+                positions.[i * 3 + 0] <- t.A0
+                positions.[i * 3 + 1] <- t.A1
+                positions.[i * 3 + 2] <- t.A2)
+
+            Some { positions = positions; chart = chart }

--- a/src/PRo3D.Base/GuiEx.fs
+++ b/src/PRo3D.Base/GuiEx.fs
@@ -93,8 +93,11 @@ module GuiEx =
 
       Incremental.i attributes AList.empty
 
+    // "square icon" is a *solid* square in Fomantic, so an unchecked box rendered as a filled
+    // block while the checked one is an outline - reading more like "on" than "off". Both states
+    // use the outline variant.
     let iconCheckBox (predicate : aval<bool>) action =
-      iconToggle predicate "check square outline icon" "square icon" action
+      iconToggle predicate "check square outline icon" "square outline icon" action
 
     // Like iconCheckBox, but the click emits an *absolute* target value (the negation of the
     // currently displayed state) rather than a fixed toggle action. Use this for bulk editing,
@@ -102,7 +105,7 @@ module GuiEx =
     // independently (mixed states just invert), whereas `setAction (not isOn)` drives every
     // item to the one uniform value the user just selected.
     let iconCheckBoxSet (predicate : aval<bool>) (setAction : bool -> 'msg) =
-      let toggleIcon = predicate |> AVal.map(fun isOn -> if isOn then "check square outline icon" else "square icon")
+      let toggleIcon = predicate |> AVal.map(fun isOn -> if isOn then "check square outline icon" else "square outline icon")
 
       let attributes =
         amap {

--- a/src/PRo3D.Base/PRo3D.Base.fsproj
+++ b/src/PRo3D.Base/PRo3D.Base.fsproj
@@ -53,6 +53,7 @@
     <Compile Include="InstrumentProjection.fs" />
     <Compile Include="GisModels.fs" />
     <Compile Include="GisModels.g.fs" />
+    <Compile Include="SurfaceChart.fs" />
     <Compile Include="FalseColors\FalseColors-Model.fs" />
     <Compile Include="FalseColors\FalseColors-Model.g.fs" />
     <Compile Include="FalseColors\FalseColorLegendApp.fs" />

--- a/src/PRo3D.Base/PRo3D.Base.fsproj
+++ b/src/PRo3D.Base/PRo3D.Base.fsproj
@@ -54,6 +54,7 @@
     <Compile Include="GisModels.fs" />
     <Compile Include="GisModels.g.fs" />
     <Compile Include="SurfaceChart.fs" />
+    <Compile Include="Annotation\PolygonFill.fs" />
     <Compile Include="FalseColors\FalseColors-Model.fs" />
     <Compile Include="FalseColors\FalseColors-Model.g.fs" />
     <Compile Include="FalseColors\FalseColorLegendApp.fs" />

--- a/src/PRo3D.Base/SurfaceChart.fs
+++ b/src/PRo3D.Base/SurfaceChart.fs
@@ -1,0 +1,132 @@
+namespace PRo3D.Base
+
+open System
+open Aardvark.Base
+open PRo3D.Base.Gis
+
+/// A 2D chart of a neighbourhood of a surface: the domain in which planar geometry
+/// (ellipse construction, triangulation, boolean ops, area) is valid.
+///
+/// Both directions are partial. Geographic conversion genuinely fails - outside a body's
+/// definition, or where SPICE has no data - and the plane charts conform to the same shape so
+/// callers never branch on which chart they are holding.
+///
+/// A chart maps to a *datum* - a plane, or the body at a given altitude - not to the terrain.
+/// Landing on the actual surface is a separate raycast step; see
+/// EllipticAnnotations.constructAndSampleFromPlane, which does chart inverse then projection.
+type SurfaceChart =
+    {
+        /// Identifies the chart in diagnostics. Not semantic.
+        name    : string
+        toChart : V3d -> V2d option
+        toWorld : V2d -> V3d option
+    }
+
+module SurfaceChart =
+
+    let private isFinite (v : float) =
+        not (Double.IsNaN v || Double.IsInfinity v)
+
+    /// Latitude beyond which the geographic chart refuses points: longitude degenerates at the
+    /// poles, so a ring spanning one cannot be represented.
+    let private poleGuardDegrees = 89.9
+
+    /// Chart of a plane: orthogonal projection onto it, and the inverse.
+    ///
+    /// Assumes a usable plane. Use tryOfPlane for planes read from stored data.
+    let ofPlane (plane : Plane3d) : SurfaceChart =
+        // cached once - GetWorldToPlane builds a matrix, and charts are applied per point
+        let w2p = plane.GetWorldToPlane()
+        let p2w = plane.GetPlaneToWorld()
+        {
+            name    = "plane"
+            toChart = fun p -> Some (w2p.TransformPos(p).XY)
+            toWorld = fun c -> Some (p2w.TransformPos(V3d(c, 0.0)))
+        }
+
+    /// ofPlane, rejecting planes that cannot define a chart.
+    ///
+    /// DipAndStrikeResults initialises every field to NaN / V3d.NaN (Annotation-Model.fs:237-242)
+    /// and that sentinel round-trips through the project format, so a stored dnsResults plane may
+    /// be degenerate. Plane3d.Invalid is caught by the same check.
+    let tryOfPlane (plane : Plane3d) : SurfaceChart option =
+        let n = plane.Normal
+        if not (isFinite n.X && isFinite n.Y && isFinite n.Z && isFinite plane.Distance) then None
+        elif n.LengthSquared < 1e-12 then None
+        else Some (ofPlane plane)
+
+    /// Chart of the plane through origin having up as its normal, with an in-plane basis built
+    /// the same way as CrossSection.buildBasisFromUp (CrossSectionClipping.fs:10-24).
+    let ofUpVector (up : V3d) (origin : V3d) : SurfaceChart =
+        let n = if up.LengthSquared < 1e-30 then V3d.OOI else up.Normalized
+
+        let x =
+            let c = Vec.cross n V3d.OOI
+            let c = if c.LengthSquared < 1e-12 then Vec.cross n V3d.IOO else c
+            c.Normalized
+
+        let y = (Vec.cross n x).Normalized
+
+        {
+            name    = "up-vector"
+            toChart = fun p ->
+                let d = p - origin
+                Some (V2d(Vec.dot d x, Vec.dot d y))
+            toWorld = fun c ->
+                Some (origin + x * c.X + y * c.Y)
+        }
+
+    /// Geographic chart: longitude / latitude in degrees, at the base point's altitude.
+    ///
+    /// Unlike the plane charts this follows the body's curvature, so it does not sag beneath the
+    /// datum the way a secant plane does across a large annotation (roughly L^2/8R: ~4 m over
+    /// 10 km on Mars, ~370 m over 100 km).
+    ///
+    /// Longitudes are unwrapped relative to the base point, so a ring crossing the +/-180 deg
+    /// meridian stays contiguous in chart space instead of jumping the seam. A ring spanning a
+    /// pole has no such repair - longitude is degenerate there - so toChart refuses points within
+    /// poleGuardDegrees of one.
+    ///
+    /// Equirectangular lon/lat is neither conformal nor equal-area. Triangulation topology is
+    /// unaffected, but triangle quality degrades at high latitude.
+    ///
+    /// Returns None when the base point itself cannot be converted.
+    let geographic
+        (planet          : Planet)
+        (referenceSystem : SpiceReferenceSystem option)
+        (basePoint       : V3d)
+        : SurfaceChart option =
+
+        let toSpherical (p : V3d) =
+            match referenceSystem with
+            | Some r -> CooTransformation.tryGetLatLonAltPlanet r.body.Value p
+            | None   -> CooTransformation.tryGetLatLonAlt planet p
+
+        let fromSpherical (sc : CooTransformation.SphericalCoo) =
+            match referenceSystem with
+            | Some r -> CooTransformation.tryGetXYZFromLatLonAltPlanet sc r.body.Value
+            | None   -> CooTransformation.tryGetXYZFromLatLonAlt sc planet
+
+        match toSpherical basePoint with
+        | None -> None
+        | Some baseCoo ->
+            // keeps a longitude within +/-180 deg of the base longitude, so a ring straddling the
+            // antimeridian reads as one contiguous run rather than two clusters 360 deg apart
+            let unwrapLongitude (lon : float) =
+                let mutable d = lon - baseCoo.longitude
+                while d > 180.0 do d <- d - 360.0
+                while d < -180.0 do d <- d + 360.0
+                baseCoo.longitude + d
+
+            Some {
+                name = "geographic"
+                toChart = fun p ->
+                    match toSpherical p with
+                    | Some c when abs c.latitude <= poleGuardDegrees ->
+                        Some (V2d(unwrapLongitude c.longitude, c.latitude))
+                    | _ -> None
+                toWorld = fun c ->
+                    // altitude comes from the base point, matching EllipticAnnotations.Conv
+                    // (EllipseAnnotation.fs:12-16): the chart is a shell at one height
+                    fromSpherical { baseCoo with longitude = c.X; latitude = c.Y }
+            }

--- a/src/PRo3D.Core/Drawing/Drawing-App.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-App.fs
@@ -196,7 +196,11 @@ module DrawingApp =
                     //(Annotation.make model.projection model.geometry model.semantic surfaceName)
                     //    with points = IndexList.ofList [p]; modelTrafo = Trafo3d.Translation p
                     (Annotation.make model.projection None model.geometry referenceSystem groupColor model.thickness surfaceName)
-                        with points = IndexList.ofList [p]; modelTrafo = Trafo3d.Translation p
+                        with points = IndexList.ofList [p]
+                             modelTrafo = Trafo3d.Translation p
+                             // fillColor is left as make set it: the active group's default colour
+                             showFill = model.fillNewAnnotations
+                             fillAlpha = model.defaultFillAlpha
                 }, None
       
         //let text = 
@@ -535,6 +539,10 @@ module DrawingApp =
                 { model with projection = mode }                  
             | ChangeThickness th, _, _ ->
                 { model with thickness = Numeric.update model.thickness th }
+            | SetFillNewAnnotations b, _, _ ->
+                { model with fillNewAnnotations = b }
+            | ChangeDefaultFillAlpha a, _, _ ->
+                { model with defaultFillAlpha = Numeric.update model.defaultFillAlpha a }
             | ChangeSamplingAmount k, _, _ ->
                 let samplingAmount = Numeric.update model.samplingAmount k
                 { model with samplingAmount = samplingAmount ; samplingDistance = DrawingModel.calculateSamplingDistance samplingAmount model.samplingUnit }
@@ -887,8 +895,11 @@ module DrawingApp =
 
             let hoveredAnnotation = cval -1
             let viewMatrix = view |> AVal.map (fun v -> (CameraView.viewTrafo v).Forward)
-            let lines, pickIds, bb = PackedRendering.linesNoIndirect config.offset hoveredAnnotation (model.annotations.selectedLeaves |> ASet.map (fun e -> e.id)) (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s))) viewMatrix
-            let fillGeometry = PackedRendering.fills config.offset (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s))) viewMatrix
+            // one cached ordering shared by every packed draw that writes an object id, so the
+            // ids the pick target reads back agree across lines and fills by construction
+            let ordered = PackedRendering.orderedAnnotations (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s)))
+            let lines, pickIds, bb = PackedRendering.linesNoIndirect config.offset hoveredAnnotation (model.annotations.selectedLeaves |> ASet.map (fun e -> e.id)) ordered viewMatrix
+            let fillGeometry = PackedRendering.fills config.offset ordered viewMatrix
             let pickRenderTarget = PackedRendering.pickRenderTarget runtime config.pickingTolerance lines fillGeometry view frustum viewport
             pickRenderTarget.Acquire()
             let packedLines = 
@@ -979,7 +990,9 @@ module DrawingApp =
                     let sg =
                         Sg.ofList [
                             // fill first, so the outline draws over it
-                            PackedRendering.fills config.offset (ASet.single (g, a)) viewMatrix
+                            // no pick target in this branch, so the ids are unused - but the
+                            // ordering is how fills takes its input
+                            PackedRendering.fills config.offset (PackedRendering.orderedAnnotations (ASet.single (g, a))) viewMatrix
                             |> PackedRendering.packedFillRender
                             |> Sg.noEvents
                             Sg.finishedAnnotationOld a c config view viewport showPoints picked pickingAllowed

--- a/src/PRo3D.Core/Drawing/Drawing-App.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-App.fs
@@ -927,15 +927,25 @@ module DrawingApp =
                                 DrawingAction.Nop
                        )
                 ]
-            let packedPoints = 
+            let packedPoints =
                 PackedRendering.points (model.annotations.selectedLeaves |> ASet.map (fun l -> l.id)) (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s))) config.offset viewMatrix
                 |> Sg.noEvents
 
-            let overlay = 
+            // listed before the lines so outlines draw on top of their own fill. The fill writes
+            // no depth, so this ordering is all that separates them.
+            //
+            // NOTE: the spice trafo (t) is dropped here exactly as linesNoIndirect drops it, so
+            // fill and outline stay aligned. The legacy branch below applies it to both for the
+            // same reason. See pro3d-space/PRo3D#672.
+            let packedFills =
+                PackedRendering.fills config.offset (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s))) viewMatrix
+                |> Sg.noEvents
+
+            let overlay =
                 Sg.ofList [
-                    // brush model.hoverPosition; 
+                    // brush model.hoverPosition;
                     annotations
-                    Sg.ofSeq [packedLines; packedPoints]
+                    Sg.ofSeq [packedFills; packedLines; packedPoints]
                     Sg.drawWorkingAnnotation config.offset (AVal.map Adaptify.FSharp.Core.Missing.AdaptiveOption.toOption model.working) // TODO v5: why need fully qualified
                 ]
 
@@ -949,24 +959,33 @@ module DrawingApp =
 
             (overlay, depthTest)
 
-        else 
+        else
             Log.startTimed "[Drawing] creating finished annotation geometry"
-            let annotations =              
-                annoSet 
-                |> ASet.map(fun (_,(a,t)) -> 
+            let viewMatrix = view |> AVal.map (fun v -> (CameraView.viewTrafo v).Forward)
+            let annotations =
+                annoSet
+                |> ASet.map(fun (g,(a,t)) ->
                     let c = UI.mkColor model.annotations a
                     let picked = UI.isSingleSelect model.annotations a
-                    let showPoints = 
-                        a.geometry 
+                    let showPoints =
+                        a.geometry
                         |> AVal.map(function | Geometry.Point | Geometry.DnS -> true | _ -> false)
 
-                    let sg = 
-                        Sg.finishedAnnotationOld a c config view viewport showPoints picked pickingAllowed
+                    // This branch applies the spice trafo per annotation, unlike the packed one
+                    // above which drops it - so the fill has to be built here, under the same
+                    // trafo as its outline, or the two separate. See pro3d-space/PRo3D#672.
+                    // Used by PRo3D.Snapshots, which turns packed rendering off.
+                    let sg =
+                        Sg.ofList [
+                            // fill first, so the outline draws over it
+                            PackedRendering.fills config.offset (ASet.single (g, a)) viewMatrix |> Sg.noEvents
+                            Sg.finishedAnnotationOld a c config view viewport showPoints picked pickingAllowed
+                        ]
                         |> Sg.trafo t
 
-                    sg 
+                    sg
                  )
-                |> Sg.set               
+                |> Sg.set
             Log.stop()
                                   
             let overlay = 

--- a/src/PRo3D.Core/Drawing/Drawing-App.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-App.fs
@@ -888,7 +888,8 @@ module DrawingApp =
             let hoveredAnnotation = cval -1
             let viewMatrix = view |> AVal.map (fun v -> (CameraView.viewTrafo v).Forward)
             let lines, pickIds, bb = PackedRendering.linesNoIndirect config.offset hoveredAnnotation (model.annotations.selectedLeaves |> ASet.map (fun e -> e.id)) (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s))) viewMatrix
-            let pickRenderTarget = PackedRendering.pickRenderTarget runtime config.pickingTolerance lines view frustum viewport
+            let fillGeometry = PackedRendering.fills config.offset (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s))) viewMatrix
+            let pickRenderTarget = PackedRendering.pickRenderTarget runtime config.pickingTolerance lines fillGeometry view frustum viewport
             pickRenderTarget.Acquire()
             let packedLines = 
                 let simple (kind : SceneEventKind) (f : SceneHit -> seq<'msg>) =
@@ -938,7 +939,7 @@ module DrawingApp =
             // fill and outline stay aligned. The legacy branch below applies it to both for the
             // same reason. See pro3d-space/PRo3D#672.
             let packedFills =
-                PackedRendering.fills config.offset (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s))) viewMatrix
+                PackedRendering.packedFillRender fillGeometry
                 |> Sg.noEvents
 
             let overlay =
@@ -978,7 +979,9 @@ module DrawingApp =
                     let sg =
                         Sg.ofList [
                             // fill first, so the outline draws over it
-                            PackedRendering.fills config.offset (ASet.single (g, a)) viewMatrix |> Sg.noEvents
+                            PackedRendering.fills config.offset (ASet.single (g, a)) viewMatrix
+                            |> PackedRendering.packedFillRender
+                            |> Sg.noEvents
                             Sg.finishedAnnotationOld a c config view viewport showPoints picked pickingAllowed
                         ]
                         |> Sg.trafo t

--- a/src/PRo3D.Core/Drawing/Drawing-Model.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-Model.fs
@@ -32,6 +32,8 @@ type AnnotationsDelta =
 type DrawingAction =
 | SetSemantic         of Semantic
 | ChangeThickness     of Numeric.Action
+| SetFillNewAnnotations of bool
+| ChangeDefaultFillAlpha of Numeric.Action
 | ChangeSamplingAmount of Numeric.Action
 | SetSamplingUnit     of SamplingUnit
 | SetGeometry         of Geometry
@@ -106,6 +108,12 @@ type DrawingModel = {
     semantic   : Semantic
     thickness  : NumericInput
 
+    /// defaults applied to the next annotation drawn. Fill colour is deliberately absent - it
+    /// comes from the active group's default colour via Annotation.make, the same single source
+    /// the outline colour uses (see the note in Drawing.UI.fs).
+    fillNewAnnotations : bool
+    defaultFillAlpha   : NumericInput
+
     samplingAmount   : NumericInput
     samplingUnit     : SamplingUnit
     samplingDistance : float
@@ -157,6 +165,9 @@ module DrawingModel =
         pick          = false
         multi         = false
         thickness     = Annotation.Initial.thickness
+
+        fillNewAnnotations = false
+        defaultFillAlpha   = Annotation.initialFillAlpha
 
         working     = None
         projection  = Projection.Linear

--- a/src/PRo3D.Core/Drawing/Drawing-Model.g.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-Model.g.fs
@@ -1,5 +1,5 @@
-//2a5c1294-597f-bf5c-1fba-c0190c248415
-//011fab16-2e0f-378e-5edf-99b0128f7a93
+//59ea86c2-89c0-b20b-aad3-3899a4c69bc4
+//b2e6edc8-5f0c-f61f-f387-54bccd9ba9d3
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -54,6 +54,8 @@ type AdaptiveDrawingModel(value : DrawingModel) =
     let _geometry_ = FSharp.Data.Adaptive.cval(value.geometry)
     let _semantic_ = FSharp.Data.Adaptive.cval(value.semantic)
     let _thickness_ = Aardvark.UI.Primitives.AdaptiveNumericInput(value.thickness)
+    let _fillNewAnnotations_ = FSharp.Data.Adaptive.cval(value.fillNewAnnotations)
+    let _defaultFillAlpha_ = Aardvark.UI.Primitives.AdaptiveNumericInput(value.defaultFillAlpha)
     let _samplingAmount_ = Aardvark.UI.Primitives.AdaptiveNumericInput(value.samplingAmount)
     let _samplingUnit_ = FSharp.Data.Adaptive.cval(value.samplingUnit)
     let _samplingDistance_ = FSharp.Data.Adaptive.cval(value.samplingDistance)
@@ -82,6 +84,8 @@ type AdaptiveDrawingModel(value : DrawingModel) =
             _geometry_.Value <- value.geometry
             _semantic_.Value <- value.semantic
             _thickness_.Update(value.thickness)
+            _fillNewAnnotations_.Value <- value.fillNewAnnotations
+            _defaultFillAlpha_.Update(value.defaultFillAlpha)
             _samplingAmount_.Update(value.samplingAmount)
             _samplingUnit_.Value <- value.samplingUnit
             _samplingDistance_.Value <- value.samplingDistance
@@ -103,6 +107,8 @@ type AdaptiveDrawingModel(value : DrawingModel) =
     member __.geometry = _geometry_ :> FSharp.Data.Adaptive.aval<PRo3D.Base.Annotation.Geometry>
     member __.semantic = _semantic_ :> FSharp.Data.Adaptive.aval<PRo3D.Base.Annotation.Semantic>
     member __.thickness = _thickness_
+    member __.fillNewAnnotations = _fillNewAnnotations_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
+    member __.defaultFillAlpha = _defaultFillAlpha_
     member __.samplingAmount = _samplingAmount_
     member __.samplingUnit = _samplingUnit_ :> FSharp.Data.Adaptive.aval<SamplingUnit>
     member __.samplingDistance = _samplingDistance_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.float>
@@ -125,7 +131,9 @@ module DrawingModelLenses =
         static member projection_ = ((fun (self : DrawingModel) -> self.projection), (fun (value : PRo3D.Base.Annotation.Projection) (self : DrawingModel) -> { self with projection = value }))
         static member geometry_ = ((fun (self : DrawingModel) -> self.geometry), (fun (value : PRo3D.Base.Annotation.Geometry) (self : DrawingModel) -> { self with geometry = value }))
         static member semantic_ = ((fun (self : DrawingModel) -> self.semantic), (fun (value : PRo3D.Base.Annotation.Semantic) (self : DrawingModel) -> { self with semantic = value }))
-        static member thickness_ =((fun (self : DrawingModel) -> self.thickness), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : DrawingModel) -> { self with thickness = value }))
+        static member thickness_ = ((fun (self : DrawingModel) -> self.thickness), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : DrawingModel) -> { self with thickness = value }))
+        static member fillNewAnnotations_ = ((fun (self : DrawingModel) -> self.fillNewAnnotations), (fun (value : Microsoft.FSharp.Core.bool) (self : DrawingModel) -> { self with fillNewAnnotations = value }))
+        static member defaultFillAlpha_ = ((fun (self : DrawingModel) -> self.defaultFillAlpha), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : DrawingModel) -> { self with defaultFillAlpha = value }))
         static member samplingAmount_ = ((fun (self : DrawingModel) -> self.samplingAmount), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : DrawingModel) -> { self with samplingAmount = value }))
         static member samplingUnit_ = ((fun (self : DrawingModel) -> self.samplingUnit), (fun (value : SamplingUnit) (self : DrawingModel) -> { self with samplingUnit = value }))
         static member samplingDistance_ = ((fun (self : DrawingModel) -> self.samplingDistance), (fun (value : Microsoft.FSharp.Core.float) (self : DrawingModel) -> { self with samplingDistance = value }))

--- a/src/PRo3D.Core/Drawing/Drawing-Properties.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-Properties.fs
@@ -29,6 +29,9 @@ module AnnotationProperties =
     | SetManualDippingAngle of Numeric.Action
     | SetManualDippingAzimuth of Numeric.Action
     | CreateCrossSection
+    | SetShowFill     of bool
+    | ChangeFillColor of ColorPicker.Action
+    | SetFillAlpha    of Numeric.Action
         
     let update (referenceSystem : ReferenceSystem) (model : Annotation) (act : Action) =
         match act with
@@ -79,6 +82,12 @@ module AnnotationProperties =
             { model with dnsResults = dnsResults }
         | CreateCrossSection ->
             model // handled at Viewer level
+        | SetShowFill b ->
+            { model with showFill = b }
+        | ChangeFillColor a ->
+            { model with fillColor = ColorPicker.update model.fillColor a }
+        | SetFillAlpha a ->
+            { model with fillAlpha = Numeric.update model.fillAlpha a }
 
 
     let view (paletteFile : string) (model : AdaptiveAnnotation) = 
@@ -95,6 +104,10 @@ module AnnotationProperties =
                 Html.row "Show Text:"   [GuiEx.iconCheckBoxSet model.showText SetShowText ]
                 Html.row "Visible:"     [GuiEx.iconCheckBoxSet model.visible SetVisible ]
                 Html.row "Show DnS:"    [GuiEx.iconCheckBoxSet model.showDns SetShowDns ]
+                // only closed geometries can be filled; the renderer ignores the rest
+                Html.row "Fill:"        [GuiEx.iconCheckBoxSet model.showFill SetShowFill ]
+                Html.row "Fill Color:"  [ColorPicker.viewAdvanced ColorPicker.defaultPalette paletteFile "pro3dFill" true model.fillColor |> UI.map ChangeFillColor ]
+                Html.row "Fill Alpha:"  [Numeric.view' [InputBox] model.fillAlpha |> UI.map SetFillAlpha ]
                 Html.row "Dip Angle:"   [Numeric.view' [InputBox] model.manualDipAngle |> UI.map SetManualDippingAngle]
                 Html.row "Dip Azimuth:" [Numeric.view' [InputBox] model.manualDipAzimuth |> UI.map SetManualDippingAzimuth]
                 Html.row "Cross Section:" [button [clazz "ui button tiny"; onClick (fun _ -> CreateCrossSection)] [text "Create"]]
@@ -120,6 +133,10 @@ module AnnotationProperties =
                 Html.row "Show Text:"   [GuiEx.iconCheckBoxSet model.showText SetShowText ]
                 Html.row "Visible:"     [GuiEx.iconCheckBoxSet model.visible SetVisible ]
                 Html.row "Show DnS:"    [GuiEx.iconCheckBoxSet model.showDns SetShowDns ]
+                Html.row "Fill:"        [GuiEx.iconCheckBoxSet model.showFill SetShowFill ]
+                // distinct picker id, same reason as the color row above
+                Html.row "Fill Color:"  [ColorPicker.viewAdvanced ColorPicker.defaultPalette paletteFile "pro3dBulkFill" true model.fillColor |> UI.map ChangeFillColor ]
+                Html.row "Fill Alpha:"  [Numeric.view' [InputBox] model.fillAlpha |> UI.map SetFillAlpha ]
             ]
         )
 

--- a/src/PRo3D.Core/Drawing/Drawing-Properties.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-Properties.fs
@@ -90,7 +90,11 @@ module AnnotationProperties =
             { model with fillAlpha = Numeric.update model.fillAlpha a }
 
 
-    let view (paletteFile : string) (model : AdaptiveAnnotation) = 
+    let fillTooltip      = "Fill the interior. Closed geometries only"
+    let fillColorTooltip = "Fill colour, defaults to the outline colour"
+    let fillAlphaTooltip = "Fill opacity, 0 to 1"
+
+    let view (paletteFile : string) (model : AdaptiveAnnotation) =
 
         require GuiEx.semui (
             Html.table [                                            
@@ -105,9 +109,9 @@ module AnnotationProperties =
                 Html.row "Visible:"     [GuiEx.iconCheckBoxSet model.visible SetVisible ]
                 Html.row "Show DnS:"    [GuiEx.iconCheckBoxSet model.showDns SetShowDns ]
                 // only closed geometries can be filled; the renderer ignores the rest
-                Html.row "Fill:"        [GuiEx.iconCheckBoxSet model.showFill SetShowFill ]
-                Html.row "Fill Color:"  [ColorPicker.viewAdvanced ColorPicker.defaultPalette paletteFile "pro3dFill" true model.fillColor |> UI.map ChangeFillColor ]
-                Html.row "Fill Alpha:"  [Numeric.view' [InputBox] model.fillAlpha |> UI.map SetFillAlpha ]
+                Html.row "Fill:"        [GuiEx.iconCheckBoxSet model.showFill SetShowFill |> UI.wrapToolTip DataPosition.Bottom fillTooltip ]
+                Html.row "Fill Color:"  [ColorPicker.viewAdvanced ColorPicker.defaultPalette paletteFile "pro3dFill" true model.fillColor |> UI.map ChangeFillColor |> UI.wrapToolTip DataPosition.Bottom fillColorTooltip ]
+                Html.row "Fill Alpha:"  [Numeric.view' [InputBox] model.fillAlpha |> UI.map SetFillAlpha |> UI.wrapToolTip DataPosition.Bottom fillAlphaTooltip ]
                 Html.row "Dip Angle:"   [Numeric.view' [InputBox] model.manualDipAngle |> UI.map SetManualDippingAngle]
                 Html.row "Dip Azimuth:" [Numeric.view' [InputBox] model.manualDipAzimuth |> UI.map SetManualDippingAzimuth]
                 Html.row "Cross Section:" [button [clazz "ui button tiny"; onClick (fun _ -> CreateCrossSection)] [text "Create"]]
@@ -133,10 +137,10 @@ module AnnotationProperties =
                 Html.row "Show Text:"   [GuiEx.iconCheckBoxSet model.showText SetShowText ]
                 Html.row "Visible:"     [GuiEx.iconCheckBoxSet model.visible SetVisible ]
                 Html.row "Show DnS:"    [GuiEx.iconCheckBoxSet model.showDns SetShowDns ]
-                Html.row "Fill:"        [GuiEx.iconCheckBoxSet model.showFill SetShowFill ]
+                Html.row "Fill:"        [GuiEx.iconCheckBoxSet model.showFill SetShowFill |> UI.wrapToolTip DataPosition.Bottom fillTooltip ]
                 // distinct picker id, same reason as the color row above
-                Html.row "Fill Color:"  [ColorPicker.viewAdvanced ColorPicker.defaultPalette paletteFile "pro3dBulkFill" true model.fillColor |> UI.map ChangeFillColor ]
-                Html.row "Fill Alpha:"  [Numeric.view' [InputBox] model.fillAlpha |> UI.map SetFillAlpha ]
+                Html.row "Fill Color:"  [ColorPicker.viewAdvanced ColorPicker.defaultPalette paletteFile "pro3dBulkFill" true model.fillColor |> UI.map ChangeFillColor |> UI.wrapToolTip DataPosition.Bottom fillColorTooltip ]
+                Html.row "Fill Alpha:"  [Numeric.view' [InputBox] model.fillAlpha |> UI.map SetFillAlpha |> UI.wrapToolTip DataPosition.Bottom fillAlphaTooltip ]
             ]
         )
 

--- a/src/PRo3D.Core/Drawing/Drawing.Sg.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.Sg.fs
@@ -158,6 +158,35 @@ module Sg =
         (cam    : aval<CameraView>) =   
         drawDns' anno.points (AVal.map Adaptify.FSharp.Core.Missing.AdaptiveOption.toOption anno.dnsResults) conf cl
 
+    /// World-space distance below which two *consecutive* polyline points count as identical.
+    /// Comfortably above double-precision noise at planetary magnitudes (~1e-9 m at 1e7 m) and
+    /// far below any meaningful annotation detail (sampling distance defaults to 1 m).
+    let private polylinePointEps = 1e-6
+
+    /// Drops points coinciding with their immediate predecessor.
+    ///
+    /// Only *consecutive* duplicates go. A closing point repeating the first one is not adjacent
+    /// to it and is kept, so closed rings — ellipses emit samples+1 points — keep their closing
+    /// edge.
+    let private dedupeConsecutive (ps : V3d[]) =
+        if ps.Length < 2 then ps
+        else
+            let res = System.Collections.Generic.List<V3d>(ps.Length)
+            res.Add ps.[0]
+            for i in 1 .. ps.Length - 1 do
+                if Vec.Distance(res.[res.Count - 1], ps.[i]) > polylinePointEps then
+                    res.Add ps.[i]
+            res.ToArray()
+
+    /// Concatenates an annotation's segments — or its raw points, when it has none — into a
+    /// polyline.
+    ///
+    /// Segments share their end points by construction: segment i's endPoint is segment i+1's
+    /// startPoint (Drawing-App.fs:161), and the last interior sample can land on the segment end
+    /// (Drawing-App.fs:171-179). The raw concatenation therefore contains doubled and tripled
+    /// vertices, which become zero-length line segments — and the thick-line geometry shader
+    /// expands those by normalizing (p1 - p0), i.e. a zero vector. Dropped here rather than at
+    /// each of the call sites.
     let getPolylinePoints (a : AdaptiveAnnotation) =
         //a.segments.Content 
         //    |> AVal.bind (fun segments -> 
@@ -170,7 +199,7 @@ module Sg =
         AVal.custom (fun t -> 
             let segments = a.segments.Content.GetValue t
             if IndexList.isEmpty segments then  
-                a.points.Content.GetValue(t) |> IndexList.toArray 
+                a.points.Content.GetValue(t) |> IndexList.toArray |> dedupeConsecutive 
             else 
                 let points = System.Collections.Generic.List<V3d>()
                 a.segments.Content.GetValue(t) |> IndexList.iter(fun (s : AdaptiveSegment) -> 
@@ -178,7 +207,7 @@ module Sg =
                     for s in s.points.Content.GetValue(t) do points.Add(s)
                     points.Add(s.endPoint.GetValue(t))
                 )
-                points.ToArray()
+                points.ToArray() |> dedupeConsecutive
         )
         //alist {                          
         //    let! hasSegments = (a.segments |> AList.count) |> AVal.map(fun x -> x > 0)

--- a/src/PRo3D.Core/Drawing/Drawing.UI.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.UI.fs
@@ -79,8 +79,8 @@ module UI =
         let thicknessTooltip = "Thickness of annotation"
         let samplingAmountTooltip = "Sampling amount used for annotations rendered with viewpoint or sky projection"
         let samplingUnitTooltip = "Sampling unit used for annotations rendered with viewpoint or sky projection"
-        let fillTooltip = "Fill new annotations. Applies to closed geometries only (polygon, ellipses); the fill takes the active group's colour."
-        let fillAlphaTooltip = "Opacity of the fill on new annotations, 0 (invisible) to 1 (opaque)"
+        let fillTooltip = "Fill new annotations. Closed geometries only; uses the group colour"
+        let fillAlphaTooltip = "Fill opacity for new annotations, 0 to 1"
 
         Html.Layout.horizontal [
             Html.Layout.boxH [ i [clazz "large Write icon"] [] ]

--- a/src/PRo3D.Core/Drawing/Drawing.UI.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.UI.fs
@@ -79,6 +79,8 @@ module UI =
         let thicknessTooltip = "Thickness of annotation"
         let samplingAmountTooltip = "Sampling amount used for annotations rendered with viewpoint or sky projection"
         let samplingUnitTooltip = "Sampling unit used for annotations rendered with viewpoint or sky projection"
+        let fillTooltip = "Fill new annotations. Applies to closed geometries only (polygon, ellipses); the fill takes the active group's colour."
+        let fillAlphaTooltip = "Opacity of the fill on new annotations, 0 (invisible) to 1 (opaque)"
 
         Html.Layout.horizontal [
             Html.Layout.boxH [ i [clazz "large Write icon"] [] ]
@@ -89,6 +91,11 @@ module UI =
             Html.Layout.boxH [ i [clazz "large crosshairs icon"] [] ]
             Html.Layout.boxH [ Numeric.view' [InputBox] model.samplingAmount |> UI.map ChangeSamplingAmount ] |> UI.wrapToolTip DataPosition.Bottom samplingAmountTooltip
             Html.Layout.boxH [ Html.SemUi.dropDown model.samplingUnit SetSamplingUnit ] |> UI.wrapToolTip DataPosition.Bottom samplingUnitTooltip
+            // no fill colour here on purpose - it follows the active group's default colour, the
+            // same single source the outline colour uses (see the note above)
+            Html.Layout.boxH [ i [clazz "large tint icon"] [] ]
+            Html.Layout.boxH [ GuiEx.iconCheckBoxSet model.fillNewAnnotations SetFillNewAnnotations ] |> UI.wrapToolTip DataPosition.Bottom fillTooltip
+            Html.Layout.boxH [ Numeric.view' [InputBox] model.defaultFillAlpha |> UI.map ChangeDefaultFillAlpha ] |> UI.wrapToolTip DataPosition.Bottom fillAlphaTooltip
         //  Html.Layout.boxH [ Html.SemUi.dropDown model.semantic SetSemantic ]
         ]
                     

--- a/src/PRo3D.Core/Drawing/PackedRendering.fs
+++ b/src/PRo3D.Core/Drawing/PackedRendering.fs
@@ -332,7 +332,45 @@ module PackedRendering =
         
 
 
-    module LensShader = 
+    module FillShader =
+
+        open FShade
+
+        type FillVertex =
+            {
+                [<Position>] pos : V4f
+                [<Color>]    c   : V4f
+            }
+
+        type FillPickVertex =
+            {
+                [<Position>] pos : V4f
+                [<Color>]    c   : V4f
+                [<Semantic("ObjId")>] obId : int
+                [<Semantic("Id")>]    id   : int
+            }
+
+        /// Plain MV + projection. No geometry shader, so the clip-space W survives into the
+        /// fragment stage untouched and depthOffsetFS can divide by it - unlike the line path,
+        /// which has to restore W explicitly after thickLine.
+        let fillVertex (v : FillVertex) =
+            vertex {
+                let mv : M44f = uniform?MV
+                let vp = mv * v.pos
+                return { v with pos = uniform.ProjTrafo * vp }
+            }
+
+        /// As fillVertex, but forwards the packed object id into the Id semantic Picking.pickId
+        /// writes out.
+        let fillVertexPicking (v : FillPickVertex) =
+            vertex {
+                let mv : M44f = uniform?MV
+                let vp = mv * v.pos
+                return { v with pos = uniform.ProjTrafo * vp; id = v.obId }
+            }
+
+
+    module LensShader =
         open FShade
         open Aardvark.Rendering.Effects
 
@@ -519,31 +557,52 @@ module PackedRendering =
 
 
 
-    let pickRenderTarget (runtime : IRuntime) (pickingTolerance : aval<float>) lines (view : aval<CameraView>) (frustum : aval<Frustum>) (viewport : aval<V2i>) =
-        let pickColors = 
+    let pickRenderTarget (runtime : IRuntime) (pickingTolerance : aval<float>) lines fills (view : aval<CameraView>) (frustum : aval<Frustum>) (viewport : aval<V2i>) =
+        let pickColors =
             let signature =
                 runtime.CreateFramebufferSignature [
                     DefaultSemantic.Colors, TextureFormat.Rgba32f
                     DefaultSemantic.DepthStencil, TextureFormat.Depth24Stencil8
                 ]
 
-            let pickColors = 
-                lines
+            let withCamera sg =
+                sg
                 |> Sg.viewTrafo (view |> AVal.map CameraView.viewTrafo)
                 |> Sg.projTrafo (frustum |> AVal.map Frustum.projTrafo) //(size |> AVal.map (fun s -> Frustum.perspective 20.0 0.01 10000.0 (s.X / s.Y)))
-                |> Sg.shader { 
+
+            let pickColors =
+                lines
+                |> withCamera
+                |> Sg.shader {
                       do! LineShader.noIndirectLineVertexPicking
                       do! LineShader.thickLine
-                      do! PRo3D.Base.Shader.DepthOffset.depthOffsetFS 
+                      do! PRo3D.Base.Shader.DepthOffset.depthOffsetFS
                       do! Picking.pickId
                 }
                 |> Sg.uniform "PickingTolerance" (pickingTolerance |> AVal.map (fun p -> p * 2.0))
                 |> Sg.compile runtime signature
 
+            // the object ids the fill emits index the same array as the lines', so a click inside
+            // a filled annotation reads back the annotation it belongs to.
+            //
+            // Deliberately none of the visible pass's state: blending would corrupt the id, which
+            // this target carries in the alpha channel.
+            let pickFills =
+                fills
+                |> withCamera
+                |> Sg.shader {
+                      do! FillShader.fillVertexPicking
+                      do! PRo3D.Base.Shader.DepthOffset.depthOffsetFS
+                      do! Picking.pickId
+                }
+                |> Sg.compile runtime signature
+
             let cleared = RenderTask.ofList [
                 runtime.CompileClear(signature, C4f(0.0f,0.0f,0.0f,-1.0f))
+                // fills first so an outline still wins the pick over its own interior
+                pickFills
                 pickColors
-            ] 
+            ]
 
             cleared |> RenderTask.renderToColor viewport
 
@@ -558,26 +617,6 @@ module PackedRendering =
                 do! PRo3D.Base.Shader.DepthOffset.depthOffsetFS 
         }
 
-
-    module FillShader =
-
-        open FShade
-
-        type FillVertex =
-            {
-                [<Position>] pos : V4f
-                [<Color>]    c   : V4f
-            }
-
-        /// Plain MV + projection. No geometry shader, so the clip-space W survives into the
-        /// fragment stage untouched and depthOffsetFS can divide by it - unlike the line path,
-        /// which has to restore W explicitly after thickLine.
-        let fillVertex (v : FillVertex) =
-            vertex {
-                let mv : M44f = uniform?MV
-                let vp = mv * v.pos
-                return { v with pos = uniform.ProjTrafo * vp }
-            }
 
     /// A flat cap needs a far larger bias than a surface-hugging line: it only touches the
     /// terrain at its rim, and sits above or below it everywhere else.
@@ -597,13 +636,23 @@ module PackedRendering =
         | _ -> false
 
     /// Packs the filled interiors of every annotation with showFill into one triangle draw.
+    ///
+    /// Returns raw geometry: the visible pass and the pick pass need different shaders and very
+    /// different render state, so neither is baked in here. Same split as linesNoIndirect /
+    /// packedRender.
     let fills (depthOffset : aval<float>) (annoSet : aset<Guid * AdaptiveAnnotation>) (view : aval<M44d>) =
         let data =
             AVal.custom (fun t ->
                 let annos = annoSet.Content.GetValue(t)
                 let vertices = List<V3f>()
                 let colors = List<C4f>()
+                let objIds = List<int>()
                 let mutable pivotTrafo = None
+
+                // object ids must index the same array linesNoIndirect builds, so this counter
+                // advances once per annotation in the same iteration over the same aset content -
+                // filled or not, visible or not - exactly as it does there
+                let mutable oid = 0
 
                 for (_, anno) in annos do
                     let visible  = anno.visible.GetValue(t)
@@ -645,9 +694,13 @@ module PackedRendering =
                             for p in mesh.positions do
                                 vertices.Add(pivot.Backward.TransformPos p |> V3f)
                                 colors.Add color
+                                objIds.Add oid
+
+                    oid <- oid + 1
 
                 {| points     = vertices.ToArray()
                    colors     = colors.ToArray()
+                   objIds     = objIds.ToArray()
                    modelTrafo = Option.defaultValue Trafo3d.Identity pivotTrafo |})
 
         let mv = (data, view) ||> AVal.map2 (fun d v -> v * d.modelTrafo.Forward)
@@ -655,9 +708,14 @@ module PackedRendering =
         Sg.draw IndexedGeometryMode.TriangleList
         |> Sg.vertexAttribute DefaultSemantic.Positions (data |> AVal.map (fun d -> d.points))
         |> Sg.vertexAttribute DefaultSemantic.Colors    (data |> AVal.map (fun d -> d.colors))
+        |> Sg.vertexAttribute (Sym.ofString "ObjId")    (data |> AVal.map (fun d -> d.objIds))
         |> Sg.uniform "MV" mv
         |> Sg.uniform "DepthOffset"
             (depthOffset |> AVal.map (fun d -> (d * fillDepthOffsetFactor) / (100.0 - 0.1)))
+
+    /// Visible pass for the packed fills.
+    let packedFillRender fills =
+        fills
         |> Sg.shader {
             do! FillShader.fillVertex
             do! PRo3D.Base.Shader.DepthOffset.depthOffsetFS

--- a/src/PRo3D.Core/Drawing/PackedRendering.fs
+++ b/src/PRo3D.Core/Drawing/PackedRendering.fs
@@ -470,11 +470,20 @@ module PackedRendering =
           sg, (instanceAttribs |> AVal.map (fun i -> i.ids )), boundingBox
 
 
-    let linesNoIndirect (depthOffset : aval<float>) (selectedAnnotation : aval<int>) (selected : aset<Guid>) (annoSet: aset<Guid * AdaptiveAnnotation>) (view : aval<M44d>) =
-          let data = 
-              AVal.custom (fun t -> 
+    /// The packed object-id space. Object id N means "index N of this array", and the Guid there
+    /// is what a pick reads back.
+    ///
+    /// Every packed draw that writes ObjId must derive its ids from this one cached ordering.
+    /// Two separate enumerations of the same aset are not guaranteed to agree, and a
+    /// disagreement shows up as clicking one annotation and selecting another.
+    let orderedAnnotations (annoSet : aset<Guid * AdaptiveAnnotation>) : aval<(Guid * AdaptiveAnnotation)[]> =
+        AVal.custom (fun t -> annoSet.Content.GetValue(t) |> HashSet.toArray)
+
+    let linesNoIndirect (depthOffset : aval<float>) (selectedAnnotation : aval<int>) (selected : aset<Guid>) (ordered : aval<(Guid * AdaptiveAnnotation)[]>) (view : aval<M44d>) =
+          let data =
+              AVal.custom (fun t ->
                   Log.startTimed "mk lines"
-                  let annos = annoSet.Content.GetValue(t)
+                  let annos = ordered.GetValue(t)
                   let selected = selected.Content.GetValue(t)
                   let vertices = List<_>()
                   let colors = List<_>()
@@ -640,21 +649,19 @@ module PackedRendering =
     /// Returns raw geometry: the visible pass and the pick pass need different shaders and very
     /// different render state, so neither is baked in here. Same split as linesNoIndirect /
     /// packedRender.
-    let fills (depthOffset : aval<float>) (annoSet : aset<Guid * AdaptiveAnnotation>) (view : aval<M44d>) =
+    let fills (depthOffset : aval<float>) (ordered : aval<(Guid * AdaptiveAnnotation)[]>) (view : aval<M44d>) =
         let data =
             AVal.custom (fun t ->
-                let annos = annoSet.Content.GetValue(t)
+                // same cached ordering linesNoIndirect indexes, so position i here and object id i
+                // there are the same annotation by construction
+                let annos = ordered.GetValue(t)
                 let vertices = List<V3f>()
                 let colors = List<C4f>()
                 let objIds = List<int>()
                 let mutable pivotTrafo = None
 
-                // object ids must index the same array linesNoIndirect builds, so this counter
-                // advances once per annotation in the same iteration over the same aset content -
-                // filled or not, visible or not - exactly as it does there
-                let mutable oid = 0
-
-                for (_, anno) in annos do
+                for i in 0 .. annos.Length - 1 do
+                    let (_, anno) = annos.[i]
                     let visible  = anno.visible.GetValue(t)
                     let showFill = anno.showFill.GetValue(t)
                     let geometry = anno.geometry.GetValue(t)
@@ -694,9 +701,7 @@ module PackedRendering =
                             for p in mesh.positions do
                                 vertices.Add(pivot.Backward.TransformPos p |> V3f)
                                 colors.Add color
-                                objIds.Add oid
-
-                    oid <- oid + 1
+                                objIds.Add i
 
                 {| points     = vertices.ToArray()
                    colors     = colors.ToArray()

--- a/src/PRo3D.Core/Drawing/PackedRendering.fs
+++ b/src/PRo3D.Core/Drawing/PackedRendering.fs
@@ -559,6 +559,116 @@ module PackedRendering =
         }
 
 
+    module FillShader =
+
+        open FShade
+
+        type FillVertex =
+            {
+                [<Position>] pos : V4f
+                [<Color>]    c   : V4f
+            }
+
+        /// Plain MV + projection. No geometry shader, so the clip-space W survives into the
+        /// fragment stage untouched and depthOffsetFS can divide by it - unlike the line path,
+        /// which has to restore W explicitly after thickLine.
+        let fillVertex (v : FillVertex) =
+            vertex {
+                let mv : M44f = uniform?MV
+                let vp = mv * v.pos
+                return { v with pos = uniform.ProjTrafo * vp }
+            }
+
+    /// A flat cap needs a far larger bias than a surface-hugging line: it only touches the
+    /// terrain at its rim, and sits above or below it everywhere else.
+    let private fillDepthOffsetFactor = 5.0
+
+    // Aardvark.Rendering exports a Geometry type of its own, and it is opened after
+    // PRo3D.Base.Annotation - so the annotation one needs saying explicitly
+    type private AnnoGeometry = PRo3D.Base.Annotation.Geometry
+
+    let private isFillable (g : AnnoGeometry) =
+        match g with
+        | AnnoGeometry.Polygon
+        | AnnoGeometry.Ellipse
+        | AnnoGeometry.AxisEllipse
+        | AnnoGeometry.Axis4PEllipse -> true
+        // DnS already visualises its plane through showDns; open geometries have no interior
+        | _ -> false
+
+    /// Packs the filled interiors of every annotation with showFill into one triangle draw.
+    let fills (depthOffset : aval<float>) (annoSet : aset<Guid * AdaptiveAnnotation>) (view : aval<M44d>) =
+        let data =
+            AVal.custom (fun t ->
+                let annos = annoSet.Content.GetValue(t)
+                let vertices = List<V3f>()
+                let colors = List<C4f>()
+                let mutable pivotTrafo = None
+
+                for (_, anno) in annos do
+                    let visible  = anno.visible.GetValue(t)
+                    let showFill = anno.showFill.GetValue(t)
+                    let geometry = anno.geometry.GetValue(t)
+
+                    if visible && showFill && isFillable geometry then
+                        // world-space points shifted by a common pivot purely to keep the float32
+                        // vertex buffer precise at planetary magnitudes; any shared trafo works
+                        let pivot =
+                            match pivotTrafo with
+                            | None ->
+                                let mt = anno.modelTrafo.GetValue(t)
+                                pivotTrafo <- Some mt
+                                mt
+                            | Some mt -> mt
+
+                        let points = anno.points.Content.GetValue(t) |> IndexList.toArray
+
+                        let chart =
+                            // the dip-and-strike plane is what the ellipse ring was built on, so
+                            // reusing it makes fill and outline coincide exactly
+                            let fromDns =
+                                match anno.dnsResults.GetValue(t) with
+                                | AdaptiveSome dns -> SurfaceChart.tryOfPlane (dns.plane.GetValue(t))
+                                | _ -> None
+                            // otherwise fit, using the same plane calculatePolygonArea reports on
+                            fromDns
+                            |> Option.orElseWith (fun () ->
+                                SurfaceChart.tryOfPlane (Calculations.calculateVertexPlane points))
+
+                        match chart |> Option.bind (fun c -> PolygonFill.tryComputeFill c points) with
+                        | None -> ()
+                        | Some mesh ->
+                            let rgb = anno.fillColor.c.GetValue(t).ToC4f()
+                            let alpha = anno.fillAlpha.value.GetValue(t)
+                            let color = C4f(rgb.R, rgb.G, rgb.B, float32 alpha)
+
+                            for p in mesh.positions do
+                                vertices.Add(pivot.Backward.TransformPos p |> V3f)
+                                colors.Add color
+
+                {| points     = vertices.ToArray()
+                   colors     = colors.ToArray()
+                   modelTrafo = Option.defaultValue Trafo3d.Identity pivotTrafo |})
+
+        let mv = (data, view) ||> AVal.map2 (fun d v -> v * d.modelTrafo.Forward)
+
+        Sg.draw IndexedGeometryMode.TriangleList
+        |> Sg.vertexAttribute DefaultSemantic.Positions (data |> AVal.map (fun d -> d.points))
+        |> Sg.vertexAttribute DefaultSemantic.Colors    (data |> AVal.map (fun d -> d.colors))
+        |> Sg.uniform "MV" mv
+        |> Sg.uniform "DepthOffset"
+            (depthOffset |> AVal.map (fun d -> (d * fillDepthOffsetFactor) / (100.0 - 0.1)))
+        |> Sg.shader {
+            do! FillShader.fillVertex
+            do! PRo3D.Base.Shader.DepthOffset.depthOffsetFS
+        }
+        |> Sg.blendMode (AVal.constant BlendMode.Blend)
+        // occluded rather than overlay: a ridge in front hides the fill, so it reads as lying on
+        // the surface instead of floating over the scene
+        |> Sg.depthTest (AVal.constant DepthTest.LessOrEqual)
+        // no depth write, so the outline and other fills are not occluded by the cap
+        |> Sg.writeBuffers' (Set.ofList [WriteBuffer.Color DefaultSemantic.Colors])
+
     let points (selected : aset<Guid>) (annoSet: aset<Guid * AdaptiveAnnotation>) (depthOffset : aval<float>) (view : aval<M44d>) =
         let instanceAttribs = 
             AVal.custom (fun t -> 

--- a/src/PRo3D.Core/Importers/MeasurementsImporter.fs
+++ b/src/PRo3D.Core/Importers/MeasurementsImporter.fs
@@ -152,6 +152,9 @@ module MeasurementsImporter =
             points           = points
             segments         = segments
             color            = { c = color }
+            showFill         = false
+            fillColor        = { c = color }
+            fillAlpha        = Annotation.initialFillAlpha
             thickness        = style.thickness
             results          = None
             dnsResults       = None

--- a/src/PRo3D.Core/Importers/SbmtImporter.fs
+++ b/src/PRo3D.Core/Importers/SbmtImporter.fs
@@ -118,6 +118,9 @@ module SbmtImporter =
             points           = IndexList.single pos
             segments         = IndexList.empty
             color            = { c = color }
+            showFill         = false
+            fillColor        = { c = color }
+            fillAlpha        = Annotation.initialFillAlpha
             thickness        = Annotation.Initial.thickness
             results          = None
             dnsResults       = None
@@ -235,6 +238,9 @@ module SbmtImporter =
             points           = IndexList.ofArray samples
             segments         = IndexList.empty
             color            = { c = color }
+            showFill         = false
+            fillColor        = { c = color }
+            fillAlpha        = Annotation.initialFillAlpha
             thickness        = Annotation.Initial.thickness
             results          = None
             dnsResults       = None

--- a/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
+++ b/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
@@ -606,7 +606,7 @@ module Gui =
             let iconAttrs =
                 amap {
                     let! prefs = m.userPreferences
-                    yield clazz (if getter prefs then "check square outline icon" else "square icon")
+                    yield clazz (if getter prefs then "check square outline icon" else "square outline icon")
                 } |> AttributeMap.ofAMap
 
             div [ clazz "ui item"

--- a/src/Tests/PolygonFillTests.fs
+++ b/src/Tests/PolygonFillTests.fs
@@ -178,6 +178,48 @@ let tests () =
                 Expect.isSome (SurfaceChart.tryOfPlane (Plane3d(V3d.OOI, V3d.Zero)))
                     "a well-formed plane must be accepted"
             }
+
+            // The geographic chart is opt-in and has no production caller yet, but the
+            // antimeridian and pole handling is the fiddly part of it - cover it here rather than
+            // discover it when merge/split starts using it. Self-skips where CooTransformation
+            // cannot convert, like the other conversion-dependent suites.
+            test "geographic chart round-trips, unwraps the antimeridian and refuses poles" {
+                let planet = Planet.Mars
+                let xyzAt (lon : float) (lat : float) =
+                    CooTransformation.tryGetXYZFromLatLonAlt
+                        { longitude = lon; latitude = lat; altitude = 0.0; radian = 0.0 } planet
+
+                match xyzAt 179.0 10.0 with
+                | None -> skiptest "CooTransformation unavailable"
+                | Some basePoint ->
+
+                match SurfaceChart.geographic planet None basePoint with
+                | None -> skiptest "geographic chart unavailable for this body"
+                | Some chart ->
+
+                // round trip
+                let rt = chart.toChart basePoint |> Option.bind chart.toWorld
+                Expect.isSome rt "the base point must convert"
+                Expect.isTrue (Vec.Distance(rt.Value, basePoint) < 1.0)
+                    "a round trip through the geographic chart must land within a metre"
+
+                // antimeridian: a neighbour just across +/-180 must stay adjacent in chart space,
+                // not jump ~360 degrees
+                match xyzAt -179.0 10.0 with
+                | None -> ()
+                | Some across ->
+                    match chart.toChart basePoint, chart.toChart across with
+                    | Some a, Some b ->
+                        Expect.isLessThan (abs (a.X - b.X)) 10.0
+                            "longitudes must be unwrapped about the base point, not split at the seam"
+                    | _ -> failtest "both points must chart"
+
+                // poles are refused rather than silently degenerate
+                match xyzAt 0.0 89.99 with
+                | None -> ()
+                | Some polar ->
+                    Expect.isNone (chart.toChart polar) "a point at the pole must be refused"
+            }
         ]
 
         // -----------------------------------------------------------------------------------

--- a/src/Tests/PolygonFillTests.fs
+++ b/src/Tests/PolygonFillTests.fs
@@ -1,0 +1,294 @@
+module PolygonFillTests
+
+open System
+open Expecto
+open Aardvark.Base
+open FSharp.Data.Adaptive
+open PRo3D.Base
+open PRo3D.Base.Annotation
+
+// ---------------------------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------------------------
+
+let private eps = PolygonFill.DefaultEpsilon
+
+/// Summed area of a triangle-list mesh.
+let private meshArea (positions : V3d[]) =
+    let mutable acc = 0.0
+    for i in 0 .. 3 .. positions.Length - 3 do
+        let a = positions.[i + 1] - positions.[i]
+        let b = positions.[i + 2] - positions.[i]
+        acc <- acc + 0.5 * Vec.Length(Vec.cross a b)
+    acc
+
+let private triangleCount (positions : V3d[]) = positions.Length / 3
+
+/// XY plane, so a ring built from V3d(x, y, 0) lies exactly in it.
+let private xyChart = SurfaceChart.ofPlane (Plane3d(V3d.OOI, V3d.Zero))
+
+let private square = [| V3d(0,0,0); V3d(10,0,0); V3d(10,10,0); V3d(0,10,0) |]
+
+/// Concave L, area 3 * 1 + 1 * 2 = 5... laid out explicitly:
+///   (0,0) (3,0) (3,1) (1,1) (1,3) (0,3)  ->  3x1 base plus 1x2 upright = 5
+let private concaveL =
+    [| V3d(0,0,0); V3d(3,0,0); V3d(3,1,0); V3d(1,1,0); V3d(1,3,0); V3d(0,3,0) |]
+
+let private ellipseRing (a : float) (b : float) (n : int) =
+    // samples+1 points, closing point repeated - exactly what computeEllipsePoints emits
+    Array.init (n + 1) (fun i ->
+        let t = Constant.PiTimesTwo * float i / float n
+        V3d(a * cos t, b * sin t, 0.0))
+
+let private isCloseTo (tolerance : float) (a : V3d) (b : V3d) = Vec.Distance(a, b) <= tolerance
+
+// ---------------------------------------------------------------------------------------------
+
+let tests () =
+    Aardvark.Init()
+
+    testList "PolygonFill" [
+
+        // -----------------------------------------------------------------------------------
+        // normalize: the duplicate machinery. Stored points carry duplicates that fixing the
+        // producers cannot retroactively remove, so this runs on every fill.
+        // -----------------------------------------------------------------------------------
+
+        testList "normalize" [
+
+            test "open ring passes through unchanged" {
+                let r = PolygonFill.normalize eps square
+                Expect.equal r square "an already-clean ring must not be altered"
+            }
+
+            test "closing point exactly equal to the first is dropped" {
+                let closed = Array.append square [| square.[0] |]
+                let r = PolygonFill.normalize eps closed
+                Expect.equal r square "the repeated closing point must go"
+            }
+
+            test "closing point within epsilon is dropped" {
+                let closed = Array.append square [| square.[0] + V3d(eps * 0.1, 0.0, 0.0) |]
+                let r = PolygonFill.normalize eps closed
+                Expect.equal r.Length 4 "a near-coincident closing point must go"
+            }
+
+            test "closing point just outside epsilon is kept" {
+                let closed = Array.append square [| square.[0] + V3d(eps * 100.0, 0.0, 0.0) |]
+                let r = PolygonFill.normalize eps closed
+                Expect.equal r.Length 5 "a genuinely distinct point must survive"
+            }
+
+            test "getPolylinePoints doubling is collapsed" {
+                // segment i's endPoint is segment i+1's startPoint
+                let a, b, c = V3d(0,0,0), V3d(1,0,0), V3d(1,1,0)
+                let doubled = [| a; b; b; c; c; a |]
+                let r = PolygonFill.normalize eps doubled
+                Expect.equal r [| a; b; c |] "doubled interior corners and the closing point must go"
+            }
+
+            test "getPolylinePoints tripling is collapsed" {
+                // ... and the last interior sample can land on the segment end as well
+                let a, b, c = V3d(0,0,0), V3d(1,0,0), V3d(1,1,0)
+                let tripled = [| a; b; b; b; c; c; c; a |]
+                let r = PolygonFill.normalize eps tripled
+                Expect.equal r [| a; b; c |] "tripled vertices must collapse to one"
+            }
+
+            test "all-identical points collapse to one" {
+                let p = V3d(5,5,5)
+                let r = PolygonFill.normalize eps [| p; p; p; p |]
+                Expect.equal r [| p |] "nothing but duplicates leaves a single point"
+            }
+
+            test "two distinct points padded with duplicates stay two" {
+                let a, b = V3d(0,0,0), V3d(1,0,0)
+                let r = PolygonFill.normalize eps [| a; a; b; b; b |]
+                Expect.equal r [| a; b |] "padding must not be mistaken for a third vertex"
+            }
+
+            test "a non-adjacent revisit is not collapsed" {
+                // a legitimate figure-eight-ish ring: the repeat is not adjacent, so it stays
+                let a, b, c = V3d(0,0,0), V3d(1,0,0), V3d(1,1,0)
+                let revisit = [| a; b; a; c |]
+                let r = PolygonFill.normalize eps revisit
+                Expect.equal r revisit "only *consecutive* duplicates may be removed"
+            }
+
+            test "is idempotent" {
+                let once = PolygonFill.normalize eps (Array.append square [| square.[0]; square.[0] |])
+                let twice = PolygonFill.normalize eps once
+                Expect.equal twice once "normalize must be a fixpoint after one application"
+            }
+
+            test "empty input is handled" {
+                Expect.equal (PolygonFill.normalize eps [||]) [||] "empty in, empty out"
+            }
+        ]
+
+        // -----------------------------------------------------------------------------------
+        // charts
+        // -----------------------------------------------------------------------------------
+
+        testList "SurfaceChart" [
+
+            test "ofPlane round-trips points lying in the plane" {
+                let plane = Plane3d(V3d(1.0, 1.0, 1.0).Normalized, V3d(3.0, 0.0, 0.0))
+                let chart = SurfaceChart.ofPlane plane
+                let p = plane.GetPlaneToWorld().TransformPos(V3d(2.0, -5.0, 0.0))
+
+                let rt = chart.toChart p |> Option.bind chart.toWorld
+                Expect.isSome rt "the plane chart is total"
+                Expect.isTrue (isCloseTo 1e-9 rt.Value p) "a point in the plane must survive the round trip"
+            }
+
+            test "ofPlane projects off-plane points onto the plane" {
+                let plane = Plane3d(V3d.OOI, V3d.Zero)
+                let chart = SurfaceChart.ofPlane plane
+                let lifted = chart.toChart (V3d(1.0, 2.0, 37.0)) |> Option.bind chart.toWorld
+
+                Expect.isSome lifted "the plane chart is total"
+                Expect.floatClose Accuracy.high (plane.Height lifted.Value) 0.0
+                    "the lifted point must land on the plane, losing its height"
+            }
+
+            test "ofUpVector round-trips" {
+                let origin = V3d(100.0, 200.0, 300.0)
+                let chart = SurfaceChart.ofUpVector (V3d(0.0, 0.0, 1.0)) origin
+                let p = origin + V3d(4.0, -7.0, 0.0)
+
+                let rt = chart.toChart p |> Option.bind chart.toWorld
+                Expect.isSome rt "the up-vector chart is total"
+                Expect.isTrue (isCloseTo 1e-9 rt.Value p) "an in-plane point must survive the round trip"
+            }
+
+            test "tryOfPlane rejects a NaN plane" {
+                // DipAndStrikeResults initialises to NaN and that sentinel round-trips through
+                // the project format, so stored planes really can look like this
+                let nanPlane = Plane3d(V3d.NaN, Double.NaN)
+                Expect.isNone (SurfaceChart.tryOfPlane nanPlane) "a NaN plane cannot define a chart"
+            }
+
+            test "tryOfPlane rejects a zero normal" {
+                Expect.isNone (SurfaceChart.tryOfPlane (Plane3d(V3d.Zero, 0.0)))
+                    "a degenerate normal cannot define a chart"
+            }
+
+            test "tryOfPlane accepts a good plane" {
+                Expect.isSome (SurfaceChart.tryOfPlane (Plane3d(V3d.OOI, V3d.Zero)))
+                    "a well-formed plane must be accepted"
+            }
+        ]
+
+        // -----------------------------------------------------------------------------------
+        // fill
+        // -----------------------------------------------------------------------------------
+
+        testList "tryComputeFill" [
+
+            test "convex square has the right area" {
+                let fill = PolygonFill.tryComputeFill xyChart square
+                Expect.isSome fill "a square must fill"
+                Expect.floatClose Accuracy.medium (meshArea fill.Value.positions) 100.0
+                    "summed triangle area must equal the square's"
+            }
+
+            test "concave L has the right area" {
+                let fill = PolygonFill.tryComputeFill xyChart concaveL
+                Expect.isSome fill "a concave polygon must fill"
+                Expect.floatClose Accuracy.medium (meshArea fill.Value.positions) 5.0
+                    "ears must not be cut across the concavity"
+            }
+
+            test "concave L agrees with calculatePolygonArea" {
+                // ties the rendered fill to the number shown in the properties panel
+                let fill = PolygonFill.tryComputeFill xyChart concaveL
+                let reported = Calculations.calculatePolygonArea (IndexList.ofArray concaveL)
+                Expect.isSome fill "a concave polygon must fill"
+                Expect.floatClose Accuracy.medium (meshArea fill.Value.positions) reported
+                    "fill area and reported area must not disagree"
+            }
+
+            test "ellipse ring approximates pi*a*b" {
+                let a, b = 7.0, 3.0
+                let fill = PolygonFill.tryComputeFill xyChart (ellipseRing a b 200)
+                Expect.isSome fill "an ellipse ring must fill"
+
+                let expected = Constant.Pi * a * b
+                let actual = meshArea fill.Value.positions
+                Expect.isLessThan (abs (actual - expected) / expected) 0.005
+                    "a 200-sample inscribed ring must be within 0.5% of the true area"
+            }
+
+            test "triangle count is vertices - 2 for a simple ring" {
+                let fill = PolygonFill.tryComputeFill xyChart concaveL
+                Expect.isSome fill "a concave polygon must fill"
+                Expect.equal (triangleCount fill.Value.positions) (concaveL.Length - 2)
+                    "a simple polygon triangulates into n-2 triangles"
+            }
+
+            test "output vertices are the input points, not their flattened images" {
+                // the whole point of carrying world positions as a tessellator attribute: the
+                // fill rim must coincide with the outline the user drew
+                let tilted =
+                    [| V3d(0,0,0); V3d(10,0,3); V3d(10,10,-2); V3d(0,10,5) |]
+                let chart = SurfaceChart.ofPlane (Plane3d(V3d.OOI, V3d.Zero))
+                let fill = PolygonFill.tryComputeFill chart tilted
+
+                Expect.isSome fill "a non-planar ring must still fill"
+                for p in fill.Value.positions do
+                    Expect.isTrue (tilted |> Array.exists (isCloseTo 1e-9 p))
+                        (sprintf "%A is not one of the input points - it was re-flattened" p)
+            }
+
+            test "every vertex lies on the chart plane for planar input" {
+                let plane = Plane3d(V3d.OOI, V3d.Zero)
+                let fill = PolygonFill.tryComputeFill (SurfaceChart.ofPlane plane) square
+                Expect.isSome fill "a square must fill"
+                for p in fill.Value.positions do
+                    Expect.floatClose Accuracy.high (plane.Height p) 0.0 "planar input stays planar"
+            }
+
+            test "winding does not matter" {
+                let cw = PolygonFill.tryComputeFill xyChart square
+                let ccw = PolygonFill.tryComputeFill xyChart (Array.rev square)
+                Expect.isSome cw "clockwise must fill"
+                Expect.isSome ccw "counter-clockwise must fill"
+                Expect.floatClose Accuracy.medium
+                    (meshArea cw.Value.positions) (meshArea ccw.Value.positions)
+                    "the tessellator normalises orientation"
+            }
+
+            test "collinear points do not fill" {
+                let collinear = [| V3d(0,0,0); V3d(1,0,0); V3d(2,0,0); V3d(3,0,0) |]
+                Expect.isNone (PolygonFill.tryComputeFill xyChart collinear)
+                    "a degenerate ring has no interior"
+            }
+
+            test "fewer than three distinct points do not fill" {
+                let a, b = V3d(0,0,0), V3d(1,0,0)
+                Expect.isNone (PolygonFill.tryComputeFill xyChart [| a; a; b; b |])
+                    "duplicates must not be counted towards the three-vertex minimum"
+                Expect.isNone (PolygonFill.tryComputeFill xyChart [| a |]) "a single point has no interior"
+                Expect.isNone (PolygonFill.tryComputeFill xyChart [||]) "an empty ring has no interior"
+            }
+
+            test "self-intersecting bowtie resolves rather than failing" {
+                // pins actual behaviour: libtess applies the winding rule instead of throwing.
+                // An earlier draft of the plan wrongly expected this case to be rejected.
+                let bowtie = [| V3d(0,0,0); V3d(2,2,0); V3d(2,0,0); V3d(0,2,0) |]
+                let fill = PolygonFill.tryComputeFill xyChart bowtie
+
+                Expect.isSome fill "a bowtie must resolve, not crash"
+                Expect.isGreaterThan (meshArea fill.Value.positions) 0.0
+                    "the winding-rule resolution has positive area"
+            }
+
+            test "a chart that does not cover the ring yields no fill" {
+                let nowhere =
+                    { name = "nowhere"; toChart = (fun _ -> None); toWorld = (fun _ -> None) }
+                Expect.isNone (PolygonFill.tryComputeFill nowhere square)
+                    "an uncovered ring must degrade to no fill, not to garbage"
+            }
+        ]
+    ]

--- a/src/Tests/Program.fs
+++ b/src/Tests/Program.fs
@@ -36,6 +36,7 @@ let allTests () : Test =
         GeoJsonRework.Tests.tests()
         SpiceTests.tests()
         TriangleSetTests.tests()
+        PolygonFillTests.tests()
 
         // requires the (non-public) HERA kernels; self-skips without them
         HeraSpiceTests.tests()

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="DidymosProjectionSpiceTest.fs" />
     <None Include="RemoteApi.rest" />
     <Compile Include="TriangleSetTests.fs" />
+    <Compile Include="PolygonFillTests.fs" />
     <Compile Include="ProfileAttributeExtractionTest.fs" />
     <Compile Include="BaseTests.fs" />
     <Compile Include="Features\TestHelpers.fs" />


### PR DESCRIPTION
@
Fills closed annotations (polygon, ellipses) with a translucent cap. Fill colour, opacity and on/off are per annotation; the drawing toolbar carries the defaults for newly drawn ones.

## How it works

A ring is flattened into a 2D **surface chart** to decide triangulation topology only. Each vertex carries its original world position through the tessellator as an attribute (`PolygonTessellator.Triangulate`, Aardvark.Geometry), so the mesh is stitched from the input points rather than their flattened images — the fill boundary coincides exactly with the drawn outline, terrain projection included. Lifting through the chart inverse instead would re-flatten the rim onto the datum, which is visible on ellipses because their points are already surface-projected.

`SurfaceChart` generalises the two modes the ellipse code already had — a fitted plane and lat/lon — into one abstraction with `toChart` / `toWorld`. Four places in the codebase hand-rolled a variant of this; they can migrate later.

Rendering packs every filled annotation into one `TriangleList` draw alongside the existing packed lines. Depth-tested with a depth offset five times the line offset, writing no depth, so a ridge in front occludes the fill and outlines are never hidden behind it.

## Known limitation

The cap is flat within each triangle, so on a large or rugged polygon its middle sits above or below the surface while only the rim is anchored. Inherent to this approach and not fixable by depth offset. Accepted; the escape hatch is subdividing in chart space and raycasting interior vertices, which would replace only the geometry step.

## Also included

- `getPolylinePoints` returned duplicate vertices: segments share end points by construction, and the last interior sample can land on the segment end. Those became zero-length segments, which the thick-line geometry shader expands by normalizing a zero vector. Fixed in the accessor (first commit, independent of this feature).
- Unchecked checkboxes rendered as a solid block — `"square icon"` is filled in Fomantic while the checked state is an outline. Both states now use the outline variant, across every checkbox.
- Object ids written by packed draws now derive from one shared cached ordering, so line and fill ids agree by construction rather than by coincidence.

## Serialization

Three new `Annotation` fields, no version bump — read optionally in `readV5` and defaulted in `readV0`-`V4`, the same approach `crossSectionClipping` took. Older builds ignore the extra keys.

## Testing

`src/Tests/PolygonFillTests.fs`, 29 tests: duplicate and triple collapsing, chart round-trips, area agreement with `calculatePolygonArea`, n-2 triangle counts, winding independence, degenerate and NaN-plane rejection, and the self-intersecting bowtie, which resolves by winding rule rather than failing.

Full suite: 248 passed, 0 failed. Verified in the viewer against an OPC scene.
@