### PR TITLE
fix(gui): numeric controls dead since the Aardvark.UI 5.7 upgrade

### DIFF
--- a/src/PRo3D.Core/AardvarkUIReworks.fs
+++ b/src/PRo3D.Core/AardvarkUIReworks.fs
@@ -41,11 +41,14 @@ module NoSemUi =
 
     let inline private thing a = { value = a }
 
+    // Aardvark.UI 5.7 moved these under ./resources/fomantic/ and dropped essentialstuff.js,
+    // which defines the jQuery `numeric` plugin `numeric` boots with below. essentialstuff.js
+    // is vendored from 5.6.0 (in PRo3D.Viewer, as only the entry assembly serves ./resources).
     let private semui =
         [
-            { kind = Stylesheet; name = "semui"; url = "./resources/semantic.css" }
-            { kind = Stylesheet; name = "semui-overrides"; url = "./resources/semantic-overrides.css" }
-            { kind = Script; name = "semui"; url = "./resources/semantic.js" }
+            { kind = Stylesheet; name = "semui"; url = "./resources/fomantic/semantic.css" }
+            { kind = Stylesheet; name = "semui-overrides"; url = "./resources/fomantic/semantic-overrides.css" }
+            { kind = Script; name = "semui"; url = "./resources/fomantic/semantic.js" }
             { kind = Script; name = "essential"; url = "./resources/essentialstuff.js" }
         ]
 

--- a/src/PRo3D.Viewer/PRo3D.Viewer.fsproj
+++ b/src/PRo3D.Viewer/PRo3D.Viewer.fsproj
@@ -85,6 +85,7 @@
     <EmbeddedResource Include="resources\calendar.css" />
     <EmbeddedResource Include="resources\calendar.js" />
     <EmbeddedResource Include="resources\utilities.js" />
+    <EmbeddedResource Include="resources\essentialstuff.js" />
     <Content Include="resources\rotationcubeXYZ\back.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/PRo3D.Viewer/resources/essentialstuff.js
+++ b/src/PRo3D.Viewer/resources/essentialstuff.js
@@ -1,0 +1,82 @@
+
+$.fn.numeric = function (ob, value) {
+
+    this.find("input").each(function () {
+
+        if ("numericsetvalue" in this) {
+            var setValue = this.numericsetvalue;
+            if (ob === "set") setValue(value, false);
+            return;
+        }
+
+        var config = { changed: function (v) { } };
+        var o = $.extend(config, ob);
+
+
+        var self = this;
+        var old = parseFloat(self.value);
+
+        function largeStep() {
+            var s = parseFloat(self.getAttribute("data-largestep"));
+            if (isNaN(s)) return 10.0;
+            else return s;
+        }
+
+        function formatFloat(value, decimal) {
+            return value.toPrecision(15)
+                .replace(/\.([0-9]*?)0+([eE][\+\-0-9]*$)?$/, ".$1$2")
+                .replace(/\.$/, "")
+                .replace(/\.([eE])/, "$1")
+                .replace("e", "E");
+        }
+
+        function setValue(value, raiseEvent) {
+            var initial = old;
+            try { initial = parseFloat(eval(value)); }
+            catch (e) { initial = old; }
+
+            var v = initial;
+            var min = parseFloat(self.min);
+            var max = parseFloat(self.max);
+
+            if (!isNaN(min) && v < min) { v = min; }
+            if (!isNaN(max) && v > max) { v = max; }
+
+            var o = old;
+            if (isNaN(v)) v = old;
+            else old = v;
+
+            if (o != v && raiseEvent) config.changed(v);
+            var str = formatFloat(v, 8);
+            self.value = str;
+        }
+
+        function step(dir) {
+            var step = parseFloat(self.step);
+            if (!step) step = 1.0;
+            setValue(parseFloat(self.value) + dir * step, true);
+        }
+
+        function checkKey(e) {
+            if ((e.key < "0" || e.key > "9") && e.key != "." && e.key != "+" && e.key != "-" && e.key != "E" && e.key != "e" && e.key != "*" && e.key != "/" && e.key != "(" && e.key != ")" && e.key != " ") e.preventDefault();
+
+        }
+
+        function down(e) {
+            if (e.keyCode == 38) { step(1); e.preventDefault(); }
+            else if (e.keyCode == 40) { step(-1); e.preventDefault(); }
+            else if (e.keyCode == 33) { step(largeStep()); e.preventDefault(); }
+            else if (e.keyCode == 34) { step(-largeStep()); e.preventDefault(); }
+            else if (e.keyCode == 13) setValue(e.target.value, true);
+            else if (e.keyCode == 27) setValue(old, true);
+        }
+
+        this["numericsetvalue"] = setValue;
+
+        $(this)
+            .bind('mousewheel', function (e) { step(-Math.sign(e.originalEvent.deltaY) * (e.originalEvent.shiftKey ? largeStep() : 1)); e.preventDefault(); })
+            .keypress(function (e) { checkKey(e); })
+            .keydown(function (e) { down(e); })
+            .change(function (e) { setValue(e.target.value, true); });
+    });
+};


### PR DESCRIPTION
`NoSemUi` kept its own copy of the semantic-ui dependency list pointing at the 5.6 resource paths, so after `75af5c83 "Update to Media 5.7"` all four URLs 404'd:

| declared | now |
|---|---|
| `./resources/semantic.css` | `./resources/fomantic/semantic.css` |
| `./resources/semantic-overrides.css` | `./resources/fomantic/semantic-overrides.css` |
| `./resources/semantic.js` | `./resources/fomantic/semantic.js` |
| `./resources/essentialstuff.js` | removed upstream |

`essentialstuff.js` defines the jQuery `numeric` plugin that `NoSemUi.numeric` boots with (`Aardvark.UI` 5.6.0 contains `fn.numeric` and `essentialstuff`; 5.7.3 contains neither). Without it the boot script threw `$(...).numeric is not a function`, which aborted the rest of that panel's DOM setup.

Visible effect in surface properties: **Blend Factor, Min, Max and Color Map never appeared, and the controls that did render were inert** — the colour map was unreachable and the blend slider did nothing. The two `GisApp/Entity.fs` numerics were broken the same way.

## Change

Repointed the three moved resources and vendored `essentialstuff.js` from 5.6.0, embedded in `PRo3D.Viewer` because only the entry assembly's resources are published under `./resources/`. **No view code changed.**

## Verification

Driven with playwright against the HERA `Dimorphos_DRACO2` OPC:

- `Passthrough` — Min/Max/Color Map correctly hidden
- select `Ramp` — Min, Max and Color Map appear; `Max` 0 → 1 and `Color Map` `-None-` → `oranges`, i.e. the model updates and the UI follows
- `$(...).numeric is not a function` gone; no failed requests across Surfaces, Annotations, ScaleBars, Instrument View, Config, Bookmarks, SequBookmarks, Viewplans, Properties, Traverses

## Notes

Present in shipped 6.0.0, hence targeting `releases/6.1.0`.

A sweep of the other resource declarations found no second instance of this bug, but two things worth separate issues: `ProvenanceApp.fs:159` loads from `cdn.rawgit.com` (shut down in 2019, alive only via redirect), and `GuiEx.semui` pulls semantic-ui 2.2.6 from a CDN at 65 call sites — which breaks offline and double-loads semantic-ui alongside the bundled fomantic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
