### PR TITLE
Show SPICE lat/lon/alt in the Under Cursor readout

### DIFF
--- a/docs/VertexAttributes.md
+++ b/docs/VertexAttributes.md
@@ -106,6 +106,14 @@ gravity magnitude) and can differ substantially for a gradient layer such as slo
 default**. The readout is the *Under Cursor* accordion in the **Config** panel, below
 *Screenshots*, and shows the surface, the patch and every per-vertex layer under the mouse.
 
+Below the cartesian position it also shows the picked point as SPICE **latitude /
+longitude / altitude**, in the same raw convention as the *Coordinate System* panel (see
+[spice.md](spice.md) for which convention applies to which body). These three rows appear
+only when the conversion succeeds: they are omitted for non-planetary reference frames
+(`Planet.None`, `.JPL`, `.ENU`), when the native call reports an error, and when it returns
+a non-finite value. Nothing else in the read-out depends on them, so an unset or
+unsupported planet costs only these rows.
+
 The readout only updates while surface picking is active — hold `CTRL` and move the mouse
 over a surface. Picking and attribute extraction run on the background picking thread, so
 neither blocks the UI.

--- a/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
+++ b/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
@@ -1116,10 +1116,31 @@ module Gui =
                             yield hint "Hold CTRL and move the mouse over a surface."
                         | Some (cursor : CursorAttributes) ->
                             let hit : AttributeHit = cursor.hit
+                            // SPICE lat/lon/alt of the picked point, shown only when available.
+                            // tryGetLatLonAlt is total: None for non-planetary frames
+                            // (Planet.None/JPL/ENU) and when the native PGRREC call reports an
+                            // error. Its out-params are nan-seeded, so a wrapper returning
+                            // success without writing cannot yield silent zeros - the finiteness
+                            // filter turns that into None as well. Either way the rows are just
+                            // omitted; the rest of the read-out is unaffected.
+                            let! planet = m.scene.referenceSystem.planet
+                            let spherical =
+                                CooTransformation.tryGetLatLonAlt planet hit.position
+                                |> Option.filter (fun sc ->
+                                    Double.IsFinite sc.latitude &&
+                                    Double.IsFinite sc.longitude &&
+                                    Double.IsFinite sc.altitude)
                             yield Html.table [
                                 yield Html.row "Surface:"  [text cursor.surfaceName]
                                 yield Html.row "Patch:"    [text hit.patchName]
                                 yield Html.row "Position:" [text (hit.position.ToString("0.000"))]
+                                match spherical with
+                                | Some sc ->
+                                    // raw convention, matching the Coordinate System panel
+                                    yield Html.row "Latitude:"  [text (sprintf "%s deg" (sc.latitude.ToString("0.00000")))]
+                                    yield Html.row "Longitude:" [text (sprintf "%s deg" (sc.longitude.ToString("0.00000")))]
+                                    yield Html.row "Altitude:"  [text (sprintf "%s m"   (sc.altitude.ToString("0.00")))]
+                                | None -> ()
                                 for a : SampledAttribute in hit.attributes do
                                     yield Html.row (a.name + ":") [text (formatValues a.values)]
                             ]


### PR DESCRIPTION
Adds Latitude / Longitude / Altitude rows to the *Under Cursor* panel, between the cartesian position and the per-vertex attribute rows.

## What it does

Applies `CooTransformation.tryGetLatLonAlt` to `hit.position` — the same call, on the same kind of world-space point, that the camera panel (`ViewerGUI.fs:155`) and the Coordinate System panel (`ReferenceSystem.fs:157`) already use.

Longitude, latitude and altitude are displayed raw, matching the Coordinate System panel and the CSV / GeoJSON / SurfaceChart export paths. Note the camera panel in the same file instead displays `360.0 - longitude`; that inconsistency is pre-existing and untouched here.

## When the conversion is unavailable

The three rows are omitted rather than showing a placeholder. That covers:

- non-planetary reference frames (`Planet.None`, `.JPL`, `.ENU`), where `tryGetLatLonAlt` returns `None` by design
- a non-zero error code from the native PGRREC call
- a non-finite result — the native out-params are nan-seeded upstream, so a wrapper returning success without writing would otherwise render `NaN`; an `Option.filter` on finiteness maps that to `None` as well

Surface, patch, position and the attribute layers render unchanged in all of those cases.

## Scope

- `ViewerGUI.fs` +21, `docs/VertexAttributes.md` +8. No deletions.
- No new model field, no new helper, no `*.g.fs` regeneration.
- `dotnet build src/PRo3D.Viewer` succeeds, 0 errors.

## Not verified

The panel has not been exercised against a live pick. The scene used to launch (`cases/unionSelectedFails.pro3d`) has `Planet.None`, which is the omit path; confirming the populated path needs a scene with a planet set.
