### PR TITLE
Move annotation control points on the surface

### DIFF
--- a/ai/RENDERING.md
+++ b/ai/RENDERING.md
@@ -80,6 +80,24 @@ Flow:
 
 **Performance note:** picking is only spawned when the current interaction actually needs it (recent change "Only spawn picking when necessary", commit `14583377`) — surface picking message spawning was previously over-eager. Results may be delivered asynchronously (`Model.pickPreviewRequested`, `backgroundPicking` thread pool; see [ARCHITECTURE.md](ARCHITECTURE.md#threads-messaging--async)).
 
+### Annotation picking — a separate, GPU-based system
+
+Annotations are **not** picked with the KdTrees. `PackedRendering.pickRenderTarget` rasterizes them into an offscreen `Rgba32f` buffer and the readback (`Drawing-App.fs`, in the packed branch of `DrawingApp.view`) downloads the single pixel under the cursor on every mouse move.
+
+Channel meanings, cleared to `(0,0,0,-1)`:
+
+| channel | meaning |
+|---|---|
+| **alpha** | packed object id — the index into `PackedRendering.orderedAnnotations`. `-1` = miss. |
+| **red** | sub-index within that object: the control point index for vertex-handle fragments, `-1` for lines and fills. `Picking.pickId` writes `-1`, `Picking.pickVertexId` writes the index. |
+| green, blue | fragment colour; read by nothing but the debug lens overlay in `OpcViewer/AnnotationViewer.fs`. |
+
+`orderedAnnotations` is the single cached ordering — **every packed draw that writes `ObjId` must take its ids from it**, or a click selects a different annotation than the one under the cursor. It is `HashSet.toArray` inside an `AVal.custom`, so the int id space can permute whenever the annotation set changes: capture the `Guid`, never the int, if you need to hold onto a pick.
+
+Draw order inside the pass is significant — fills, then lines, then vertex handles — so an outline wins over its own fill and a handle wins over the outline through it. Each also gets a progressively larger `DepthOffset` (`fillDepthOffsetFactor`, `handleDepthOffsetFactor`).
+
+Gates: `ViewerApp.allowAnnotationPicking` decides whether the readback is honoured at all; `ViewerApp.allowVertexEditing` additionally gates the handles. `Interactions.EditAnnotation` is the one mode where annotation picking *and* KdTree surface picking are both live — see [docs/AnnotationVertexEditing.md](../docs/AnnotationVertexEditing.md) for why that ordering hazard needs `VertexGrab.movedSinceGrab`.
+
 ### KdTrees
 
 File: `src/PRo3D.Base/KdTrees.fs`. See also `docs/KdTrees.md`.

--- a/docs/AnnotationVertexEditing.md
+++ b/docs/AnnotationVertexEditing.md
@@ -1,0 +1,135 @@
+# Annotation vertex editing
+
+Move the individual points of an annotation after it has been drawn.
+
+Until this feature, an annotation's points were fixed the moment you finished it. A vertex clicked
+a few metres off meant deleting the whole annotation and drawing it again. This adds an editing
+mode in which the points you originally clicked come back as handles you can pick up and put down
+somewhere else on the surface.
+
+This is the "move" half of [#639](https://github.com/pro3d-space/PRo3D/issues/639). Adding and
+removing points build on the same machinery and are not implemented yet — see
+[Not yet](#not-yet).
+
+## Using it
+
+1. Choose **Edit Annotation** in the interaction dropdown in the top toolbar.
+2. Select an annotation — Ctrl+click it in the 3D view, or pick it in the annotation tree. Its
+   control points appear as white discs.
+3. **Ctrl+click a handle** to pick it up. It turns green, and a green line runs from the cursor to
+   its two neighbours showing where the annotation would go.
+4. Move the cursor over the surface. The point follows the 3D cursor's live surface hit.
+5. **Ctrl+click again** to put it down. The annotation's length, area and dip/strike are
+   recomputed.
+
+**Escape** at any time puts a picked-up point back where it was. **Ctrl+Z** undoes a completed
+move.
+
+The hint line beside the interaction dropdown says which of the two states you are in.
+
+### Notes
+
+- **Ctrl is what separates picking from navigating**, here as everywhere else in PRo3D. Without it
+  the mouse drives the camera. If you have the "invert drawing" toggle on, it is the other way
+  round.
+- **Clicking an annotation's body selects it** instead of grabbing anything, so you can move from
+  one annotation to the next without leaving the mode.
+- **You have to move the cursor between picking a point up and putting it down.** A pick-up
+  followed by an immediate click on the same spot leaves the point in hand.
+- **Clicking where there is no surface does nothing** — the point stays in hand until you click
+  somewhere the cursor actually finds ground. An annotation vertex can never end up off-surface.
+- **A point may be moved onto a different surface** than the annotation was drawn on. This is
+  allowed; a message appears at the top right saying which surface it landed on. The annotation
+  keeps recording the surface it was drawn on.
+
+### Which annotations can be edited
+
+Points, lines, polylines and polygons.
+
+Ellipses cannot. Their stored points are the *sampled outline* computed when the ellipse was
+finished, not the two or four points you clicked to define it — there are no control points left
+to move.
+
+Dip-and-strike and true-thickness annotations are also excluded: their points mean "samples of a
+fitted plane" rather than "corners of a polyline", so moving one individually is not a meaningful
+operation.
+
+## What happens on drop
+
+The moved point is written into the annotation, and then:
+
+- **The segments either side of it are re-sampled** onto the terrain, at the annotation's sampling
+  distance. For a closed polygon, moving the first or last point also re-samples the segment that
+  closes the ring.
+- **Annotations that carry no segments keep none.** Every tool except the two ellipse ones defaults
+  to `Projection.Linear`, which draws straight lines between points and generates no terrain
+  samples at all. An edit does not silently promote such an annotation to a terrain-following one —
+  it keeps the shape it was drawn with. (Set the projection to Viewpoint, Sky or Bookmark *before*
+  drawing to get terrain-following segments.)
+- **Measurements are recomputed** — length, area, height, dip and strike.
+- **One undo entry is pushed** for the whole drop.
+
+While a point is in hand nothing is written to the annotation at all, which is why cancelling is
+instant and free.
+
+## How it works
+
+### Handles and picking
+
+PRo3D picks annotations by rendering them into an offscreen `Rgba32f` buffer with an object id in
+the alpha channel, then downloading the single pixel under the cursor
+(`PackedRendering.pickRenderTarget`). The handles ride in that same pass rather than in one of
+their own:
+
+| channel | meaning |
+|---|---|
+| alpha | packed object id — index into `PackedRendering.orderedAnnotations`. `-1` means nothing was hit. |
+| red | control point index for a handle fragment, `-1` for everything else |
+
+So one 1×1 download tells the readback both *which annotation* is under the cursor and *whether it
+is one of its handles*. Red ≥ 0 is the whole discriminator. Green and blue still carry the
+fragment colour, which nothing reads except the debug lens overlay in OpcViewer's
+`AnnotationViewer`.
+
+Handles are drawn last in the pick pass and with a larger depth offset than fills or lines, so
+grabbing a control point beats picking the outline running through it. They are also fattened in
+the pick pass only, the same forgiveness the line picking already applies.
+
+### Why a grab needs a mouse move before it can be dropped
+
+`Interactions.EditAnnotation` is the first mode with *both* pick systems live: annotation picking
+(the offscreen id buffer) and surface picking (kd-tree rays, which produce the live 3D cursor). The
+feature needs both — one to know which handle you clicked, the other to know where you are pointing.
+
+The consequence is that the click which grabs a handle also reaches the surface, and would read as
+a drop. Which of the two messages the update loop happens to process first would then decide the
+outcome. `VertexGrab.movedSinceGrab` removes the ambiguity: a drop is only accepted once the
+preview cursor has produced a fresh hit after the grab. Both orderings then behave identically, and
+"move it before you drop it" is what the gesture means anyway.
+
+### Model
+
+`DrawingModel.vertexGrab : Option<VertexGrab>` holds the annotation id, the control point index,
+the original position (so cancelling is free) and that `movedSinceGrab` flag. It lives on `Model`
+rather than `Scene`, so it is session state and is never written to a scene file — no scene version
+bump.
+
+The *live* position is deliberately not in the model. It is read from `Model.surfaceIntersection`,
+which the background picking thread already maintains; writing it into the drawing model on every
+mouse move would dirty the model and rebuild the packed line geometry at cursor rate. Only the
+small rubber-band scene graph depends on it.
+
+## Not yet
+
+- **Adding and removing points**, the rest of #639. Removing is straightforward on this base — drop
+  the point, merge the two segments either side and re-sample. Adding needs picking a *segment*
+  rather than a vertex, which means either a second sub-index in the pick buffer or a
+  nearest-segment test on the CPU.
+- **Editing an annotation while you are still drawing it.** Handles appear only on finished
+  annotations. Backspace still removes the last point mid-draw.
+- **Dragging** (press, move, release) rather than click-to-grab, click-to-drop.
+
+## See also
+
+- [AdvancedAnnotations.md](AdvancedAnnotations.md) — the annotation tools themselves
+- [KdTrees.md](KdTrees.md) — the surface intersection the 3D cursor and the re-sampling both use

--- a/docs/AnnotationVertexEditing.md
+++ b/docs/AnnotationVertexEditing.md
@@ -32,6 +32,9 @@ The hint line beside the interaction dropdown says which of the two states you a
 - **Ctrl is what separates picking from navigating**, here as everywhere else in PRo3D. Without it
   the mouse drives the camera. If you have the "invert drawing" toggle on, it is the other way
   round.
+- **The 3D cursor is switched on for you** while you are in this mode, whatever the scene's
+  "preview intersection" setting says — the drop needs a live surface hit. Your setting is read,
+  never overwritten, and applies again as soon as you leave the mode.
 - **Clicking an annotation's body selects it** instead of grabbing anything, so you can move from
   one annotation to the next without leaving the mode.
 - **You have to move the cursor between picking a point up and putting it down.** A pick-up
@@ -73,6 +76,32 @@ While a point is in hand nothing is written to the annotation at all, which is w
 instant and free.
 
 ## How it works
+
+### Why the handles are drawn the way they are
+
+Each handle is **six vertices expanded on the CPU** — two triangles at the same world position,
+told apart by a corner offset that the vertex shader turns into a screen-space quad. That looks
+roundabout for what is visually a dot, and the alternatives were each tried and rejected:
+
+- **`gl_PointSize` + `gl_PointCoord`** depends on `GL_PROGRAM_POINT_SIZE`, and every point draw in
+  the codebase that actually renders composes `DefaultSurfaces.pointSprite` alongside it.
+- **`DefaultSurfaces.pointSprite`** cannot be used, because it does not carry `ObjId`/`SubId`
+  through — and carrying those is the entire purpose of this draw.
+- **A hand-written point→quad geometry shader** works in principle (`LineShader.thickLine` is one
+  for lines) but adds a stage for no gain once the expansion is this cheap: 14 handles is 84
+  vertices.
+
+Two more constraints worth knowing before editing these shaders:
+
+- The shader bodies are **written out inline** — no `[<ReflectedDefinition>]` helper, no
+  module-level colour constants. FShade has to inline the whole body.
+- The pick pass uses **one** fragment shader (`handlePickFragment`), not `handleFragment` followed
+  by `Picking.pickVertexId`. Chaining two fragment shaders makes FShade carry the whole
+  `HandleVertex` record — including its `[<Position>]` — between them.
+- `uniform.ViewportSize` is **not** the pick target's size. The handles are drawn into two
+  different targets, so the viewport is passed explicitly per pass as `HandleViewport`.
+- `Id` and `SubId` are declared `Flat`: integers cannot be interpolated, and `Picking.SubVertex`
+  already declared them that way.
 
 ### Handles and picking
 

--- a/src/PRo3D.Base/Annotation/Annotation-Model.fs
+++ b/src/PRo3D.Base/Annotation/Annotation-Model.fs
@@ -22,16 +22,30 @@ type Projection =
 | Sky = 2
 | Bookmark = 3
 
-type Geometry = 
-| Point         = 0 
-| Line          = 1 
-| Polyline      = 2 
-| Polygon       = 3 
+type Geometry =
+| Point         = 0
+| Line          = 1
+| Polyline      = 2
+| Polygon       = 3
 | DnS           = 4
 | TT            = 5
 | Ellipse       = 6
 | AxisEllipse   = 7
 | Axis4PEllipse = 8
+
+module Geometry =
+
+    /// Whether an annotation's `points` are still the control points the user clicked, and so can
+    /// be edited one vertex at a time.
+    ///
+    /// The ellipse tools are excluded: once the ellipse is constructed, `getFinishedAnnotation`
+    /// replaces their `points` with the sampled outline, so there are no control points left to
+    /// move. DnS and TT are excluded because their points carry a fitted plane's meaning rather
+    /// than a free polyline's.
+    let isVertexEditable (geometry : Geometry) =
+        match geometry with
+        | Geometry.Point | Geometry.Line | Geometry.Polyline | Geometry.Polygon -> true
+        | _ -> false
 
 type Semantic = 
 | Horizon0 = 0 

--- a/src/PRo3D.Core/Drawing/Drawing-App.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-App.fs
@@ -1093,8 +1093,6 @@ module DrawingApp =
                                 // and whether it was a handle
                                 let sub : int = floor p.R |> int
                                 let ids = pickIds.GetValue()
-                                if vertexEditingAllowed.GetValue() && (id >= 0 || sub >= 0) then
-                                    Log.line "[VertexPick] raw pixel R=%f A=%f -> obj=%d sub=%d" p.R p.A id sub
                                 if id >= 0 && id < ids.Length  && allowed then
                                     //Log.line "hoverhit %A" (id, ids.[id])
                                     transact (fun _ ->
@@ -1128,12 +1126,11 @@ module DrawingApp =
                                     // the annotation you are editing would deselect it and take its
                                     // handles away - which is exactly what a slightly missed handle
                                     // click looks like.
-                                    Log.line "editclick (already selected) %A vertex=%d" ids.[id] vertex
                                     DrawingAction.Nop
                                 else
                                     // a click on the body still re-selects, so you can move
                                     // between annotations without leaving edit mode
-                                    Log.line "clickhit %A editing=%b vertex=%d" (id, ids.[id]) editing vertex
+                                    Log.line "clickhit %A" (id, ids.[id])
                                     DrawingAction.PickDirectly(ids.[id])
                             else
                                 DrawingAction.Nop
@@ -1156,7 +1153,7 @@ module DrawingApp =
             // after the lines, so a handle is never hidden by the outline running through it -
             // matching the pick pass, where handles are drawn last for the same reason
             let packedVertexHandles =
-                PackedRendering.packedVertexHandleRender hoveredVertex grabbedVertex handleGeometry
+                PackedRendering.packedVertexHandleRender hoveredVertex grabbedVertex viewport handleGeometry
                 |> Sg.noEvents
 
             let overlay =

--- a/src/PRo3D.Core/Drawing/Drawing-App.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-App.fs
@@ -46,8 +46,117 @@ module DrawingApp =
     let mutable usePackedAnnotationRendering = true
 
    // open Newtonsoft.Json
-        
-    let closePolyline (a:Annotation) = 
+
+    /// Walks the straight line from `a` to `b` in `samplingDistance` steps and projects each step
+    /// onto the surface with `samplePoint`, dropping the steps that miss.
+    ///
+    /// The resulting Segment carries only the *interior* samples in `points`; `getPolylinePoints`
+    /// puts `startPoint` and `endPoint` around them when it flattens the annotation.
+    ///
+    /// Shared by `addPoint` (a freshly drawn segment) and `MoveVertex` (re-sampling the segments
+    /// either side of a moved control point) so the two cannot drift apart.
+    let resampleSegment (samplingDistance : float) (samplePoint : V3d -> Option<V3d>) (a : V3d) (b : V3d) : Segment =
+        let vec    = b - a
+        let length = vec.Length
+        // A zero-length segment has no direction to walk along, and a non-positive sampling
+        // distance would ask for infinitely many steps. Both collapse to a bare start/end pair.
+        // The first case is reachable from vertex editing: dropping a point onto its neighbour.
+        if length <= 0.0 || samplingDistance <= 0.0 then
+            { startPoint = a; endPoint = b; points = IndexList.empty }
+        else
+            let dir          = vec / length
+            let numOfSamples = (length / samplingDistance) |> floor |> int
+            let points =
+                [ for s in 1 .. numOfSamples do
+                    let p = a + dir * (float s) * samplingDistance // world space
+                    match samplePoint p with
+                    | None -> ()
+                    | Some projectedPoint -> yield projectedPoint ]
+            { startPoint = a; endPoint = b; points = IndexList.ofList points }
+
+    /// Whether an annotation's segments form a closed ring.
+    ///
+    /// `closePolyline` appends one extra segment joining the last point back to the first, so a
+    /// ring has exactly as many segments as points where an open chain has one fewer. Derived from
+    /// the counts rather than from `geometry`, because that is the invariant the segment indices
+    /// actually rest on.
+    let private hasClosingSegment (pointCount : int) (segmentCount : int) =
+        segmentCount >= pointCount
+
+    /// The segments invalidated by moving control point `pointIndex`.
+    ///
+    /// Segment j runs points[j] -> points[j+1], so an interior point sits between segments j-1 and
+    /// j. On a ring the first and last points additionally bound the trailing closing segment.
+    let touchedSegments (pointCount : int) (segmentCount : int) (pointIndex : int) : list<int> =
+        if segmentCount <= 0 || pointIndex < 0 || pointIndex >= pointCount then
+            []
+        else
+            let isClosed = hasClosingSegment pointCount segmentCount
+            let closing  = segmentCount - 1
+            let before =
+                if pointIndex > 0 then Some (pointIndex - 1)
+                elif isClosed then Some closing
+                else None
+            let after =
+                if pointIndex < pointCount - 1 then Some pointIndex
+                elif isClosed then Some closing
+                else None
+            [ before; after ]
+            |> List.choose id
+            |> List.distinct
+            |> List.filter (fun i -> i >= 0 && i < segmentCount)
+
+    /// The two control points segment `segmentIndex` spans, or None if the index is out of range.
+    /// The closing segment of a ring runs first -> last, matching how `closePolyline` builds it.
+    let segmentEndpoints (points : IndexList<V3d>) (segmentCount : int) (segmentIndex : int) : Option<V3d * V3d> =
+        let pointCount = IndexList.count points
+        if hasClosingSegment pointCount segmentCount && segmentIndex = segmentCount - 1 then
+            match IndexList.tryFirst points, IndexList.tryLast points with
+            | Some first, Some last -> Some (first, last)
+            | _ -> None
+        else
+            match IndexList.tryAt segmentIndex points, IndexList.tryAt (segmentIndex + 1) points with
+            | Some a, Some b -> Some (a, b)
+            | _ -> None
+
+    /// Moves control point `pointIndex` to `position` and brings the annotation back into a
+    /// consistent state: the segments either side of the point are re-sampled onto the surface, and
+    /// the derived measurements are recomputed.
+    ///
+    /// Annotations drawn with `Projection.Linear` - which `SetGeometry` selects for every tool
+    /// except the two ellipse ones - carry no segments at all, and none are invented here: the
+    /// annotation keeps the shape it was drawn with.
+    ///
+    /// `modelTrafo` is deliberately left alone. It is the precision anchor the packed renderer
+    /// works in, and re-anchoring it on every edit would be churn for no gain.
+    let moveVertex
+        (up : V3d) (north : V3d) (planet : Planet)
+        (samplingDistance : float) (samplePoint : V3d -> Option<V3d>)
+        (pointIndex : int) (position : V3d)
+        (a : Annotation) : Annotation =
+
+        if pointIndex < 0 || pointIndex >= IndexList.count a.points then
+            a
+        else
+            let points = a.points |> IndexList.setAt pointIndex position
+
+            let segmentCount = IndexList.count a.segments
+            let segments =
+                if segmentCount = 0 then
+                    a.segments
+                else
+                    touchedSegments (IndexList.count points) segmentCount pointIndex
+                    |> List.fold (fun (segs : IndexList<Segment>) i ->
+                        match segmentEndpoints points segmentCount i with
+                        | Some (s, e) -> segs |> IndexList.setAt i (resampleSegment samplingDistance samplePoint s e)
+                        | None        -> segs
+                    ) a.segments
+
+            let a = { a with points = points; segments = segments }
+            let a = { a with dnsResults = points |> DipAndStrike.calculateDipAndStrikeResults up north }
+            { a with results = Some (Calculations.calculateAnnotationResults a up north planet) }
+
+    let closePolyline (a:Annotation) =
         let firstP = a.points.[0]
         let lastP = a.points.[(a.points.Count-1)]
         match a.projection with
@@ -156,29 +265,14 @@ module DrawingApp =
                         match IndexList.tryAt (IndexList.count w.points-1) w.points with
                         | None -> 
                             annotation, None
-                        | Some a -> 
+                        | Some a ->
                             let segmentIndex = IndexList.count annotation.segments
-                            let newSegment = { startPoint = a; endPoint = p; points = IndexList.ofList [a;p] }
-                            
+
                             if PRo3D.Config.useAsyncIntersections then
+                                let newSegment = { startPoint = a; endPoint = p; points = IndexList.ofList [a;p] }
                                 { annotation with segments = IndexList.add newSegment annotation.segments }, Some (newSegment,segmentIndex)
                             else
-                                let vec = newSegment.endPoint - newSegment.startPoint
-                                let dir = vec.Normalized
-                                //let step = vec.Length / float PRo3D.Config.sampleCount
-                                let numOfSamples = (vec.Length / model.samplingDistance) |> floor |> int
-
-                                let points = [ 
-                                    for s in 1 .. numOfSamples do
-                                        let p = newSegment.startPoint + dir * (float s) * model.samplingDistance // world space
-
-                                        Log.line "[Drawing] Spawning p: %A at %A" s ((float s) * model.samplingDistance)
-
-                                        match samplePoint p with
-                                        | None -> ()
-                                        | Some projectedPoint -> yield projectedPoint
-                                ]
-                                let newSegment = { startPoint = a; endPoint = p; points = IndexList.ofList points }
+                                let newSegment = resampleSegment model.samplingDistance samplePoint a p
                                 { annotation with segments = IndexList.add newSegment annotation.segments }, None
                     | Projection.Linear ->
                         annotation, None
@@ -368,6 +462,11 @@ module DrawingApp =
     let automaticallyReExportGeoJson (action : DrawingAction) =
         match action with
         | DrawingAction.Move p  -> false
+        // picking a control point up and putting it back down again change no geometry; only the
+        // drop (MoveVertex) does, and that one falls through to true below
+        | GrabVertex _          -> false
+        | ArmVertexGrab         -> false
+        | CancelVertexEdit      -> false
         | ExportAsGeoJSON _     -> false
         | ExportAsAnnotations _ -> false
         | ExportAsCsv _         -> false
@@ -636,9 +735,63 @@ module DrawingApp =
                             Log.line "[DrawingApp] single select"
                             GroupsApp.update model.annotations (GroupsAppAction.SingleSelectLeaf(List.empty, ann.key, String.Empty))
                     
-                    { model with annotations = annotations }
+                    // selecting a different annotation abandons any control point being moved
+                    { model with annotations = annotations; vertexGrab = None }
 
-                | _ -> model        
+                | _ -> model
+
+            // ---- vertex editing (Interactions.EditAnnotation) ----------------------------------
+            // Same (draw = false, pick = true) gate as annotation selection above: both are picks.
+
+            | GrabVertex (id, pointIndex), false, true ->
+                match model.annotations.flat.TryFind id with
+                | Some (Leaf.Annotations ann) when Geometry.isVertexEditable ann.geometry ->
+                    match IndexList.tryAt pointIndex ann.points with
+                    | Some original ->
+                        { model with
+                            vertexGrab =
+                                Some { annotation = id; pointIndex = pointIndex
+                                       original = original; movedSinceGrab = false } }
+                    | None -> model
+                | _ -> model
+
+            | ArmVertexGrab, _, _ ->
+                // the preview cursor produced a hit after the grab, so the next click is a drop
+                match model.vertexGrab with
+                | Some g when not g.movedSinceGrab ->
+                    { model with vertexGrab = Some { g with movedSinceGrab = true } }
+                | _ -> model
+
+            | CancelVertexEdit, _, _ ->
+                // the annotation was never touched while the grab was live, so forgetting the grab
+                // is the whole of the undo
+                { model with vertexGrab = None }
+
+            | MoveVertex (id, pointIndex, position, samplePoint), false, true ->
+                match model.annotations.flat.TryFind id with
+                | Some (Leaf.Annotations ann) when Geometry.isVertexEditable ann.geometry ->
+                    let up     = smallConfig.up.Get(bigConfig)
+                    let north  = smallConfig.north.Get(bigConfig)
+                    let planet = smallConfig.planet.Get(bigConfig)
+
+                    let before = model.annotations
+                    let after =
+                        before
+                        |> Groups.updateLeaf id (fun leaf ->
+                            match leaf with
+                            | Leaf.Annotations a ->
+                                a
+                                |> moveVertex up north planet model.samplingDistance samplePoint pointIndex position
+                                |> Leaf.Annotations
+                            | other -> other
+                        )
+
+                    // one atomic update, and therefore one undo entry, per drop
+                    { model with annotations = after; vertexGrab = None }
+                    |> pushUndo (SnapshotDelta(before, after))
+                | _ ->
+                    { model with vertexGrab = None }
+
             | AddAnnotations path, _,_ ->
                 match path |> List.tryHead with
                 | Some p -> 
@@ -840,7 +993,10 @@ module DrawingApp =
         (frustum          : aval<Frustum>)
         (runtime          : IRuntime)
         (viewport         : aval<V2i>)
-        (pickingAllowed   : aval<bool>)        
+        (pickingAllowed   : aval<bool>)
+        /// true only in Interactions.EditAnnotation - gates the control point handles, which are
+        /// both drawn and pickable only while the user is actually editing.
+        (vertexEditingAllowed : aval<bool>)
         (model            : AdaptiveDrawingModel)
         : ISg<DrawingAction> * ISg<DrawingAction> =
         // order is irrelevant for rendering. change list to set,
@@ -894,13 +1050,26 @@ module DrawingApp =
             Log.stop()
 
             let hoveredAnnotation = cval -1
+            // control point index under the cursor, or -1. Read from the red channel of the same
+            // pixel hoveredAnnotation comes from, so one download serves both.
+            let hoveredVertex = cval -1
+            // VertexGrab is not a ModelType, so adaptify leaves this a plain aval of the option
+            let grabbedVertex = model.vertexGrab |> AVal.map (function Some g -> g.pointIndex | None -> -1)
+
             let viewMatrix = view |> AVal.map (fun v -> (CameraView.viewTrafo v).Forward)
             // one cached ordering shared by every packed draw that writes an object id, so the
-            // ids the pick target reads back agree across lines and fills by construction
+            // ids the pick target reads back agree across lines, fills and handles by construction
             let ordered = PackedRendering.orderedAnnotations (annoSet |> ASet.map ((fun (g, (s,t)) -> g,s)))
             let lines, pickIds, bb = PackedRendering.linesNoIndirect config.offset hoveredAnnotation (model.annotations.selectedLeaves |> ASet.map (fun e -> e.id)) ordered viewMatrix
             let fillGeometry = PackedRendering.fills config.offset ordered viewMatrix
-            let pickRenderTarget = PackedRendering.pickRenderTarget runtime config.pickingTolerance lines fillGeometry view frustum viewport
+
+            // handles exist only for the single selected annotation, and only in edit mode
+            let handleTarget =
+                (vertexEditingAllowed, model.annotations.singleSelectLeaf)
+                ||> AVal.map2 (fun editing selected -> if editing then selected else None)
+            let handleGeometry = PackedRendering.vertexHandles config.offset handleTarget ordered viewMatrix
+
+            let pickRenderTarget = PackedRendering.pickRenderTarget runtime config.pickingTolerance lines fillGeometry handleGeometry view frustum viewport
             pickRenderTarget.Acquire()
             let packedLines = 
                 let simple (kind : SceneEventKind) (f : SceneHit -> seq<'msg>) =
@@ -919,23 +1088,44 @@ module DrawingApp =
                                 let allowed = pickingAllowed.GetValue()
                                 let p = m.[0,0]
                                 let id : int = floor p.A |> int //BitConverter.SingleToInt32Bits(p.A)
+                                // red carries the control point index for handle fragments and -1
+                                // for everything else, so this one pixel says both what was hit
+                                // and whether it was a handle
+                                let sub : int = floor p.R |> int
                                 let ids = pickIds.GetValue()
                                 if id >= 0 && id < ids.Length  && allowed then
                                     //Log.line "hoverhit %A" (id, ids.[id])
-                                    transact (fun _ -> hoveredAnnotation.Value <- id)
+                                    transact (fun _ ->
+                                        hoveredAnnotation.Value <- id
+                                        hoveredVertex.Value <- sub)
                                     Seq.empty
-                                else 
-                                    transact (fun _ -> hoveredAnnotation.Value <- -1)
+                                else
+                                    transact (fun _ ->
+                                        hoveredAnnotation.Value <- -1
+                                        hoveredVertex.Value <- -1)
                                     Seq.empty
                             with e -> Seq.empty
                        )
-                       Sg.onMouseDown (fun b p -> 
+                       Sg.onMouseDown (fun b p ->
                             let id = hoveredAnnotation.GetValue()
                             let ids = pickIds.GetValue()
-                            if id >= 0 && id < ids.Length then
-                                Log.line "clickhit %A" (id, ids.[id])
-                                DrawingAction.PickDirectly(ids.[id])
-                            else 
+                            let vertex = hoveredVertex.GetValue()
+                            let editing = vertexEditingAllowed.GetValue()
+                            let alreadyGrabbed = grabbedVertex.GetValue() >= 0
+                            if alreadyGrabbed then
+                                // a grab is live: the drop belongs to the viewer's surface-click
+                                // path, which is the only place the live hit point exists
+                                DrawingAction.Nop
+                            elif id >= 0 && id < ids.Length then
+                                if vertex >= 0 && editing then
+                                    Log.line "vertexhit %A" (id, ids.[id], vertex)
+                                    DrawingAction.GrabVertex(ids.[id], vertex)
+                                else
+                                    // a click on the body still re-selects, so you can move
+                                    // between annotations without leaving edit mode
+                                    Log.line "clickhit %A" (id, ids.[id])
+                                    DrawingAction.PickDirectly(ids.[id])
+                            else
                                 DrawingAction.Nop
                        )
                 ]
@@ -953,11 +1143,17 @@ module DrawingApp =
                 PackedRendering.packedFillRender fillGeometry
                 |> Sg.noEvents
 
+            // after the lines, so a handle is never hidden by the outline running through it -
+            // matching the pick pass, where handles are drawn last for the same reason
+            let packedVertexHandles =
+                PackedRendering.packedVertexHandleRender hoveredVertex grabbedVertex handleGeometry
+                |> Sg.noEvents
+
             let overlay =
                 Sg.ofList [
                     // brush model.hoverPosition;
                     annotations
-                    Sg.ofSeq [packedFills; packedLines; packedPoints]
+                    Sg.ofSeq [packedFills; packedLines; packedPoints; packedVertexHandles]
                     Sg.drawWorkingAnnotation config.offset (AVal.map Adaptify.FSharp.Core.Missing.AdaptiveOption.toOption model.working) // TODO v5: why need fully qualified
                 ]
 

--- a/src/PRo3D.Core/Drawing/Drawing-App.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-App.fs
@@ -1093,6 +1093,8 @@ module DrawingApp =
                                 // and whether it was a handle
                                 let sub : int = floor p.R |> int
                                 let ids = pickIds.GetValue()
+                                if vertexEditingAllowed.GetValue() && (id >= 0 || sub >= 0) then
+                                    Log.line "[VertexPick] raw pixel R=%f A=%f -> obj=%d sub=%d" p.R p.A id sub
                                 if id >= 0 && id < ids.Length  && allowed then
                                     //Log.line "hoverhit %A" (id, ids.[id])
                                     transact (fun _ ->
@@ -1120,10 +1122,18 @@ module DrawingApp =
                                 if vertex >= 0 && editing then
                                     Log.line "vertexhit %A" (id, ids.[id], vertex)
                                     DrawingAction.GrabVertex(ids.[id], vertex)
+                                elif editing && model.annotations.singleSelectLeaf.GetValue() = Some ids.[id] then
+                                    // A body click on the annotation being edited must not reach
+                                    // PickDirectly: addSingleSelectedLeaf *toggles*, so clicking
+                                    // the annotation you are editing would deselect it and take its
+                                    // handles away - which is exactly what a slightly missed handle
+                                    // click looks like.
+                                    Log.line "editclick (already selected) %A vertex=%d" ids.[id] vertex
+                                    DrawingAction.Nop
                                 else
                                     // a click on the body still re-selects, so you can move
                                     // between annotations without leaving edit mode
-                                    Log.line "clickhit %A" (id, ids.[id])
+                                    Log.line "clickhit %A editing=%b vertex=%d" (id, ids.[id]) editing vertex
                                     DrawingAction.PickDirectly(ids.[id])
                             else
                                 DrawingAction.Nop

--- a/src/PRo3D.Core/Drawing/Drawing-Model.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-Model.fs
@@ -29,6 +29,31 @@ type AnnotationsDelta =
     | LeafRemoved   of leaf: Leaf * groupPath: list<Index>
     | SnapshotDelta of before: GroupsModel * after: GroupsModel
 
+/// A control point that has been picked up in Interactions.EditAnnotation and is following the
+/// preview cursor until it is dropped.
+///
+/// `original` is kept so cancelling costs nothing: the annotation itself is never touched while a
+/// grab is live. The *live* position is deliberately absent - it is read adaptively from
+/// Model.surfaceIntersection, because writing it here on every mouse move would dirty the drawing
+/// model and rebuild the packed line geometry at cursor rate.
+///
+/// `annotation` is a Guid, not a packed object id: PackedRendering.orderedAnnotations can permute
+/// the int id space whenever the annotation set changes.
+type VertexGrab = {
+    annotation : Guid
+    pointIndex : int
+    original   : V3d
+
+    /// False until the preview cursor has produced a fresh surface hit after the grab.
+    ///
+    /// In EditAnnotation both pick systems are live, so the click that grabs a handle *also*
+    /// reaches the surface and would otherwise be taken for a drop - and which of the two messages
+    /// the mailbox happens to process first would decide the outcome. Requiring a mouse move in
+    /// between makes the sequence order-independent, and "drop only after you have moved it" is
+    /// what the gesture means anyway.
+    movedSinceGrab : bool
+}
+
 type DrawingAction =
 | SetSemantic         of Semantic
 | ChangeThickness     of Numeric.Action
@@ -55,7 +80,12 @@ type DrawingAction =
 | LegacySaveVersioned
 | LegacyLoadVersioned
 | SetSegment             of int * Segment
-| Finish                   
+// vertex editing (Interactions.EditAnnotation)
+| GrabVertex             of Guid * int
+| MoveVertex             of Guid * int * V3d * (V3d -> Option<V3d>)
+| ArmVertexGrab
+| CancelVertexEdit
+| Finish
 | Undo                   
 | Redo                   
 | FlyToAnnotation        of Guid
@@ -101,6 +131,10 @@ type DrawingModel = {
     hoverPosition : option<Trafo3d>    
 
     working    : Option<Annotation>
+
+    /// Set while a control point is being moved in Interactions.EditAnnotation. Session state:
+    /// DrawingModel lives on Model, not Scene, so this is never serialized.
+    vertexGrab : Option<VertexGrab>
 
     //TODO refactor ... put this into separate model type and save it with the scene or in user/app data
     projection : Projection
@@ -170,6 +204,7 @@ module DrawingModel =
         defaultFillAlpha   = Annotation.initialFillAlpha
 
         working     = None
+        vertexGrab  = None
         projection  = Projection.Linear
         geometry    = Geometry.Line
         semantic    = Semantic.Horizon3

--- a/src/PRo3D.Core/Drawing/Drawing-Model.g.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-Model.g.fs
@@ -1,5 +1,5 @@
-//59ea86c2-89c0-b20b-aad3-3899a4c69bc4
-//b2e6edc8-5f0c-f61f-f387-54bccd9ba9d3
+//bcf3b9eb-46bd-628b-5e38-d3f4b411e4fb
+//49b2acb6-23c5-15ad-ea15-58e7ffdac979
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -50,6 +50,7 @@ type AdaptiveDrawingModel(value : DrawingModel) =
             (unbox<PRo3D.Base.Annotation.AdaptiveAnnotation> o).Update(v)
             o
         Adaptify.FSharp.Core.AdaptiveOption<PRo3D.Base.Annotation.Annotation, PRo3D.Base.Annotation.AdaptiveAnnotation, PRo3D.Base.Annotation.AdaptiveAnnotation>(value.working, (fun (v : PRo3D.Base.Annotation.Annotation) -> PRo3D.Base.Annotation.AdaptiveAnnotation(v) :> System.Object), __arg2, (fun (o : System.Object) -> unbox<PRo3D.Base.Annotation.AdaptiveAnnotation> o), (fun (v : PRo3D.Base.Annotation.Annotation) -> PRo3D.Base.Annotation.AdaptiveAnnotation(v) :> System.Object), __arg5, (fun (o : System.Object) -> unbox<PRo3D.Base.Annotation.AdaptiveAnnotation> o))
+    let _vertexGrab_ = FSharp.Data.Adaptive.cval(value.vertexGrab)
     let _projection_ = FSharp.Data.Adaptive.cval(value.projection)
     let _geometry_ = FSharp.Data.Adaptive.cval(value.geometry)
     let _semantic_ = FSharp.Data.Adaptive.cval(value.semantic)
@@ -80,6 +81,7 @@ type AdaptiveDrawingModel(value : DrawingModel) =
             _multi_.Value <- value.multi
             _hoverPosition_.Value <- value.hoverPosition
             _working_.Update(value.working)
+            _vertexGrab_.Value <- value.vertexGrab
             _projection_.Value <- value.projection
             _geometry_.Value <- value.geometry
             _semantic_.Value <- value.semantic
@@ -103,6 +105,7 @@ type AdaptiveDrawingModel(value : DrawingModel) =
     member __.multi = _multi_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.bool>
     member __.hoverPosition = _hoverPosition_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.option<Aardvark.Base.Trafo3d>>
     member __.working = _working_ :> FSharp.Data.Adaptive.aval<Adaptify.FSharp.Core.AdaptiveOptionCase<PRo3D.Base.Annotation.Annotation, PRo3D.Base.Annotation.AdaptiveAnnotation, PRo3D.Base.Annotation.AdaptiveAnnotation>>
+    member __.vertexGrab = _vertexGrab_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.Option<VertexGrab>>
     member __.projection = _projection_ :> FSharp.Data.Adaptive.aval<PRo3D.Base.Annotation.Projection>
     member __.geometry = _geometry_ :> FSharp.Data.Adaptive.aval<PRo3D.Base.Annotation.Geometry>
     member __.semantic = _semantic_ :> FSharp.Data.Adaptive.aval<PRo3D.Base.Annotation.Semantic>
@@ -128,6 +131,7 @@ module DrawingModelLenses =
         static member multi_ = ((fun (self : DrawingModel) -> self.multi), (fun (value : Microsoft.FSharp.Core.bool) (self : DrawingModel) -> { self with multi = value }))
         static member hoverPosition_ = ((fun (self : DrawingModel) -> self.hoverPosition), (fun (value : Microsoft.FSharp.Core.option<Aardvark.Base.Trafo3d>) (self : DrawingModel) -> { self with hoverPosition = value }))
         static member working_ = ((fun (self : DrawingModel) -> self.working), (fun (value : Microsoft.FSharp.Core.Option<PRo3D.Base.Annotation.Annotation>) (self : DrawingModel) -> { self with working = value }))
+        static member vertexGrab_ = ((fun (self : DrawingModel) -> self.vertexGrab), (fun (value : Microsoft.FSharp.Core.Option<VertexGrab>) (self : DrawingModel) -> { self with vertexGrab = value }))
         static member projection_ = ((fun (self : DrawingModel) -> self.projection), (fun (value : PRo3D.Base.Annotation.Projection) (self : DrawingModel) -> { self with projection = value }))
         static member geometry_ = ((fun (self : DrawingModel) -> self.geometry), (fun (value : PRo3D.Base.Annotation.Geometry) (self : DrawingModel) -> { self with geometry = value }))
         static member semantic_ = ((fun (self : DrawingModel) -> self.semantic), (fun (value : PRo3D.Base.Annotation.Semantic) (self : DrawingModel) -> { self with semantic = value }))

--- a/src/PRo3D.Core/Drawing/Drawing.Sg.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.Sg.fs
@@ -187,28 +187,29 @@ module Sg =
     /// vertices, which become zero-length line segments — and the thick-line geometry shader
     /// expands those by normalizing (p1 - p0), i.e. a zero vector. Dropped here rather than at
     /// each of the call sites.
+    /// The flattening itself, evaluated against the caller's token.
+    ///
+    /// Anything already inside an AVal.custom must call this rather than getPolylinePoints.
+    /// Building an adaptive value inside another one's evaluation creates a node that nothing
+    /// holds a strong reference to, and adaptive outputs are weak: once it is collected, the
+    /// invalidation chain from `a.points` to the enclosing computation is gone and the geometry
+    /// silently stops updating until something unrelated marks it dirty. That is what made an
+    /// edited annotation only redraw once the next annotation was drawn.
+    let getPolylinePointsAt (a : AdaptiveAnnotation) (t : AdaptiveToken) : V3d[] =
+        let segments = a.segments.Content.GetValue t
+        if IndexList.isEmpty segments then
+            a.points.Content.GetValue(t) |> IndexList.toArray |> dedupeConsecutive
+        else
+            let points = System.Collections.Generic.List<V3d>()
+            segments |> IndexList.iter(fun (s : AdaptiveSegment) ->
+                points.Add(s.startPoint.GetValue(t))
+                for p in s.points.Content.GetValue(t) do points.Add(p)
+                points.Add(s.endPoint.GetValue(t))
+            )
+            points.ToArray() |> dedupeConsecutive
+
     let getPolylinePoints (a : AdaptiveAnnotation) =
-        //a.segments.Content 
-        //    |> AVal.bind (fun segments -> 
-        //        if IndexList.isEmpty segments then a.points |> AList.toAVal |> AVal.map IndexList.toArray
-        //        else 
-        //            segments |> IndexList.map (fun s -> 
-                        
-        //            )
-        //    )
-        AVal.custom (fun t -> 
-            let segments = a.segments.Content.GetValue t
-            if IndexList.isEmpty segments then  
-                a.points.Content.GetValue(t) |> IndexList.toArray |> dedupeConsecutive 
-            else 
-                let points = System.Collections.Generic.List<V3d>()
-                a.segments.Content.GetValue(t) |> IndexList.iter(fun (s : AdaptiveSegment) -> 
-                    points.Add(s.startPoint.GetValue(t))
-                    for s in s.points.Content.GetValue(t) do points.Add(s)
-                    points.Add(s.endPoint.GetValue(t))
-                )
-                points.ToArray() |> dedupeConsecutive
-        )
+        AVal.custom (getPolylinePointsAt a)
         //alist {                          
         //    let! hasSegments = (a.segments |> AList.count) |> AVal.map(fun x -> x > 0)
         //    if hasSegments |> not then

--- a/src/PRo3D.Core/Drawing/PackedRendering.fs
+++ b/src/PRo3D.Core/Drawing/PackedRendering.fs
@@ -321,15 +321,50 @@ module PackedRendering =
 
             }
 
+        /// As Vertex, plus a sub-index within the object - the control point index, for the vertex
+        /// handle draw. Flat, like the object id, so no interpolation can corrupt it.
+        type SubVertex =
+            {
+                [<Semantic("Id");Interpolation(InterpolationMode.Flat)>]
+                id : int
+
+                [<Semantic("SubId");Interpolation(InterpolationMode.Flat)>]
+                subId : int
+
+                [<Position>]
+                pos : V4f
+
+                [<Color>]
+                c : V4f
+            }
+
         [<GLSLIntrinsic("intBitsToFloat({0})")>]
         let intBitsToFloat (i : int) : float32 = failwith ""
 
-        let pickId (v : Vertex) = 
+        // The pick target is Rgba32f cleared to (0,0,0,-1).
+        //
+        //   alpha : the packed object id, indexing PackedRendering.orderedAnnotations. -1 = miss.
+        //   red   : the sub-index within that object, or -1 when the fragment is not a sub-object.
+        //           Today only vertex handles set it, which is how a readback tells "clicked the
+        //           annotation" from "clicked one of its control points".
+        //
+        // Green and blue still carry the fragment colour and are read by nothing but the debug lens
+        // overlay in OpcViewer's AnnotationViewer.
+
+        let pickId (v : Vertex) =
             fragment {
                 let i = v.id
-                return V4f(v.c.X, v.c.Y, v.c.Z, float32 i)
+                return V4f(-1.0f, v.c.Y, v.c.Z, float32 i)
             }
-        
+
+        /// As pickId, but writes the control point index into red so the readback can tell a handle
+        /// hit from a hit on the annotation body.
+        let pickVertexId (v : SubVertex) =
+            fragment {
+                return V4f(float32 v.subId, v.c.Y, v.c.Z, float32 v.id)
+            }
+
+
 
 
     module FillShader =
@@ -369,6 +404,97 @@ module PackedRendering =
                 return { v with pos = uniform.ProjTrafo * vp; id = v.obId }
             }
 
+
+    module VertexHandleShader =
+
+        open FShade
+        open PRo3D.Base.Shader.DepthOffset
+
+        type HandleVertex =
+            {
+                [<Position>] pos : V4f
+                [<Semantic("np")>] np : V4f
+                [<Semantic("Sizes")>] size : float32
+                [<PointSize>] pointSize : float32
+                [<Color>] c : V4f
+                [<PointCoord>] tc : V2f
+
+                // ObjId is the per-vertex attribute; Id is what Picking.pickVertexId reads. Same
+                // in/out pair the line path uses (ThickLineVertex.obId -> id).
+                [<Semantic("ObjId")>] obId : int
+                [<Semantic("Id")>] id : int
+
+                // SubId is both the attribute and the output - it passes straight through.
+                [<Semantic("SubId")>] subId : int
+
+                [<Depth(DepthWriteMode.OnlyLess)>]
+                depth : float32
+            }
+
+        type UniformScope with
+            /// Control point index currently hovered, or -1. Compared per vertex, like SelectedId.
+            member x.HoveredVertex : int = uniform?HoveredVertex
+            /// Control point index currently grabbed, or -1.
+            member x.GrabbedVertex : int = uniform?GrabbedVertex
+            /// Extra radius, in the same units as Sizes, applied only in the pick pass.
+            member x.HandlePickBonus : float32 = uniform?HandlePickBonus
+
+        // A fixed palette, deliberately independent of the annotation's own colour: handles have to
+        // stay legible whatever colour the group is, and green already reads as "selected"
+        // everywhere else in PRo3D.
+        let private handleNormal  = V4f(1.0f, 1.0f, 1.0f, 1.0f)
+        let private handleHovered = V4f(1.0f, 0.85f, 0.1f, 1.0f)
+        let private handleGrabbed = V4f(0.2f, 0.8f, 0.2f, 1.0f)
+
+        /// Places a handle from its local-space position through the MV uniform, matching the
+        /// convention linesNoIndirect and fills use. (PointsShader.pointSpriteVertex instead expects
+        /// positions already view-transformed on the CPU.)
+        let handleVertex (v : HandleVertex) =
+            vertex {
+                let mv : M44f = uniform?MV
+                let vp = mv * v.pos
+                let c =
+                    if v.subId = uniform.GrabbedVertex then handleGrabbed
+                    elif v.subId = uniform.HoveredVertex then handleHovered
+                    else handleNormal
+                return { v with pos = uniform.ProjTrafo * vp; np = vp; pointSize = v.size; c = c }
+            }
+
+        /// As handleVertex, but fattens the sprite so a handle is forgiving to click, and forwards
+        /// the object and control point ids for Picking.pickVertexId. The colour is left alone -
+        /// the pick pass only reads the ids.
+        let handleVertexPicking (v : HandleVertex) =
+            vertex {
+                let mv : M44f = uniform?MV
+                let vp = mv * v.pos
+                return
+                    { v with
+                        pos = uniform.ProjTrafo * vp
+                        np = vp
+                        pointSize = v.size + uniform.HandlePickBonus
+                        id = v.obId }
+            }
+
+        /// Shades the sprite as a disc and discards outside it, so the pickable region is exactly
+        /// the visible circle. Same construction as PointsShader.pointSpriteFragment.
+        let handleFragment (v : HandleVertex) =
+            fragment {
+                let tc = v.tc
+
+                let c = 2.0f * tc - V2f.II
+                if c.Length > 1.0f then
+                    discard()
+
+                let n = V3f(c, sqrt(1.0f - Vec.dot c c)) |> Vec.normalize
+                let p = v.np + V4f(n, 1.0f)
+
+                let pp = uniform.ProjTrafo * p
+                let nd = pp.Z / pp.W
+                let d = (nd + 1.0f) / 2.0f
+
+                let d = (d - uniform.DepthOffset) / v.pos.W
+                return { v with c = v.c; depth = ((depthDiff() * d) + depthNear() + depthFar()) / 2.0f }
+            }
 
     module LensShader =
         open FShade
@@ -566,7 +692,19 @@ module PackedRendering =
 
 
 
-    let pickRenderTarget (runtime : IRuntime) (pickingTolerance : aval<float>) lines fills (view : aval<CameraView>) (frustum : aval<Frustum>) (viewport : aval<V2i>) =
+    /// Handles sit further off the surface than the fills, which already sit further off than the
+    /// lines, so a handle wins the pick against the annotation it belongs to.
+    let private handleDepthOffsetFactor = 10.0
+
+    /// Radius added to a handle on top of the annotation's line thickness, so a control point is a
+    /// target rather than a hairline.
+    let private handleSizeBonus = 6.0f
+
+    /// Further radius the handle gets in the pick pass only - the same forgiveness
+    /// noIndirectLineVertexPicking gives lines.
+    let private handlePickBonus = 5.0f
+
+    let pickRenderTarget (runtime : IRuntime) (pickingTolerance : aval<float>) lines fills handles (view : aval<CameraView>) (frustum : aval<Frustum>) (viewport : aval<V2i>) =
         let pickColors =
             let signature =
                 runtime.CreateFramebufferSignature [
@@ -606,11 +744,27 @@ module PackedRendering =
                 }
                 |> Sg.compile runtime signature
 
+            // control point handles of the annotation being edited. These write the same object id
+            // in alpha, plus the control point index in red, which is how the readback tells a
+            // handle from the annotation body.
+            let pickHandles =
+                handles
+                |> withCamera
+                |> Sg.uniform "HandlePickBonus" (AVal.constant handlePickBonus)
+                |> Sg.shader {
+                      do! VertexHandleShader.handleVertexPicking
+                      do! VertexHandleShader.handleFragment
+                      do! Picking.pickVertexId
+                }
+                |> Sg.compile runtime signature
+
             let cleared = RenderTask.ofList [
                 runtime.CompileClear(signature, C4f(0.0f,0.0f,0.0f,-1.0f))
                 // fills first so an outline still wins the pick over its own interior
                 pickFills
                 pickColors
+                // handles last: grabbing a control point has to beat picking the line through it
+                pickHandles
             ]
 
             cleared |> RenderTask.renderToColor viewport
@@ -731,6 +885,91 @@ module PackedRendering =
         |> Sg.depthTest (AVal.constant DepthTest.LessOrEqual)
         // no depth write, so the outline and other fills are not occluded by the cap
         |> Sg.writeBuffers' (Set.ofList [WriteBuffer.Color DefaultSemantic.Colors])
+
+    /// Draggable control-point handles for one annotation - the one being edited.
+    ///
+    /// The object id written to alpha indexes the same `ordered` array lines and fills use, so a
+    /// pick resolves to a Guid through the identical path. The control point index goes to red,
+    /// where `Picking.pickId` writes -1; red >= 0 is therefore what distinguishes "clicked a
+    /// handle" from "clicked the annotation".
+    ///
+    /// Emits `anno.points` - the control points the user clicked - and deliberately not
+    /// `Drawing.Sg.getPolylinePoints`, which returns the terrain-sampled polyline and would put a
+    /// handle on every sample.
+    ///
+    /// Returns bare geometry so the visible and pick passes can attach different shaders.
+    let vertexHandles
+        (depthOffset : aval<float>)
+        (selected    : aval<Option<Guid>>)
+        (ordered     : aval<(Guid * AdaptiveAnnotation)[]>)
+        (view        : aval<M44d>) =
+
+        let data =
+            AVal.custom (fun t ->
+                let annos    = ordered.GetValue(t)
+                let selected = selected.GetValue(t)
+
+                let positions = List<V3f>()
+                let subIds    = List<int>()
+                let objIds    = List<int>()
+                let sizes     = List<float32>()
+                let mutable pivotTrafo = None
+
+                // the object id *is* the index into the shared ordering
+                let index =
+                    match selected with
+                    | None -> None
+                    | Some sel -> annos |> Array.tryFindIndex (fun (id, _) -> id = sel)
+
+                match index with
+                | None -> ()
+                | Some oid ->
+                    let (_, anno) = annos.[oid]
+                    let visible   = anno.visible.GetValue(t)
+                    let geometry  = anno.geometry.GetValue(t)
+
+                    if visible && Geometry.isVertexEditable geometry then
+                        let pivot = anno.modelTrafo.GetValue(t)
+                        pivotTrafo <- Some pivot
+
+                        let thickness = anno.thickness.value.GetValue(t)
+                        let size = float32 thickness + handleSizeBonus
+
+                        let mutable i = 0
+                        for p in anno.points.Content.GetValue(t) do
+                            positions.Add(pivot.Backward.TransformPos p |> V3f)
+                            subIds.Add i
+                            objIds.Add oid
+                            sizes.Add size
+                            i <- i + 1
+
+                {| points     = positions.ToArray()
+                   subIds     = subIds.ToArray()
+                   objIds     = objIds.ToArray()
+                   sizes      = sizes.ToArray()
+                   modelTrafo = Option.defaultValue Trafo3d.Identity pivotTrafo |})
+
+        let mv = (data, view) ||> AVal.map2 (fun d v -> v * d.modelTrafo.Forward)
+
+        Sg.draw IndexedGeometryMode.PointList
+        |> Sg.vertexAttribute DefaultSemantic.Positions (data |> AVal.map (fun d -> d.points))
+        |> Sg.vertexAttribute (Sym.ofString "ObjId")    (data |> AVal.map (fun d -> d.objIds))
+        |> Sg.vertexAttribute (Sym.ofString "SubId")    (data |> AVal.map (fun d -> d.subIds))
+        |> Sg.vertexAttribute (Sym.ofString "Sizes")    (data |> AVal.map (fun d -> d.sizes))
+        |> Sg.uniform "MV" mv
+        |> Sg.uniform "DepthOffset"
+            (depthOffset |> AVal.map (fun d -> (d * handleDepthOffsetFactor) / (100.0 - 0.1)))
+
+    /// Visible pass for the vertex handles. `hovered` and `grabbed` are control point indices, or
+    /// -1; the shader compares them per vertex the way SelectedId works for lines.
+    let packedVertexHandleRender (hovered : aval<int>) (grabbed : aval<int>) handles =
+        handles
+        |> Sg.uniform "HoveredVertex" hovered
+        |> Sg.uniform "GrabbedVertex" grabbed
+        |> Sg.shader {
+            do! VertexHandleShader.handleVertex
+            do! VertexHandleShader.handleFragment
+        }
 
     let points (selected : aset<Guid>) (annoSet: aset<Guid * AdaptiveAnnotation>) (depthOffset : aval<float>) (view : aval<M44d>) =
         let instanceAttribs = 

--- a/src/PRo3D.Core/Drawing/PackedRendering.fs
+++ b/src/PRo3D.Core/Drawing/PackedRendering.fs
@@ -431,10 +431,14 @@ module PackedRendering =
                 // ObjId is the per-vertex attribute; Id is what Picking.pickVertexId reads. Same
                 // in/out pair the line path uses (ThickLineVertex.obId -> id).
                 [<Semantic("ObjId")>] obId : int
-                [<Semantic("Id")>] id : int
 
-                // SubId is both the attribute and the output - it passes straight through.
-                [<Semantic("SubId")>] subId : int
+                // Id and SubId travel to the fragment stage, so they must be flat - integers cannot
+                // be interpolated - and must agree with Picking.SubVertex, which declares them flat.
+                // Without this the pick pass composes two fragment shaders with conflicting
+                // interpolation for the same varying and the draw silently produces nothing, while
+                // the visible pass (which never sees Picking.SubVertex) renders perfectly.
+                [<Semantic("Id"); Interpolation(InterpolationMode.Flat)>] id : int
+                [<Semantic("SubId"); Interpolation(InterpolationMode.Flat)>] subId : int
             }
 
         type UniformScope with
@@ -442,8 +446,13 @@ module PackedRendering =
             member x.HoveredVertex : int = uniform?HoveredVertex
             /// Control point index currently grabbed, or -1.
             member x.GrabbedVertex : int = uniform?GrabbedVertex
-            /// Extra radius, in the same units as Sizes, applied only in the pick pass.
-            member x.HandlePickBonus : float32 = uniform?HandlePickBonus
+
+            /// Size in pixels of the target this pass renders into.
+            ///
+            /// Supplied explicitly rather than read from uniform.ViewportSize, because the handles
+            /// are drawn into two different targets - the render control and the offscreen pick
+            /// buffer - and the quad has to be scaled by the size of whichever one it is in.
+            member x.HandleViewport : V2f = uniform?HandleViewport
 
         // Everything below is written out inline rather than sharing a [<ReflectedDefinition>]
         // helper or module-level colour constants: FShade has to be able to inline the whole body,
@@ -463,8 +472,8 @@ module PackedRendering =
 
                 // a zero viewport would push every corner to infinity and the quad would silently
                 // never rasterize
-                let vpX = max 1.0f (float32 uniform.ViewportSize.X)
-                let vpY = max 1.0f (float32 uniform.ViewportSize.Y)
+                let vpX = max 1.0f uniform.HandleViewport.X
+                let vpY = max 1.0f uniform.HandleViewport.Y
                 // NDC spans 2 units across the viewport, hence the factor of two
                 let dx = v.corner.X * v.size * 2.0f / vpX * clip.W
                 let dy = v.corner.Y * v.size * 2.0f / vpY * clip.W
@@ -484,9 +493,11 @@ module PackedRendering =
                 let mv : M44f = uniform?MV
                 let clip = uniform.ProjTrafo * (mv * v.pos)
 
-                let vpX = max 1.0f (float32 uniform.ViewportSize.X)
-                let vpY = max 1.0f (float32 uniform.ViewportSize.Y)
-                let size = v.size + uniform.HandlePickBonus
+                let vpX = max 1.0f uniform.HandleViewport.X
+                let vpY = max 1.0f uniform.HandleViewport.Y
+                // literal, like the +5.0f noIndirectLineVertexPicking adds to line width: one less
+                // uniform to bind on a pass whose only job is to be hit-tested
+                let size = v.size + 5.0f
                 let dx = v.corner.X * size * 2.0f / vpX * clip.W
                 let dy = v.corner.Y * size * 2.0f / vpY * clip.W
 
@@ -506,6 +517,22 @@ module PackedRendering =
                 if v.corner.Length > 1.0f then
                     discard()
                 return { v with c = v.c }
+            }
+
+        /// The pick pass's fragment stage: the same disc, writing the ids instead of a colour.
+        ///
+        /// One shader rather than handleFragment followed by Picking.pickVertexId. Chaining two
+        /// fragment shaders makes FShade carry HandleVertex's whole record - including its
+        /// [<Position>] - between them, and the draw silently produces nothing.
+        ///
+        /// Channel layout matches Picking.pickId: alpha is the packed object id, red is the
+        /// sub-index within it (here the control point), and pickId writes -1 to red so that
+        /// red >= 0 means "this is a handle".
+        let handlePickFragment (v : HandleVertex) =
+            fragment {
+                if v.corner.Length > 1.0f then
+                    discard()
+                return V4f(float32 v.subId, v.c.Y, v.c.Z, float32 v.id)
             }
 
     module LensShader =
@@ -708,10 +735,6 @@ module PackedRendering =
     /// target rather than a hairline.
     let private handleSizeBonus = 6.0f
 
-    /// Further radius the handle gets in the pick pass only - the same forgiveness
-    /// noIndirectLineVertexPicking gives lines.
-    let private handlePickBonus = 5.0f
-
     let pickRenderTarget (runtime : IRuntime) (pickingTolerance : aval<float>) lines fills handles (view : aval<CameraView>) (frustum : aval<Frustum>) (viewport : aval<V2i>) =
         let pickColors =
             let signature =
@@ -758,11 +781,10 @@ module PackedRendering =
             let pickHandles =
                 handles
                 |> withCamera
-                |> Sg.uniform "HandlePickBonus" (AVal.constant handlePickBonus)
+                |> Sg.uniform "HandleViewport" (viewport |> AVal.map (fun (v : V2i) -> V2d(float v.X, float v.Y)))
                 |> Sg.shader {
                       do! VertexHandleShader.handleVertexPicking
-                      do! VertexHandleShader.handleFragment
-                      do! Picking.pickVertexId
+                      do! VertexHandleShader.handlePickFragment
                 }
                 // No depth test. This pass contains no terrain - only lines, fills and handles -
                 // so depth here only arbitrates between annotation geometry, and a handle must
@@ -971,14 +993,6 @@ module PackedRendering =
                                 colors.Add(C4f(1.0f, 1.0f, 1.0f, 1.0f))
                             i <- i + 1
 
-                // only runs when the selection or the annotation changes, so this is not chatty -
-                // and "no handles appeared" is otherwise very hard to tell from "handles missed"
-                Log.line "[VertexHandles] selected=%A -> %d handle(s), %d vertices" selected (positions.Count / 6) positions.Count
-                if positions.Count > 0 then
-                    let pivot = Option.defaultValue Trafo3d.Identity pivotTrafo
-                    Log.line "[VertexHandles] pivot=%A local[0]=%A world[0]=%A size[0]=%f"
-                        pivot.Forward.C3.XYZ positions.[0] (pivot.Forward.TransformPos (V3d positions.[0])) sizes.[0]
-
                 {| points     = positions.ToArray()
                    corners    = corners.ToArray()
                    subIds     = subIds.ToArray()
@@ -1000,10 +1014,11 @@ module PackedRendering =
 
     /// Visible pass for the vertex handles. `hovered` and `grabbed` are control point indices, or
     /// -1; the shader compares them per vertex the way SelectedId works for lines.
-    let packedVertexHandleRender (hovered : aval<int>) (grabbed : aval<int>) handles =
+    let packedVertexHandleRender (hovered : aval<int>) (grabbed : aval<int>) (viewport : aval<V2i>) handles =
         handles
         |> Sg.uniform "HoveredVertex" hovered
         |> Sg.uniform "GrabbedVertex" grabbed
+        |> Sg.uniform "HandleViewport" (viewport |> AVal.map (fun (v : V2i) -> V2d(float v.X, float v.Y)))
         |> Sg.shader {
             do! VertexHandleShader.handleVertex
             do! VertexHandleShader.handleFragment

--- a/src/PRo3D.Core/Drawing/PackedRendering.fs
+++ b/src/PRo3D.Core/Drawing/PackedRendering.fs
@@ -413,11 +413,20 @@ module PackedRendering =
         type HandleVertex =
             {
                 [<Position>] pos : V4f
-                [<Semantic("np")>] np : V4f
+
+                /// Radius in pixels. Per vertex; the pick pass inflates it.
                 [<Semantic("Sizes")>] size : float32
-                [<PointSize>] pointSize : float32
+
                 [<Color>] c : V4f
-                [<PointCoord>] tc : V2f
+
+                /// Which corner of the quad this vertex is, in [-1,1]^2. Supplied per vertex by
+                /// `vertexHandles`, which emits six vertices per control point.
+                ///
+                /// The billboard is expanded here rather than in a geometry shader: a stock sprite
+                /// stage such as DefaultSurfaces.pointSprite would not carry ObjId/SubId through,
+                /// which is the whole point of this draw, and gl_PointSize would additionally
+                /// depend on GL_PROGRAM_POINT_SIZE. Six vertices per handle is nothing.
+                [<Semantic("HandleCorner")>] corner : V2f
 
                 // ObjId is the per-vertex attribute; Id is what Picking.pickVertexId reads. Same
                 // in/out pair the line path uses (ThickLineVertex.obId -> id).
@@ -426,9 +435,6 @@ module PackedRendering =
 
                 // SubId is both the attribute and the output - it passes straight through.
                 [<Semantic("SubId")>] subId : int
-
-                [<Depth(DepthWriteMode.OnlyLess)>]
-                depth : float32
             }
 
         type UniformScope with
@@ -439,61 +445,67 @@ module PackedRendering =
             /// Extra radius, in the same units as Sizes, applied only in the pick pass.
             member x.HandlePickBonus : float32 = uniform?HandlePickBonus
 
-        // A fixed palette, deliberately independent of the annotation's own colour: handles have to
-        // stay legible whatever colour the group is, and green already reads as "selected"
+        // Everything below is written out inline rather than sharing a [<ReflectedDefinition>]
+        // helper or module-level colour constants: FShade has to be able to inline the whole body,
+        // and self-contained shader code removes that question entirely.
+        //
+        // The palette is deliberately independent of the annotation's own colour - handles have to
+        // stay legible whatever the group colour is, and green already reads as "selected"
         // everywhere else in PRo3D.
-        let private handleNormal  = V4f(1.0f, 1.0f, 1.0f, 1.0f)
-        let private handleHovered = V4f(1.0f, 0.85f, 0.1f, 1.0f)
-        let private handleGrabbed = V4f(0.2f, 0.8f, 0.2f, 1.0f)
 
         /// Places a handle from its local-space position through the MV uniform, matching the
-        /// convention linesNoIndirect and fills use. (PointsShader.pointSpriteVertex instead expects
-        /// positions already view-transformed on the CPU.)
+        /// convention linesNoIndirect and fills use, then offsets it to its quad corner. The offset
+        /// is scaled by the clip-space W so the perspective divide leaves a constant pixel size.
         let handleVertex (v : HandleVertex) =
             vertex {
                 let mv : M44f = uniform?MV
-                let vp = mv * v.pos
+                let clip = uniform.ProjTrafo * (mv * v.pos)
+
+                // a zero viewport would push every corner to infinity and the quad would silently
+                // never rasterize
+                let vpX = max 1.0f (float32 uniform.ViewportSize.X)
+                let vpY = max 1.0f (float32 uniform.ViewportSize.Y)
+                // NDC spans 2 units across the viewport, hence the factor of two
+                let dx = v.corner.X * v.size * 2.0f / vpX * clip.W
+                let dy = v.corner.Y * v.size * 2.0f / vpY * clip.W
+
                 let c =
-                    if v.subId = uniform.GrabbedVertex then handleGrabbed
-                    elif v.subId = uniform.HoveredVertex then handleHovered
-                    else handleNormal
-                return { v with pos = uniform.ProjTrafo * vp; np = vp; pointSize = v.size; c = c }
+                    if v.subId = uniform.GrabbedVertex then V4f(0.2f, 0.8f, 0.2f, 1.0f)
+                    elif v.subId = uniform.HoveredVertex then V4f(1.0f, 0.85f, 0.1f, 1.0f)
+                    else V4f(1.0f, 1.0f, 1.0f, 1.0f)
+
+                return { v with pos = V4f(clip.X + dx, clip.Y + dy, clip.Z, clip.W); c = c }
             }
 
-        /// As handleVertex, but fattens the sprite so a handle is forgiving to click, and forwards
-        /// the object and control point ids for Picking.pickVertexId. The colour is left alone -
-        /// the pick pass only reads the ids.
+        /// As handleVertex, but fattens the quad so a handle is forgiving to click, and forwards the
+        /// object id for Picking.pickVertexId. The colour is left alone - the pick pass reads ids.
         let handleVertexPicking (v : HandleVertex) =
             vertex {
                 let mv : M44f = uniform?MV
-                let vp = mv * v.pos
-                return
-                    { v with
-                        pos = uniform.ProjTrafo * vp
-                        np = vp
-                        pointSize = v.size + uniform.HandlePickBonus
-                        id = v.obId }
+                let clip = uniform.ProjTrafo * (mv * v.pos)
+
+                let vpX = max 1.0f (float32 uniform.ViewportSize.X)
+                let vpY = max 1.0f (float32 uniform.ViewportSize.Y)
+                let size = v.size + uniform.HandlePickBonus
+                let dx = v.corner.X * size * 2.0f / vpX * clip.W
+                let dy = v.corner.Y * size * 2.0f / vpY * clip.W
+
+                return { v with pos = V4f(clip.X + dx, clip.Y + dy, clip.Z, clip.W); id = v.obId }
             }
 
-        /// Shades the sprite as a disc and discards outside it, so the pickable region is exactly
-        /// the visible circle. Same construction as PointsShader.pointSpriteFragment.
+        /// Shades the sprite as a flat disc and discards outside it, so the pickable region is
+        /// exactly the visible circle - which is what makes a grab land where it looks like it will.
+        ///
+        /// Writes no gl_FragDepth. PointsShader.pointSpriteFragment does, computing a sphere normal
+        /// and re-projecting it, but a handle is an editing overlay for one annotation: it should be
+        /// reachable whenever it is on screen, and both passes disable the depth test for exactly
+        /// that reason. Custom depth here would only reintroduce the question.
         let handleFragment (v : HandleVertex) =
             fragment {
-                let tc = v.tc
-
-                let c = 2.0f * tc - V2f.II
-                if c.Length > 1.0f then
+                // `corner` interpolates across the quad, so it doubles as the disc coordinate
+                if v.corner.Length > 1.0f then
                     discard()
-
-                let n = V3f(c, sqrt(1.0f - Vec.dot c c)) |> Vec.normalize
-                let p = v.np + V4f(n, 1.0f)
-
-                let pp = uniform.ProjTrafo * p
-                let nd = pp.Z / pp.W
-                let d = (nd + 1.0f) / 2.0f
-
-                let d = (d - uniform.DepthOffset) / v.pos.W
-                return { v with c = v.c; depth = ((depthDiff() * d) + depthNear() + depthFar()) / 2.0f }
+                return { v with c = v.c }
             }
 
     module LensShader =
@@ -692,10 +704,6 @@ module PackedRendering =
 
 
 
-    /// Handles sit further off the surface than the fills, which already sit further off than the
-    /// lines, so a handle wins the pick against the annotation it belongs to.
-    let private handleDepthOffsetFactor = 10.0
-
     /// Radius added to a handle on top of the annotation's line thickness, so a control point is a
     /// target rather than a hairline.
     let private handleSizeBonus = 6.0f
@@ -756,6 +764,11 @@ module PackedRendering =
                       do! VertexHandleShader.handleFragment
                       do! Picking.pickVertexId
                 }
+                // No depth test. This pass contains no terrain - only lines, fills and handles -
+                // so depth here only arbitrates between annotation geometry, and a handle must
+                // always beat the outline running through it. Tuning depth offsets to achieve that
+                // is fragile; drawing last with the test off says it outright.
+                |> Sg.depthTest (AVal.constant DepthTest.None)
                 |> Sg.compile runtime signature
 
             let cleared = RenderTask.ofList [
@@ -913,6 +926,8 @@ module PackedRendering =
                 let subIds    = List<int>()
                 let objIds    = List<int>()
                 let sizes     = List<float32>()
+                let colors    = List<C4f>()
+                let corners   = List<V2f>()
                 let mutable pivotTrafo = None
 
                 // the object id *is* the index into the shared ordering
@@ -935,30 +950,53 @@ module PackedRendering =
                         let thickness = anno.thickness.value.GetValue(t)
                         let size = float32 thickness + handleSizeBonus
 
+                        // two triangles per control point, all six vertices at the same world
+                        // position and told apart only by their corner offset, which the vertex
+                        // shader turns into a screen-space quad
+                        let quad =
+                            [| V2f(-1.0f, -1.0f); V2f(1.0f, -1.0f); V2f(1.0f, 1.0f)
+                               V2f(-1.0f, -1.0f); V2f(1.0f, 1.0f); V2f(-1.0f, 1.0f) |]
+
                         let mutable i = 0
                         for p in anno.points.Content.GetValue(t) do
-                            positions.Add(pivot.Backward.TransformPos p |> V3f)
-                            subIds.Add i
-                            objIds.Add oid
-                            sizes.Add size
+                            let local = pivot.Backward.TransformPos p |> V3f
+                            for c in quad do
+                                positions.Add local
+                                corners.Add c
+                                subIds.Add i
+                                objIds.Add oid
+                                sizes.Add size
+                                // the shader chooses the visible colour; supplied because every
+                                // packed draw does and HandleVertex declares Colors as an input
+                                colors.Add(C4f(1.0f, 1.0f, 1.0f, 1.0f))
                             i <- i + 1
 
+                // only runs when the selection or the annotation changes, so this is not chatty -
+                // and "no handles appeared" is otherwise very hard to tell from "handles missed"
+                Log.line "[VertexHandles] selected=%A -> %d handle(s), %d vertices" selected (positions.Count / 6) positions.Count
+                if positions.Count > 0 then
+                    let pivot = Option.defaultValue Trafo3d.Identity pivotTrafo
+                    Log.line "[VertexHandles] pivot=%A local[0]=%A world[0]=%A size[0]=%f"
+                        pivot.Forward.C3.XYZ positions.[0] (pivot.Forward.TransformPos (V3d positions.[0])) sizes.[0]
+
                 {| points     = positions.ToArray()
+                   corners    = corners.ToArray()
                    subIds     = subIds.ToArray()
                    objIds     = objIds.ToArray()
                    sizes      = sizes.ToArray()
+                   colors     = colors.ToArray()
                    modelTrafo = Option.defaultValue Trafo3d.Identity pivotTrafo |})
 
         let mv = (data, view) ||> AVal.map2 (fun d v -> v * d.modelTrafo.Forward)
 
-        Sg.draw IndexedGeometryMode.PointList
-        |> Sg.vertexAttribute DefaultSemantic.Positions (data |> AVal.map (fun d -> d.points))
-        |> Sg.vertexAttribute (Sym.ofString "ObjId")    (data |> AVal.map (fun d -> d.objIds))
-        |> Sg.vertexAttribute (Sym.ofString "SubId")    (data |> AVal.map (fun d -> d.subIds))
-        |> Sg.vertexAttribute (Sym.ofString "Sizes")    (data |> AVal.map (fun d -> d.sizes))
+        Sg.draw IndexedGeometryMode.TriangleList
+        |> Sg.vertexAttribute DefaultSemantic.Positions   (data |> AVal.map (fun d -> d.points))
+        |> Sg.vertexAttribute (Sym.ofString "HandleCorner") (data |> AVal.map (fun d -> d.corners))
+        |> Sg.vertexAttribute (Sym.ofString "ObjId")      (data |> AVal.map (fun d -> d.objIds))
+        |> Sg.vertexAttribute (Sym.ofString "SubId")      (data |> AVal.map (fun d -> d.subIds))
+        |> Sg.vertexAttribute (Sym.ofString "Sizes")      (data |> AVal.map (fun d -> d.sizes))
+        |> Sg.vertexAttribute DefaultSemantic.Colors      (data |> AVal.map (fun d -> d.colors))
         |> Sg.uniform "MV" mv
-        |> Sg.uniform "DepthOffset"
-            (depthOffset |> AVal.map (fun d -> (d * handleDepthOffsetFactor) / (100.0 - 0.1)))
 
     /// Visible pass for the vertex handles. `hovered` and `grabbed` are control point indices, or
     /// -1; the shader compares them per vertex the way SelectedId works for lines.
@@ -970,6 +1008,10 @@ module PackedRendering =
             do! VertexHandleShader.handleVertex
             do! VertexHandleShader.handleFragment
         }
+        // Always visible while the annotation is being edited, and never occluded by its own
+        // outline. The pick pass makes the same choice, so what you see is what you can grab.
+        |> Sg.depthTest (AVal.constant DepthTest.None)
+        |> Sg.writeBuffers' (Set.ofList [WriteBuffer.Color DefaultSemantic.Colors])
 
     let points (selected : aset<Guid>) (annoSet: aset<Guid * AdaptiveAnnotation>) (depthOffset : aval<float>) (view : aval<M44d>) =
         let instanceAttribs = 

--- a/src/PRo3D.Core/Drawing/PackedRendering.fs
+++ b/src/PRo3D.Core/Drawing/PackedRendering.fs
@@ -573,8 +573,7 @@ module PackedRendering =
                   let mutable b = Box3d.Invalid
                   for (id,anno) in annos do   
                       let kind = anno.geometry.GetValue t
-                      let p = PRo3D.Core.Drawing.Sg.getPolylinePoints anno
-                      let ps = p.GetValue(t)
+                      let ps = PRo3D.Core.Drawing.Sg.getPolylinePointsAt anno t
                       b <- Box3d(b, Box3d(ps))
                       let offset = 0.0
                       let color = if HashSet.contains id selected then C4b.VRVisGreen else anno.color.c.GetValue(t)
@@ -664,8 +663,7 @@ module PackedRendering =
                   let mutable oid = 0
                   for (id,anno) in annos do   
                       let kind = anno.geometry.GetValue t
-                      let p = PRo3D.Core.Drawing.Sg.getPolylinePoints anno
-                      let ps = p.GetValue(t)
+                      let ps = PRo3D.Core.Drawing.Sg.getPolylinePointsAt anno t
                       b <- Box3d(b, Box3d(ps))
                       let offset = 0.0
                       let color = if HashSet.contains id selected then C4b.VRVisGreen else anno.color.c.GetValue(t)
@@ -1047,21 +1045,16 @@ module PackedRendering =
                         let color = if isSelected then C4b.VRVisGreen else c.GetValue(t)
                         match kind with
                         | Geometry.Point ->
-                            let p    = PRo3D.Core.Drawing.Sg.getPolylinePoints anno
-                            let c    = anno.color.c
-                            let size = anno.thickness.value |> AVal.map(fun x -> x + 0.5)
-                            let px   = p.GetValue(t)
+                            let px   = PRo3D.Core.Drawing.Sg.getPolylinePointsAt anno t
+                            let size = anno.thickness.value.GetValue(t) + 0.5
 
                             modelPos.Add(px.[0])
                             colors.Add(color)
-                            sizes.Add(float32 <| size.GetValue(t))
+                            sizes.Add(float32 size)
                         | Geometry.DnS -> 
                             if isSelected then
-                                let p    = PRo3D.Core.Drawing.Sg.getPolylinePoints anno
-                                let c    = anno.color.c.GetValue(t)
-                                let size = anno.thickness.value |> AVal.map(fun x -> x + 0.5)
-                                let size = size.GetValue(t)
-                                let px   = p.GetValue(t)
+                                let px   = PRo3D.Core.Drawing.Sg.getPolylinePointsAt anno t
+                                let size = anno.thickness.value.GetValue(t) + 0.5
 
                                 for p in px do 
                                     modelPos.Add(p)
@@ -1131,11 +1124,10 @@ module PackedRendering =
                 let dnsResults = anno.dnsResults.GetValue(t)
                 match dnsResults with
                 | AdaptiveSome s when visible && showDns -> 
-                    let p = PRo3D.Core.Drawing.Sg.getPolylinePoints anno
+                    let ps = PRo3D.Core.Drawing.Sg.getPolylinePointsAt anno t
                     let dipAngle = s.dipAngle.GetValue(t)
                     let _ = fcm.Current.GetValue(t)
                     let r = PRo3D.FalseColorLegendApp.Draw.getColorDnS fcm s.dipAngle
-                    let ps = p.GetValue(t)
                     let color = r.GetValue(t)
 
                     if ps.Length > 0 then

--- a/src/PRo3D.Core/Model.fs
+++ b/src/PRo3D.Core/Model.fs
@@ -24,7 +24,8 @@ type Interactions =
     | PickPivotPoint        = 18
     | PickSurfaceRefSys     = 19
     | PickDistancePoint     = 20
-    
+    | EditAnnotation        = 21 // move the control points of the selected annotation
+
 
 module Interactions =
     // excludes interactions from dropdown in topmenu

--- a/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
@@ -1112,6 +1112,16 @@ module ViewerUtils =
                 | _ -> true
             )
 
+        // Vertex editing is driven entirely by the live surface hit, so it has to keep the preview
+        // picking running even when the scene has it switched off. #669 made `true` the default,
+        // but scenes saved before that carry an explicit `false` and Json.tryRead only defaults a
+        // key that is absent - so without this, opening an older scene makes edit mode inert.
+        // The user's config value is read, never written.
+        let previewPickingEnabled =
+            (m.scene.config.showPreviewIntersection, m.interaction)
+            ||> AVal.map2 (fun showIt interaction ->
+                showIt || interaction = Interactions.EditAnnotation)
+
         let vpVisible = isViewPlanVisible m
         let selected = m.scene.surfacesModel.surfaces.singleSelectLeaf
         let refSystem = m.scene.referenceSystem
@@ -1192,7 +1202,7 @@ module ViewerUtils =
                             m.frustum 
                             selected 
                             surfacePicking
-                            m.scene.config.showPreviewIntersection
+                            previewPickingEnabled
                             surface.globalBB
                             refSystem 
                             observationSystem

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -293,7 +293,39 @@ module ViewerApp =
             let drawing = DrawingApp.update m.scene.referenceSystem drawingConfig referenceSystem bc view m.shiftFlag m.drawing msg
             //Log.stop()
             { m with drawing = drawing } |> stash
-        | Interactions.PlaceCoordinateSystem, ViewerMode.Standard ->                                   
+        | Interactions.EditAnnotation, _ ->
+            // Grabbing a handle is emitted by the annotation scene graph itself, which is the only
+            // place that knows *which* control point is under the cursor. Dropping lands here,
+            // because a vertex is normally dropped away from the annotation, on bare surface.
+            match m.drawing.vertexGrab with
+            | Some grab when grab.movedSinceGrab ->
+                let view =
+                    match m.viewerMode with
+                    | ViewerMode.Standard -> m.navigation.camera.view
+                    | ViewerMode.Instrument -> m.scene.viewPlans.instrumentCam
+
+                let msg = DrawingAction.MoveVertex(grab.annotation, grab.pointIndex, p, hitFunction)
+                let drawing = DrawingApp.update m.scene.referenceSystem drawingConfig referenceSystem bc view m.shiftFlag m.drawing msg
+
+                // surfaceName is only ever advisory and nothing re-validates it, so a vertex may
+                // legitimately end up on a different surface than the annotation was drawn on -
+                // but silently is not the way to do it
+                let movedAcrossSurfaces =
+                    match m.drawing.annotations.flat.TryFind grab.annotation with
+                    | Some (Leaf.Annotations a) -> a.surfaceName <> surf.name
+                    | _ -> false
+
+                let m = { m with drawing = drawing } |> stash
+                if movedAcrossSurfaces then
+                    // same 3 s transient top-right overlay "Importing OPCs..." and "scene saved" use
+                    m |> logScreen 3000 (sprintf "vertex moved onto surface \"%s\"" surf.name)
+                else
+                    m
+            | _ ->
+                // Either nothing is grabbed, or this is the very click that grabbed and the cursor
+                // has not moved yet. Both mean "not a drop".
+                m
+        | Interactions.PlaceCoordinateSystem, ViewerMode.Standard ->
             let m = updateUpNorthForPosition p m
             
             //update camera upvector
@@ -427,11 +459,19 @@ module ViewerApp =
         match k with
         | Aardvark.Application.Keys.Enter    -> DrawingAction.Finish
         | Aardvark.Application.Keys.Back     -> DrawingAction.RemoveLastPoint
-        | Aardvark.Application.Keys.Escape   -> DrawingAction.ClearWorking
+        | Aardvark.Application.Keys.Escape   ->
+            match interaction with
+            // in edit mode Escape puts a grabbed control point back where it was; there is no
+            // working annotation to clear
+            | Interactions.EditAnnotation -> DrawingAction.CancelVertexEdit
+            | _ -> DrawingAction.ClearWorking
         | Keyboard.Modifier ->
-            match interaction with 
+            match interaction with
             | Interactions.DrawAnnotation -> (if inverseFlag then DrawingAction.StopDrawing else DrawingAction.StartDrawing)
             | Interactions.PickAnnotation -> (if inverseFlag then DrawingAction.StopPicking else DrawingAction.StartPicking)
+            // vertex editing dispatches on (draw = false, pick = true) like annotation selection,
+            // so without this the ctrl press never sets model.pick and nothing reaches the handlers
+            | Interactions.EditAnnotation -> (if inverseFlag then DrawingAction.StopPicking else DrawingAction.StartPicking)
             | _ -> DrawingAction.Nop
         //| Aardvark.Application.Keys.LeftShift -> 
         //    match m.interaction with                     
@@ -1251,9 +1291,17 @@ module ViewerApp =
                         p
                 let normal = if info.HasValidNormal then Some info.Normal else None
                 let s = { surfaceName = name; hitPoint = hitPosOnRay; normal = normal }
+                // A fresh hit after a grab means the cursor has moved, which is what separates the
+                // click that picks a control point up from the click that puts it back down.
+                let drawing =
+                    match m.drawing.vertexGrab with
+                    | Some g when not g.movedSinceGrab ->
+                        DrawingApp.update m.scene.referenceSystem drawingConfig None sendQueue m.navigation.camera.view m.shiftFlag m.drawing DrawingAction.ArmVertexGrab
+                    | _ -> m.drawing
                 { m with
                     surfaceIntersection = Some { surfaceName = name; hitPoint = hitPosOnRay; normal = normal }
                     cursorAttributes = attributes |> Option.map (fun hit -> { surfaceName = name; hit = hit })
+                    drawing = drawing
                     ellipseModel = EllipseAnnotations.App.update m.scene.referenceSystem.up.value  project (EllipseAnnotations.SetPreviewPoint s) m.ellipseModel
                 }
             | _ -> 
@@ -1580,9 +1628,10 @@ module ViewerApp =
                     let view = m.navigation.camera.view
                     let d = DrawingApp.update m.scene.referenceSystem drawingConfig None sendQueue view m.shiftFlag m.drawing (if m.inverseFlag then DrawingAction.StartDrawing else DrawingAction.StopDrawing)
                     { m with drawing = d; ctrlFlag = false; picking = m.inverseFlag }
-                | Interactions.PickAnnotation -> 
+                | Interactions.PickAnnotation
+                | Interactions.EditAnnotation ->
                     let view = m.navigation.camera.view
-                    let d = DrawingApp.update m.scene.referenceSystem drawingConfig None sendQueue view m.shiftFlag m.drawing (if m.inverseFlag then DrawingAction.StartPicking else DrawingAction.StopPicking) 
+                    let d = DrawingApp.update m.scene.referenceSystem drawingConfig None sendQueue view m.shiftFlag m.drawing (if m.inverseFlag then DrawingAction.StartPicking else DrawingAction.StopPicking)
                     { m with drawing = d; ctrlFlag = false; picking = m.inverseFlag }
                 //| Interactions.PickMinervaProduct -> { m with minervaModel = { m.minervaModel with picking = false }}
                 |_-> { m with ctrlFlag = false; picking = m.inverseFlag }
@@ -1592,7 +1641,13 @@ module ViewerApp =
             // let feedback = sprintf "pick refrence plane; confirm with ENTER" t |> UserFeedback.create 3000
             //let feedback = "pick refrence plane \n confirm with ENTER" |> UserFeedback.create 3000
 
-            { m with interaction = t } //|> UserFeedback.queueFeedback feedback
+            // leaving edit mode abandons whatever control point was in hand
+            let drawing =
+                match m.drawing.vertexGrab with
+                | Some _ when t <> Interactions.EditAnnotation -> { m.drawing with vertexGrab = None }
+                | _ -> m.drawing
+
+            { m with interaction = t; drawing = drawing } //|> UserFeedback.queueFeedback feedback
         | ReferenceSystemMessage a,_ ->                                
             let refsystem',_ = 
                 ReferenceSystemApp.update
@@ -2259,9 +2314,21 @@ module ViewerApp =
         // drawing app needs pickable stuff. however whether annotations are pickable depends on 
         // outer application state. we consider annotations to pickable if they are visible
         // and we are in "pick annotation" mode.
-        m.interaction |> AVal.map (function  
+        m.interaction |> AVal.map (function
             | Interactions.PickAnnotation -> true
             | Interactions.DrawLog -> true
+            // editing needs the same pick target: a click on the body re-selects, and the handles
+            // ride in the same offscreen pass
+            | Interactions.EditAnnotation -> true
+            | _ -> false
+        )
+
+    /// Whether the control point handles are drawn and pickable. Unlike allowAnnotationPicking,
+    /// this is the *only* mode that shows them - handles on every selected annotation everywhere
+    /// would be noise, and would put every annotation's vertices in the pick buffer.
+    let allowVertexEditing (m : AdaptiveModel) =
+        m.interaction |> AVal.map (function
+            | Interactions.EditAnnotation -> true
             | _ -> false
         )
 
@@ -2379,7 +2446,8 @@ module ViewerApp =
                 frustum
                 runtime
                 (m.viewPortSizes |> AMap.tryFind id |> AVal.map (Option.defaultValue V2i.II))
-                (allowAnnotationPicking m)                 
+                (allowAnnotationPicking m)
+                (allowVertexEditing m)
                 m.drawing
          
         let annotationSg =

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -2435,6 +2435,48 @@ module ViewerApp =
             distancePointsText
         ] |> Sg.ofList
                                  
+    /// While a control point is grabbed, shows where it would land: straight lines from the live
+    /// surface hit to the two neighbouring control points.
+    ///
+    /// Straight on purpose. The terrain re-sampling happens on drop, so bending these to the
+    /// surface here would promise a shape that has not been computed yet. The grabbed handle stays
+    /// drawn at its old position, so the pair reads as "from here, to there".
+    ///
+    /// Drawn with PRo3D.Core.Drawing.Sg.lines, which re-bases the polyline on its first point and
+    /// places it with a trafo, so the float32 vertex buffer never sees planetary-scale coordinates.
+    let private vertexEditPreview (m : AdaptiveModel) =
+        // previous -> live hit -> next, as one polyline. An end point of an open chain has only
+        // one neighbour, so this is two points there and three in the middle of a line.
+        let polyline =
+            AVal.custom (fun t ->
+                match m.drawing.vertexGrab.GetValue t, m.surfaceIntersection.GetValue t with
+                | Some grab, Some hit ->
+                    match m.drawing.annotations.flat.Content.GetValue t |> HashMap.tryFind grab.annotation with
+                    | Some (AdaptiveAnnotations ann) ->
+                        let points = ann.points.Content.GetValue t
+                        let count  = IndexList.count points
+                        // a ring has as many segments as points, so its ends are neighbours too
+                        let isClosed = IndexList.count (ann.segments.Content.GetValue t) >= count
+
+                        let previous =
+                            if grab.pointIndex > 0 then IndexList.tryAt (grab.pointIndex - 1) points
+                            elif isClosed then IndexList.tryLast points
+                            else None
+                        let next =
+                            if grab.pointIndex < count - 1 then IndexList.tryAt (grab.pointIndex + 1) points
+                            elif isClosed then IndexList.tryFirst points
+                            else None
+
+                        [| previous; Some hit.hitPoint; next |] |> Array.choose id
+                    | _ -> [||]
+                | _ -> [||])
+
+        polyline
+        |> AVal.map (fun points ->
+            if points.Length < 2 then Sg.empty
+            else PRo3D.Core.Drawing.Sg.lines C4b.VRVisGreen 3.0 points)
+        |> Sg.dynamic
+
     // depthTested that occur in instrumentview + main renderview
     let getDepthTested (frustum: aval<Frustum>) (view :aval<CameraView>) (observer : aval<ObserverSystem option>) (id : string) (runtime : IRuntime) (m: AdaptiveModel) =
         let annotations, discs = 
@@ -2506,10 +2548,14 @@ module ViewerApp =
                 m.scene.viewPlans 
             |> Sg.map ViewPlanMessage    
 
-        let surfaceIntersection = 
+        let surfaceIntersection =
             Picking.pickVisualization m
-            |> Sg.noEvents     
-            
+            |> Sg.noEvents
+
+        let vertexEdit =
+            vertexEditPreview m
+            |> Sg.noEvents
+
         let ellipseDrawing = 
             m.ellipseModel |> AVal.map (function
                 | AdaptiveNone -> Sg.empty
@@ -2528,6 +2574,7 @@ module ViewerApp =
                 traverses
                 distancePoints
                 surfaceIntersection
+                vertexEdit
                 curtainSg
             ] |> Sg.ofList
 

--- a/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
+++ b/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
@@ -866,6 +866,16 @@ module Gui =
             //| Interactions.PickLinking           -> "CTRL+click to place point on surface"
             | _ -> ""
 
+        /// As interactionText, but also reflects whether a control point is currently in hand.
+        /// Click-to-grab has no drag affordance to feel out, so the hint line is most of what makes
+        /// the gesture discoverable.
+        let interactionTextWithState (i : Interactions) (grabbed : bool) =
+            let ctrl = if RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX) then "CMD" else "CTRL"
+            match i with
+            | Interactions.EditAnnotation when grabbed -> sprintf "%s+click to drop the point, ESC to cancel" ctrl
+            | Interactions.EditAnnotation -> sprintf "%s+click a vertex of the selected annotation to move it" ctrl
+            | _ -> interactionText i
+
         let interactionTooltip (i : Interactions) : string =
             match i with 
             | Interactions.PickExploreCenter     -> "Pick the camera pivot point if ArcBall navigation is activated."
@@ -873,6 +883,7 @@ module Gui =
             | Interactions.DrawAnnotation        -> "Choose an annotation mode to draw an annotation on a surface."
             | Interactions.PlaceRover            -> "Select a rover model in the rover menu."
             | Interactions.PickAnnotation        -> "Select an annotation in the main view. The selected annotation will be highlighted green."
+            | Interactions.EditAnnotation        -> "Move the vertices of the selected annotation. Its control points appear as handles; click one to pick it up, move the cursor over the surface and click again to put it down. Clicking an annotation selects it."
             | Interactions.PickSurface           -> "Select a surface in the main view. The selected surface will be highlighted green."
             | Interactions.SelectArea            -> ""
             | Interactions.PlaceScaleBar         -> ""
@@ -894,7 +905,9 @@ module Gui =
                 Html.Layout.boxH [ Drawing.UI.dropDown Interactions.hideSet model.interaction SetInteraction interactionTooltip ]
                 Html.Layout.boxH [
                     div [style "font-style:italic"] [
-                        Incremental.text (model.interaction |> AVal.map interactionText)
+                        Incremental.text (
+                            (model.interaction, model.drawing.vertexGrab |> AVal.map Option.isSome)
+                            ||> AVal.map2 interactionTextWithState)
                     ]]
             ]
 

