### PR TITLE
Fix axis 4P ellipse (forward-port of #680 to 6.1.0)

### DIFF
--- a/PRODUCT_RELEASE_NOTES.md
+++ b/PRODUCT_RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ## 6.0.0
 First stable release of the 6.0 line. The individual changes since 5.x are listed in the `6.0.0-prerelease*` and `6.0.0-rc*` entries below.
 
+- Annotations: the **4-point ellipse is drawn as an ellipse again** — the four clicks were kept as raw points and rendered as an open polyline, because the ellipse fit on the dip/strike plane only handled the 3-point case
 - Sequenced bookmarks: **playback keeps the camera pointing where the bookmarks point** — moving between two bookmarks that look the same way lost the view direction and swung the camera up into the sky for the whole segment. Stepping to a bookmark, and batch-rendered snapshots, were unaffected
 
 ## 6.0.0-rc2

--- a/docs/Test_Protocol/PRo3D_TestProtocol.tex
+++ b/docs/Test_Protocol/PRo3D_TestProtocol.tex
@@ -166,7 +166,8 @@
 		\ref{tc:14} & Draw Polygon Annotation & \checkbox~Pass / \checkbox~Fail & \\
 		\ref{tc:15} & Draw Dip and Strike Annotation & \checkbox~Pass / \checkbox~Fail & \\
 		\ref{tc:60} & Draw AxisEllipse Annotation & \checkbox~Pass / \checkbox~Fail & \\
-		\ref{tc:61} & Draw Axis4PEllipse Annotation & \checkbox~Pass / \checkbox~Fail & \\
+		% re-enable together with the tc:61 block below
+		%\ref{tc:61} & Draw Axis4PEllipse Annotation & \checkbox~Pass / \checkbox~Fail & \\
 		\ref{tc:16} & Annotation Projection Modes & \checkbox~Pass / \checkbox~Fail & \\
 		\ref{tc:17} & Pick Annotation (via UI list) & \checkbox~Pass / \checkbox~Fail & \\
 		\ref{tc:18} & Pick Annotation (via 3D view) & \checkbox~Pass / \checkbox~Fail & \\
@@ -719,39 +720,44 @@
 
 	\vspace{1em}
 
+	% tc:61 (Draw Axis4PEllipse Annotation) is commented out: the Axis4PEllipse geometry is
+	% currently hidden from the annotation mode selector, so the case is not executable.
+	% Re-enable this block (and its row in the summary table above) when the geometry is
+	% offered again.
+	%
 	%--- tc:61 ---
-	\testcase{61}{Draw Axis4PEllipse Annotation}
-
-	\begin{tabularx}{\textwidth}{lX}
-		\toprule
-		\textbf{Prerequisites} & DrawAnnotation mode is active. \\
-		\midrule
-		\textbf{Steps} &
-		\begin{enumerate}[leftmargin=*, nosep]
-			\item In the annotation mode selector, choose \button{Axis4PEllipse}.
-			\item Hold \key{Ctrl} and click \key{LMB} to set the \textbf{first endpoint} of the major axis.
-			\item Hold \key{Ctrl} and click \key{LMB} to set the \textbf{second endpoint} of the major axis.
-			\item Hold \key{Ctrl} and click \key{LMB} to set a \textbf{third point} defining the semi-minor extent on one side.
-			\item Hold \key{Ctrl} and click \key{LMB} to set a \textbf{fourth point} defining the semi-minor extent on the other side (or on the same side for a half-moon).
-			\item Verify a symmetric ellipse, asymmetric ellipse, and a half-moon by varying where points 3 and 4 are placed relative to the major axis.
-		\end{enumerate} \\
-		\midrule
-		\textbf{Expected Result} &
-		\begin{itemize}[leftmargin=*, nosep]
-			\item \textbf{Opposite sides, equal distance}: a symmetric ellipse is drawn.
-			\item \textbf{Opposite sides, different distances}: an asymmetric ellipse is drawn (the two halves have different widths).
-			\item \textbf{Same side}: a half-moon shape is drawn.
-			\item In all cases the annotation appears in the \tab{Annotations} list and remains visible when the camera is moved.
-			\item The properties panel shows the semi-axis values and rotation angle.
-		\end{itemize} \\
-		\midrule
-		\textbf{Result} & \checkbox~Pass \quad \checkbox~Fail \\
-		\midrule
-		\textbf{Notes} & \\[1.5cm]
-		\bottomrule
-	\end{tabularx}
-
-	\vspace{1em}
+	%\testcase{61}{Draw Axis4PEllipse Annotation}
+	%
+	%\begin{tabularx}{\textwidth}{lX}
+	%	\toprule
+	%	\textbf{Prerequisites} & DrawAnnotation mode is active. \\
+	%	\midrule
+	%	\textbf{Steps} &
+	%	\begin{enumerate}[leftmargin=*, nosep]
+	%		\item In the annotation mode selector, choose \button{Axis4PEllipse}.
+	%		\item Hold \key{Ctrl} and click \key{LMB} to set the \textbf{first endpoint} of the major axis.
+	%		\item Hold \key{Ctrl} and click \key{LMB} to set the \textbf{second endpoint} of the major axis.
+	%		\item Hold \key{Ctrl} and click \key{LMB} to set a \textbf{third point} defining the semi-minor extent on one side.
+	%		\item Hold \key{Ctrl} and click \key{LMB} to set a \textbf{fourth point} defining the semi-minor extent on the other side (or on the same side for a half-moon).
+	%		\item Verify a symmetric ellipse, asymmetric ellipse, and a half-moon by varying where points 3 and 4 are placed relative to the major axis.
+	%	\end{enumerate} \\
+	%	\midrule
+	%	\textbf{Expected Result} &
+	%	\begin{itemize}[leftmargin=*, nosep]
+	%		\item \textbf{Opposite sides, equal distance}: a symmetric ellipse is drawn.
+	%		\item \textbf{Opposite sides, different distances}: an asymmetric ellipse is drawn (the two halves have different widths).
+	%		\item \textbf{Same side}: a half-moon shape is drawn.
+	%		\item In all cases the annotation appears in the \tab{Annotations} list and remains visible when the camera is moved.
+	%		\item The properties panel shows the semi-axis values and rotation angle.
+	%	\end{itemize} \\
+	%	\midrule
+	%	\textbf{Result} & \checkbox~Pass \quad \checkbox~Fail \\
+	%	\midrule
+	%	\textbf{Notes} & \\[1.5cm]
+	%	\bottomrule
+	%\end{tabularx}
+	%
+	%\vspace{1em}
 
 	%--- tc:16 ---
 	\testcase{16}{Annotation Projection Modes}

--- a/src/PRo3D.Core/Drawing/Drawing.UI.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.UI.fs
@@ -82,7 +82,9 @@ module UI =
 
         Html.Layout.horizontal [
             Html.Layout.boxH [ i [clazz "large Write icon"] [] ]
-            Html.Layout.boxH [ dropDown ( [ Geometry.Ellipse ] |> HashSet.ofList ) model.geometry SetGeometry geometryTooltip ]
+            // Axis4PEllipse is hidden from the selector for now — the geometry itself and its
+            // update/rendering path stay intact, so existing annotations still load and draw.
+            Html.Layout.boxH [ dropDown ( [ Geometry.Ellipse; Geometry.Axis4PEllipse ] |> HashSet.ofList ) model.geometry SetGeometry geometryTooltip ]
             Html.Layout.boxH [ dropDown HashSet.empty model.projection SetProjection projectionTooltip ]
             // annotation color now comes from the active group's default color, so the tool-level color picker was removed
             Html.Layout.boxH [ Numeric.view' [InputBox] model.thickness |> UI.map ChangeThickness ] |> UI.wrapToolTip DataPosition.Bottom thicknessTooltip

--- a/src/PRo3D.Core/Drawing/EllipseAnnotation.fs
+++ b/src/PRo3D.Core/Drawing/EllipseAnnotation.fs
@@ -4,7 +4,9 @@ open Aardvark.Base
 open PRo3D.Base
 
 module EllipticAnnotations =
-    let sampleNumber = 50    
+    let sampleNumber = 50
+    /// sample count used when the ellipse is constructed on the fitted plane (world space)
+    let planeSampleNumber = 200
 
     module Conv = 
         let geographicalToCartesian (v : CooTransformation.SphericalCoo) =
@@ -34,6 +36,9 @@ module EllipticAnnotations =
         {
             constructionPlane : Plane3d
             ellipseOnPlane : Ellipse2d
+            /// second half-ellipse of an asymmetric (four point) ellipse. it shares the major
+            /// axis with ellipseOnPlane and only differs in its semi-minor axis.
+            ellipseOnPlaneAssym : Option<Ellipse2d>
             surfaceProjectedEllipsePoints : array<V3d>
         }
 
@@ -62,23 +67,43 @@ module EllipticAnnotations =
     let constructAndSampleFromPlane (fittedPlane : Plane3d) (points : array<V3d>) (projectToSurface : V3d -> Option<V3d>) = 
         let w2Plane = fittedPlane.GetWorldToPlane()
         let plane2World = fittedPlane.GetPlaneToWorld()
-        match points |> Array.map (fun p -> w2Plane.TransformPos(p), p) with
-        | [| (plane0, p0); (plane1, p1); (plane2, p2); |] -> 
-            let ellipse = EllipseConstruction.constructEllipseOrtho2d (plane0.XY) (plane1.XY) (plane2.XY)
-            let sampledPoints = EllipseConstruction.computeEllipsePoints ellipse 200
-            let projectedEllipse = 
-                sampledPoints 
-                |> Array.choose (fun planePoint -> 
-                    let position = plane2World.TransformPos(V3d(planePoint, 0.0))
-                    match projectToSurface position with
-                    | None -> 
-                        Log.warn "could not reproject ellipse point."
-                        None
-                    | Some p -> 
-                        Some p
-                )
-            Some { constructionPlane = fittedPlane; ellipseOnPlane = ellipse; surfaceProjectedEllipsePoints = projectedEllipse }
-        | _ -> 
+
+        let projectOntoSurface (planePoints : array<V2d>) =
+            planePoints
+            |> Array.choose (fun planePoint ->
+                let position = plane2World.TransformPos(V3d(planePoint, 0.0))
+                match projectToSurface position with
+                | None ->
+                    Log.warn "could not reproject ellipse point."
+                    None
+                | Some p ->
+                    Some p
+            )
+
+        match points |> Array.map (fun p -> w2Plane.TransformPos(p).XY) with
+        | [| plane0; plane1; plane2 |] ->
+            let ellipse = EllipseConstruction.constructEllipseOrtho2d plane0 plane1 plane2
+            let sampledPoints = EllipseConstruction.computeEllipsePoints ellipse planeSampleNumber
+            Some {
+                constructionPlane = fittedPlane
+                ellipseOnPlane = ellipse
+                ellipseOnPlaneAssym = None
+                surfaceProjectedEllipsePoints = projectOntoSurface sampledPoints
+            }
+        // four point (asymmetric) ellipse: plane0/plane1 are the ends of the major axis,
+        // plane2 and plane3 give the semi-minor length on either side of it.
+        | [| plane0; plane1; plane2; plane3 |] ->
+            let ellipse0 = EllipseConstruction.constructEllipseOrtho2d plane0 plane1 plane2
+            let ellipse1 = EllipseConstruction.constructEllipseOrtho2d plane0 plane1 plane3
+            let sampledPoints =
+                EllipseConstruction.constructAssimmetricalEllipse2dPoints ellipse0 ellipse1 planeSampleNumber
+            Some {
+                constructionPlane = fittedPlane
+                ellipseOnPlane = ellipse0
+                ellipseOnPlaneAssym = Some ellipse1
+                surfaceProjectedEllipsePoints = projectOntoSurface sampledPoints
+            }
+        | _ ->
             None
 
     let constructAndSampleGeographical (planet : Planet) (referenceSystem: Option<PRo3D.Base.Gis.SpiceReferenceSystem>) (points : array<V3d>) (projectToSurface : V3d -> Option<V3d>) =

--- a/src/Tests/Features/Section03_DrawingAnnotations.fs
+++ b/src/Tests/Features/Section03_DrawingAnnotations.fs
@@ -119,16 +119,11 @@ let private drawingE2ETests =
 
         // TC-3.7 Draw Axis4PEllipse
         //
-        // Skipped, not deleted: the four-point ellipse is not fitted at all on the
-        // currently-active path. getFinishedAnnotation takes the plane-based branch
-        // (`let geo = false`, Drawing-App.fs) and EllipseAnnotation.constructAndSampleFromPlane
-        // matches only the three-point case `[| p0; p1; p2 |]`, returning None for four
-        // points — so the annotation keeps its four raw clicks and no outline is sampled.
-        // The disabled geographical path (constructAndSampleGeographical) does handle four
-        // points. Drop the skiptest below once the plane path covers Axis4PEllipse.
+        // The first two clicks are the ends of the major axis, the last two give the
+        // semi-minor length on either side of it, so the outline is stitched together
+        // from two half-ellipses that share the major axis.
 
         test "TC-3.7 four clicks in Axis4PEllipse mode fit an ellipse" {
-            skiptest "Axis4PEllipse is not fitted: constructAndSampleFromPlane handles only 3 points"
             let c  = V3d(693177.21, -3147511.67, 1070879.15)
             let m  = Draw.drawFull Draw.refSystemMars Geometry.Axis4PEllipse true
                         [ c + V3d(60.0, 0.0, 0.0); c - V3d(60.0, 0.0, 0.0)


### PR DESCRIPTION
Same change as #680, which was merged into `releases/6.0.0` by mistake. `releases/6.0.0` sits at the `v6.0.0` tag and is not the active line, so the fix needs to land here.

Merges cleanly into `releases/6.1.0` (verified, no conflicts).

Commits:
- `da13f79f` Fix axis 4P ellipse
- `e353cb6d` Remove axis4Ellipse as an option