--- a/src/Tests/AdaptiveNestingTests.fs
+++ b/src/Tests/AdaptiveNestingTests.fs
@@ -1,0 +1,114 @@
+module AdaptiveNestingTests
+
+open System
+open Expecto
+open Aardvark.Base
+open FSharp.Data.Adaptive
+
+open PRo3D.Base
+open PRo3D.Base.Annotation
+open PRo3D.Core.Drawing
+open PRo3D.Tests
+
+// ---------------------------------------------------------------------------------------------
+// Building an adaptive value *inside* another one's evaluation
+//
+// PackedRendering used to do exactly that: `Drawing.Sg.getPolylinePoints` returns an AVal.custom,
+// and linesNoIndirect called it from inside its own AVal.custom and read it immediately. The
+// symptom was an edited annotation not redrawing until some unrelated change (drawing the next
+// annotation) marked the packed geometry dirty by another route.
+//
+// Why it happens: in FSharp.Data.Adaptive dependency edges point forwards only and are weak.
+// IAdaptiveObject carries `Outputs : IWeakOutputSet` and no Inputs collection, and AVal.custom
+// retains only its compute function - not the values that function read. So `source -> inner`
+// and `inner -> outer` are both weak, and after the outer's evaluation returns, `inner` is a
+// local that nothing holds. Collect it and the whole chain from source to outer is gone; the
+// outer is never marked out of date and keeps serving its cached value.
+//
+// The first three tests are free of PRo3D types so the pattern can be judged on its own.
+// ---------------------------------------------------------------------------------------------
+
+/// Builds a fresh AVal.custom on every evaluation and reads it immediately.
+let private nestedReader (source : cval<int>) : aval<int> =
+    AVal.custom (fun t ->
+        let intermediate = AVal.custom (fun t -> source.GetValue t * 10)
+        intermediate.GetValue t)
+
+/// AVal.map has the same shape - it also allocates a node per evaluation.
+let private mappedReader (source : cval<int>) : aval<int> =
+    AVal.custom (fun t ->
+        let intermediate = source |> AVal.map (fun x -> x * 10)
+        intermediate.GetValue t)
+
+/// The same computation, reading the long-lived cval against the caller's token.
+let private directReader (source : cval<int>) : aval<int> =
+    AVal.custom (fun t -> source.GetValue t * 10)
+
+let private collect () =
+    GC.Collect()
+    GC.WaitForPendingFinalizers()
+    GC.Collect()
+
+/// evaluate, collect, change the source, evaluate again
+let private roundTrip (build : cval<int> -> aval<int>) =
+    let source = cval 1
+    let out = build source
+    let before = AVal.force out
+    collect ()
+    transact (fun () -> source.Value <- 2)
+    before, AVal.force out
+
+/// The hazard needs the intermediate to actually be collected. It always has been here, but a
+/// runtime that keeps it alive would make the value correct rather than wrong - so treat that as
+/// "not observable", never as a failure.
+let private expectStale (after : int) (what : string) =
+    if after = 20 then
+        skiptestf "%s: the intermediate survived this collection, so the hazard is not observable here" what
+    Expect.equal after 10 (sprintf "%s: the outer kept its cached value" what)
+
+let tests () =
+    testList "adaptive nesting" [
+
+        test "reading the source directly propagates across a collection" {
+            let before, after = roundTrip directReader
+            Expect.equal before 10 "initial value"
+            Expect.equal after 20 "the change reached the outer computation"
+        }
+
+        test "an AVal.custom built inside another's evaluation does not" {
+            let before, after = roundTrip nestedReader
+            Expect.equal before 10 "initial value"
+            expectStale after "AVal.custom inside AVal.custom"
+        }
+
+        test "an AVal.map built inside another's evaluation does not" {
+            let before, after = roundTrip mappedReader
+            Expect.equal before 10 "initial value"
+            expectStale after "AVal.map inside AVal.custom"
+        }
+
+        // The regression test proper: the real flattening, in the shape linesNoIndirect uses it.
+        // This fails with Drawing.Sg.getPolylinePoints and passes with getPolylinePointsAt.
+        test "the packed flattening sees a moved control point after a collection" {
+            let drawn =
+                Draw.drawFull Draw.refSystemFlat Geometry.Polyline false
+                    [ V3d.Zero; V3d(1.0, 0.0, 0.0); V3d(2.0, 0.0, 0.0) ]
+            let anno = Draw.theAnnotation "adaptive nesting" drawn
+            let adaptiveAnno = AdaptiveAnnotation(anno)
+
+            let outer =
+                AVal.custom (fun t -> PRo3D.Core.Drawing.Sg.getPolylinePointsAt adaptiveAnno t)
+
+            let before = AVal.force outer
+            Expect.equal before.Length 3 "three control points to start with"
+
+            collect ()
+
+            let target = V3d(1.0, 5.0, 0.0)
+            let moved = { anno with points = anno.points |> IndexList.setAt 1 target }
+            transact (fun () -> adaptiveAnno.Update moved)
+
+            let after = AVal.force outer
+            Expect.equal after.[1] target "the moved control point reached the flattening"
+        }
+    ]

--- a/src/Tests/Program.fs
+++ b/src/Tests/Program.fs
@@ -37,6 +37,7 @@ let allTests () : Test =
         SpiceTests.tests()
         TriangleSetTests.tests()
         PolygonFillTests.tests()
+        VertexEditingTests.tests()
 
         // requires the (non-public) HERA kernels; self-skips without them
         HeraSpiceTests.tests()

--- a/src/Tests/Program.fs
+++ b/src/Tests/Program.fs
@@ -37,6 +37,7 @@ let allTests () : Test =
         SpiceTests.tests()
         TriangleSetTests.tests()
         PolygonFillTests.tests()
+        AdaptiveNestingTests.tests()
         VertexEditingTests.tests()
 
         // requires the (non-public) HERA kernels; self-skips without them

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -59,6 +59,8 @@
     <Compile Include="Features\Section16_CommandLine.fs" />
     <Compile Include="Features\Section18_KeyboardShortcuts.fs" />
     <Compile Include="Features\Section19_UndoRedoGroupColor.fs" />
+    <!-- after Features\TestHelpers.fs: drives the real DrawingApp through the Draw harness -->
+    <Compile Include="VertexEditingTests.fs" />
     <Compile Include="Program.fs" />
     <None Include="paket.references" />
   </ItemGroup>

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -59,7 +59,8 @@
     <Compile Include="Features\Section16_CommandLine.fs" />
     <Compile Include="Features\Section18_KeyboardShortcuts.fs" />
     <Compile Include="Features\Section19_UndoRedoGroupColor.fs" />
-    <!-- after Features\TestHelpers.fs: drives the real DrawingApp through the Draw harness -->
+    <!-- after Features\TestHelpers.fs: these drive the real DrawingApp through the Draw harness -->
+    <Compile Include="AdaptiveNestingTests.fs" />
     <Compile Include="VertexEditingTests.fs" />
     <Compile Include="Program.fs" />
     <None Include="paket.references" />

--- a/src/Tests/VertexEditingTests.fs
+++ b/src/Tests/VertexEditingTests.fs
@@ -1,0 +1,321 @@
+module VertexEditingTests
+
+open System
+open Expecto
+open Aardvark.Base
+open FSharp.Data.Adaptive
+
+open PRo3D.Base
+open PRo3D.Base.Annotation
+open PRo3D.Core
+open PRo3D.Core.Drawing
+
+open PRo3D.Tests
+
+// ---------------------------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------------------------
+
+let private eps = 1e-9
+
+/// A sampler that projects nothing - stands in for a ray that misses the surface everywhere.
+let private missEverywhere : V3d -> Option<V3d> = fun _ -> None
+
+/// A sampler that drops every sample onto z = 0, so a re-sampled segment is distinguishable from
+/// the straight line between its end points.
+let private flattenToGround : V3d -> Option<V3d> = fun p -> Some (V3d(p.X, p.Y, 0.0))
+
+/// Draws a polyline whose segments are actually generated. `startTool` selects Projection.Linear
+/// for every non-ellipse tool, and Linear produces no segments at all, so the projection has to be
+/// set back after choosing the geometry.
+let private drawProjected (geom : Geometry) (points : V3d list) =
+    let refSystem = Draw.refSystemFlat
+    let start =
+        Draw.startTool refSystem geom
+        |> fun m -> Draw.run refSystem m (DrawingAction.SetProjection Projection.Sky)
+    let drawn = points |> List.fold (fun m p -> Draw.click refSystem p m) start
+    Draw.run refSystem drawn DrawingAction.Finish
+
+let private theOnly (label : string) (m : DrawingModel) = Draw.theAnnotation label m
+
+let private pointAt i (a : Annotation) =
+    match IndexList.tryAt i a.points with
+    | Some p -> p
+    | None   -> failtestf "no point at index %d" i
+
+/// Puts the model into the state Interactions.EditAnnotation runs in: draw off, pick on. The Draw
+/// harness leaves draw = true after startTool, and the vertex arms - like annotation selection -
+/// dispatch on (draw = false, pick = true).
+let private startEditing (m : DrawingModel) =
+    let refSystem = Draw.refSystemFlat
+    m
+    |> fun m -> Draw.run refSystem m DrawingAction.StopDrawing
+    |> fun m -> Draw.run refSystem m DrawingAction.StartPicking
+
+/// grab control point `i` of the single annotation, arm the grab, then drop it at `target`
+let private grabAndDrop (i : int) (target : V3d) (sampler : V3d -> Option<V3d>) (m : DrawingModel) =
+    let refSystem = Draw.refSystemFlat
+    let a = theOnly "grabAndDrop" m
+    m
+    |> startEditing
+    |> fun m -> Draw.run refSystem m (DrawingAction.GrabVertex(a.key, i))
+    |> fun m -> Draw.run refSystem m DrawingAction.ArmVertexGrab
+    |> fun m -> Draw.run refSystem m (DrawingAction.MoveVertex(a.key, i, target, sampler))
+
+// ---------------------------------------------------------------------------------------------
+// pure index arithmetic
+// ---------------------------------------------------------------------------------------------
+
+let private touchedSegmentTests =
+    testList "touchedSegments" [
+
+        // an open chain of n points has n-1 segments; segment j spans points[j] -> points[j+1]
+        test "interior point of an open chain touches the segments either side" {
+            Expect.equal (DrawingApp.touchedSegments 4 3 1 |> List.sort) [0; 1] "point 1 sits between segments 0 and 1"
+            Expect.equal (DrawingApp.touchedSegments 4 3 2 |> List.sort) [1; 2] "point 2 sits between segments 1 and 2"
+        }
+
+        test "first point of an open chain touches only the first segment" {
+            Expect.equal (DrawingApp.touchedSegments 4 3 0) [0] "nothing precedes point 0"
+        }
+
+        test "last point of an open chain touches only the last segment" {
+            Expect.equal (DrawingApp.touchedSegments 4 3 3) [2] "nothing follows the last point"
+        }
+
+        // a ring has one segment per point: the extra one closes last -> first
+        test "first point of a ring also touches the closing segment" {
+            Expect.equal (DrawingApp.touchedSegments 4 4 0 |> List.sort) [0; 3] "closing segment is the last one"
+        }
+
+        test "last point of a ring also touches the closing segment" {
+            Expect.equal (DrawingApp.touchedSegments 4 4 3 |> List.sort) [2; 3] "segment 2 before it, closing segment after"
+        }
+
+        test "interior point of a ring is unaffected by the closure" {
+            Expect.equal (DrawingApp.touchedSegments 4 4 1 |> List.sort) [0; 1] "same as the open case"
+        }
+
+        test "out of range and empty inputs yield nothing" {
+            Expect.isEmpty (DrawingApp.touchedSegments 4 3 -1) "negative index"
+            Expect.isEmpty (DrawingApp.touchedSegments 4 3 4) "index past the end"
+            Expect.isEmpty (DrawingApp.touchedSegments 4 0 1) "no segments to touch"
+        }
+
+        test "a result never indexes outside the segment list" {
+            // a two point line: one segment, and both ends must resolve to it alone
+            Expect.equal (DrawingApp.touchedSegments 2 1 0) [0] "start of a single segment"
+            Expect.equal (DrawingApp.touchedSegments 2 1 1) [0] "end of a single segment"
+        }
+    ]
+
+let private segmentEndpointTests =
+    testList "segmentEndpoints" [
+
+        let points = IndexList.ofList [ V3d.Zero; V3d.IOO; V3d.OIO; V3d.OOI ]
+
+        test "a regular segment spans consecutive control points" {
+            Expect.equal (DrawingApp.segmentEndpoints points 3 0) (Some (V3d.Zero, V3d.IOO)) "segment 0"
+            Expect.equal (DrawingApp.segmentEndpoints points 3 2) (Some (V3d.OIO, V3d.OOI)) "segment 2"
+        }
+
+        test "the closing segment of a ring runs first to last" {
+            // closePolyline builds it as { startPoint = first; endPoint = last }
+            Expect.equal (DrawingApp.segmentEndpoints points 4 3) (Some (V3d.Zero, V3d.OOI)) "closing segment"
+        }
+
+        test "an out of range index yields nothing" {
+            Expect.isNone (DrawingApp.segmentEndpoints points 3 3) "past the last open segment"
+            Expect.isNone (DrawingApp.segmentEndpoints points 3 -1) "negative"
+        }
+    ]
+
+// ---------------------------------------------------------------------------------------------
+// resampleSegment
+// ---------------------------------------------------------------------------------------------
+
+let private resampleTests =
+    testList "resampleSegment" [
+
+        test "keeps the end points it was given" {
+            let a = V3d(0.0, 0.0, 5.0)
+            let b = V3d(10.0, 0.0, 5.0)
+            let s = DrawingApp.resampleSegment 1.0 flattenToGround a b
+            Expect.equal s.startPoint a "start"
+            Expect.equal s.endPoint b "end"
+        }
+
+        test "interior samples are projected, not interpolated" {
+            // the straight line sits at z = 5; the sampler drops everything to z = 0, so a sample
+            // still at z = 5 would mean the projection was skipped
+            let s = DrawingApp.resampleSegment 1.0 flattenToGround (V3d(0.0, 0.0, 5.0)) (V3d(10.0, 0.0, 5.0))
+            Expect.isGreaterThan (IndexList.count s.points) 0 "some interior samples"
+            for p in s.points do
+                Expect.floatClose Accuracy.high p.Z 0.0 "sample was projected onto the ground"
+        }
+
+        test "sample count follows the sampling distance" {
+            // 10 units at 1 unit steps: s = 1..10, and the step at s = 10 lands exactly on the end
+            let s = DrawingApp.resampleSegment 1.0 flattenToGround V3d.Zero (V3d(10.0, 0.0, 0.0))
+            Expect.equal (IndexList.count s.points) 10 "one sample per step"
+
+            let coarse = DrawingApp.resampleSegment 5.0 flattenToGround V3d.Zero (V3d(10.0, 0.0, 0.0))
+            Expect.equal (IndexList.count coarse.points) 2 "two steps at distance 5"
+        }
+
+        test "samples that miss the surface are dropped rather than interpolated" {
+            let s = DrawingApp.resampleSegment 1.0 missEverywhere V3d.Zero (V3d(10.0, 0.0, 0.0))
+            Expect.isEmpty s.points "nothing projected"
+            Expect.equal s.startPoint V3d.Zero "start survives"
+            Expect.equal s.endPoint (V3d(10.0, 0.0, 0.0)) "end survives"
+        }
+
+        test "a zero length segment produces no samples instead of NaN" {
+            // reachable from vertex editing: dropping a control point onto its neighbour. The
+            // direction is undefined here, and normalising it would fill points with NaN.
+            let s = DrawingApp.resampleSegment 1.0 flattenToGround V3d.Zero V3d.Zero
+            Expect.isEmpty s.points "no direction to walk along"
+        }
+
+        test "a non-positive sampling distance produces no samples instead of hanging" {
+            let s = DrawingApp.resampleSegment 0.0 flattenToGround V3d.Zero (V3d(10.0, 0.0, 0.0))
+            Expect.isEmpty s.points "would otherwise ask for infinitely many steps"
+        }
+    ]
+
+// ---------------------------------------------------------------------------------------------
+// moveVertex, through the real DrawingApp.update
+// ---------------------------------------------------------------------------------------------
+
+let private moveTests =
+    testList "moving a control point" [
+
+        test "the moved point takes the new position and the others do not budge" {
+            let m = Draw.drawFull Draw.refSystemFlat Geometry.Polyline false [ V3d.Zero; V3d(1,0,0); V3d(2,0,0) ]
+            let target = V3d(1.0, 5.0, 0.0)
+            let moved = m |> grabAndDrop 1 target Draw.identityHit |> theOnly "moved"
+
+            Expect.equal (pointAt 1 moved) target "point 1 moved"
+            Expect.equal (pointAt 0 moved) V3d.Zero "point 0 untouched"
+            Expect.equal (pointAt 2 moved) (V3d(2,0,0)) "point 2 untouched"
+        }
+
+        test "the grab is released by the drop" {
+            let m = Draw.drawFull Draw.refSystemFlat Geometry.Polyline false [ V3d.Zero; V3d(1,0,0); V3d(2,0,0) ]
+            let after = m |> grabAndDrop 1 (V3d(1.0, 5.0, 0.0)) Draw.identityHit
+            Expect.isNone after.vertexGrab "nothing left in hand"
+        }
+
+        test "cancelling leaves the annotation exactly as it was" {
+            let refSystem = Draw.refSystemFlat
+            let m = Draw.drawFull refSystem Geometry.Polyline false [ V3d.Zero; V3d(1,0,0); V3d(2,0,0) ]
+            let before = theOnly "before" m
+            let a = before
+
+            let cancelled =
+                m
+                |> startEditing
+                |> fun m -> Draw.run refSystem m (DrawingAction.GrabVertex(a.key, 1))
+                |> fun m -> Draw.run refSystem m DrawingAction.ArmVertexGrab
+                |> fun m -> Draw.run refSystem m DrawingAction.CancelVertexEdit
+
+            Expect.isNone cancelled.vertexGrab "grab released"
+            Expect.equal (theOnly "after" cancelled).points before.points "points identical - the grab never mutated anything"
+        }
+
+        test "a drop pushes exactly one undo entry, and undo restores the old position" {
+            let refSystem = Draw.refSystemFlat
+            let m = Draw.drawFull refSystem Geometry.Polyline false [ V3d.Zero; V3d(1,0,0); V3d(2,0,0) ]
+            let original = pointAt 1 (theOnly "original" m)
+            let undoBefore = List.length m.undoStack
+
+            let moved = m |> grabAndDrop 1 (V3d(1.0, 5.0, 0.0)) Draw.identityHit
+            Expect.equal (List.length moved.undoStack) (undoBefore + 1) "one entry for the whole drop"
+
+            let undone = Draw.run refSystem moved DrawingAction.Undo
+            Expect.equal (pointAt 1 (theOnly "undone" undone)) original "back where it started"
+        }
+
+        test "measurements are recomputed on the drop" {
+            // a 1-unit line stretched to 5 units: if results were left stale the length would not move
+            let m = Draw.drawFull Draw.refSystemFlat Geometry.Line true [ V3d.Zero; V3d(1,0,0) ]
+            let before = theOnly "before" m
+            let moved = m |> grabAndDrop 1 (V3d(5.0, 0.0, 0.0)) Draw.identityHit |> theOnly "moved"
+
+            match before.results, moved.results with
+            | Some b, Some a ->
+                Expect.floatClose Accuracy.medium b.length 1.0 "drawn length"
+                Expect.floatClose Accuracy.medium a.length 5.0 "length after the move"
+            | _ -> failtest "annotation carries no results"
+        }
+
+        test "an out of range control point index changes nothing" {
+            let refSystem = Draw.refSystemFlat
+            let m = Draw.drawFull refSystem Geometry.Polyline false [ V3d.Zero; V3d(1,0,0); V3d(2,0,0) ]
+            let a = theOnly "before" m
+            let after =
+                m
+                |> startEditing
+                |> fun m -> Draw.run refSystem m (DrawingAction.MoveVertex(a.key, 17, V3d(9,9,9), Draw.identityHit))
+            Expect.equal (theOnly "after" after).points a.points "untouched"
+        }
+    ]
+
+let private segmentUpdateTests =
+    testList "segments after a move" [
+
+        test "an annotation drawn without segments does not grow any" {
+            // the default projection for every non-ellipse tool is Linear, which generates none;
+            // an edit must not silently upgrade the annotation to a terrain-following one
+            let m = Draw.drawFull Draw.refSystemFlat Geometry.Polyline false [ V3d.Zero; V3d(1,0,0); V3d(2,0,0) ]
+            Expect.isTrue (IndexList.isEmpty (theOnly "drawn" m).segments) "precondition: no segments"
+
+            let moved = m |> grabAndDrop 1 (V3d(1.0, 5.0, 0.0)) flattenToGround |> theOnly "moved"
+            Expect.isTrue (IndexList.isEmpty moved.segments) "still none"
+        }
+
+        test "only the segments either side of the moved point are re-sampled" {
+            let m = drawProjected Geometry.Polyline [ V3d.Zero; V3d(10,0,0); V3d(20,0,0); V3d(30,0,0) ]
+            let before = theOnly "drawn" m
+            Expect.equal (IndexList.count before.segments) 3 "precondition: three segments"
+
+            let moved = m |> grabAndDrop 1 (V3d(10.0, 10.0, 0.0)) flattenToGround |> theOnly "moved"
+
+            let segAt i (a : Annotation) =
+                match IndexList.tryAt i a.segments with
+                | Some s -> s
+                | None -> failtestf "no segment %d" i
+
+            Expect.equal (segAt 0 moved).endPoint (V3d(10.0, 10.0, 0.0)) "segment 0 follows the point"
+            Expect.equal (segAt 1 moved).startPoint (V3d(10.0, 10.0, 0.0)) "segment 1 follows the point"
+            // the far segment must be untouched, contents and all
+            Expect.equal (segAt 2 moved) (segAt 2 before) "segment 2 was not rebuilt"
+        }
+
+        test "moving the first point of a ring re-samples the closing segment" {
+            let m = drawProjected Geometry.Polygon [ V3d.Zero; V3d(10,0,0); V3d(10,10,0) ]
+            let before = theOnly "drawn" m
+            // closePolyline appended the ring's closing segment, so segments = points
+            Expect.equal (IndexList.count before.segments) (IndexList.count before.points) "precondition: closed ring"
+
+            let target = V3d(-5.0, -5.0, 0.0)
+            let moved = m |> grabAndDrop 0 target flattenToGround |> theOnly "moved"
+
+            let closing =
+                match IndexList.tryLast moved.segments with
+                | Some s -> s
+                | None -> failtest "no closing segment"
+
+            // closePolyline builds the closing segment as first -> last
+            Expect.equal closing.startPoint target "the closing segment tracks point 0"
+        }
+    ]
+
+let tests () =
+    testList "vertex editing" [
+        touchedSegmentTests
+        segmentEndpointTests
+        resampleTests
+        moveTests
+        segmentUpdateTests
+    ]


### PR DESCRIPTION
Adds `Interactions.EditAnnotation`, in which the control points of the selected annotation appear as handles. Ctrl+click one to pick it up, it follows the preview cursor's live surface hit, ctrl+click again to drop it. Escape restores. Clicking an annotation body still re-selects, so you move between annotations without leaving the mode.

Part of #639. That issue asks for add/remove point; this is the move operation plus the infrastructure those need. Add and remove are not implemented.

**Stacked on #679** — based on `features/annotation-polygon-fill` because it rewrites `Picking.pickId` and `pickRenderTarget`, which that PR introduced. Retarget to `develop` once #679 merges.

## Why it needed new infrastructure

Nothing could edit a finished annotation's geometry before: `SetSegment` only reaches `model.working`, and finished leaves are only touched via `Groups.updateLeaf`.

**Pick buffer sub-index.** Alpha already carried the packed object id; red was unread except by OpcViewer's debug lens. `pickId` now writes `-1` there and `pickVertexId` writes the control point index, so `red >= 0` distinguishes a handle from the annotation body. One 1×1 download still serves both, no second render target, and handles take their ids from the same `orderedAnnotations` array as lines and fills.

**Both pick systems live at once.** `PickAnnotation` turns kd-tree picking off; here the live surface hit is the whole point. So the click that grabs a handle also reaches the surface and would read as a drop, with mailbox ordering deciding the outcome. `VertexGrab.movedSinceGrab` makes it order-independent: a drop requires a preview hit after the grab.

**Handle geometry** is six CPU-expanded vertices per control point. `gl_PointSize`/`gl_PointCoord` depend on `GL_PROGRAM_POINT_SIZE`, and `DefaultSurfaces.pointSprite` cannot be used because it does not carry `ObjId`/`SubId`. Constraints found the hard way are recorded in `docs/AnnotationVertexEditing.md`.

## Commit behaviour

Re-samples only the segments either side of the moved point, via `resampleSegment` factored out of `addPoint`. Most annotations are `Projection.Linear` and carry no segments, so that branch is usually skipped — an edit never changes the shape an annotation was drawn with. Measurements are recomputed inline so a drop is one model update and one undo entry, pushed as the `SnapshotDelta` property edits already use.

A vertex may land on a surface other than the one recorded; that is allowed (`surfaceName` is advisory) and reported through the transient top-right overlay.

## Two fixes that are not the feature

**Packed geometry stopped updating in place.** `Drawing.Sg.getPolylinePoints` returns an `AVal.custom`, and the packed draws called it from inside their own `AVal.custom`. Adaptive edges are forward-only and weak, so `source -> intermediate -> outer` hung off a node nothing held; once collected, an edited annotation only redrew when something unrelated marked the geometry dirty. `getPolylinePointsAt` flattens against the caller's token instead. Pre-existing and not specific to this feature — vertex editing is simply the first in-place geometry edit. `src/Tests/AdaptiveNestingTests.fs` demonstrates it in plain FSharp.Data.Adaptive and regression-tests the real flattening.

**Preview picking forced on in edit mode.** #669 made `showPreviewIntersection` default to `true`, but `Json.tryRead` only defaults an absent key, so scenes saved earlier carry an explicit `false`. The drop is gated on a live surface hit, which made edit mode inert on exactly those scenes. The config value is read, never written.

## Testing

290 tests pass, 39 new across `VertexEditingTests.fs` and `AdaptiveNestingTests.fs`: `resampleSegment`, the touched-segment index arithmetic including polygon wrap, and grab/commit/cancel/undo through the headless `Draw` harness.

Verified in the viewer against the VictoriaCrater OPC scene, driven with Playwright: selecting shows 14 handles, the one under the cursor reads back as vertex 4 of annotation 0, grabbing turns it green and switches the hint line, and the drop moves the point and releases — including when dropping onto another handle rather than bare terrain.

## Not covered

Ellipses (their `points` are the sampled outline, not control points), the in-progress `working` annotation, and press-drag-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
